### PR TITLE
Add shared workspace setup

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -1,0 +1,26 @@
+"$schema" = "https://conductor.build/schemas/settings.repo.schema.json"
+
+[scripts]
+setup = "pnpm local:setup"
+archive = "pnpm local:down"
+run_mode = "concurrent"
+
+[scripts.run.dev]
+command = "pnpm local:dev"
+default = true
+icon = "play"
+available_in = [ "local" ]
+
+[scripts.run.doctor]
+command = "pnpm local:doctor"
+icon = "stethoscope"
+available_in = [ "local" ]
+
+[scripts.run.tunnel]
+command = "pnpm tunnel:claim"
+icon = "radio-tower"
+available_in = [ "local" ]
+
+[scripts.run.test]
+command = "pnpm typecheck && pnpm lint && pnpm test"
+icon = "test-tube"

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,5 @@
+# Shared machine-local integration configuration.
+/.env.providers.local
+/.env.tunnel.local
+
+# .env.local is intentionally absent. Each worktree generates its own copy.

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
   
 <br />
 
-[![Last Commit](https://img.shields.io/github/last-commit/superloglabs/responder-oss?labelColor=333333&color=666666)](https://github.com/superloglabs/superlog/commits/main)
-[![Commit Activity](https://img.shields.io/github/commit-activity/m/superloglabs/responder-oss?labelColor=333333&color=666666)](https://github.com/superloglabs/superlog/graphs/commit-activity)
-[![Apache 2.0 License](https://img.shields.io/badge/License-Apache_2.0-555555.svg?labelColor=333333&color=666666)](./LICENSE.md)
+[![Last Commit](https://img.shields.io/github/last-commit/superloglabs/responder-oss?labelColor=333333&color=666666)](https://github.com/superloglabs/responder-oss/commits/main)
+[![Commit Activity](https://img.shields.io/github/commit-activity/m/superloglabs/responder-oss?labelColor=333333&color=666666)](https://github.com/superloglabs/responder-oss/graphs/commit-activity)
+[![Apache 2.0 License](https://img.shields.io/badge/License-Apache_2.0-555555.svg?labelColor=333333&color=666666)](./LICENSE)
 <br>
 [![Discord](https://img.shields.io/discord/1511214206123380867?logo=discord&logoColor=white&label=Discord&color=5865F2)](https://discord.gg/wJ56aRh8hx)
 <a href="https://www.ycombinator.com"><img src="https://img.shields.io/badge/Y%20Combinator-P26-orange" alt="Y Combinator P26"></a>


### PR DESCRIPTION
## Summary

- configure setup, development, health-check, tunnel, and validation actions for isolated workspaces
- allow concurrent local workspaces using the existing worktree-safe scripts
- copy shared gitignored provider and tunnel configuration while keeping generated local environment files workspace-specific
- fix repository and license badge destinations

## Validation

- configuration matches the working private-repository setup
- every referenced package script exists
- git diff --check
- CI and security analysis passed before the README-only follow-up; checks rerun on the final commit