### PR TITLE
Fix workspace invitation routing

### DIFF
--- a/apps/control-plane/e2e/workspace-onboarding.spec.ts
+++ b/apps/control-plane/e2e/workspace-onboarding.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type Page } from "@playwright/test";
 
 const organization = {
   id: "11111111-1111-4111-8111-111111111111",
@@ -19,6 +19,40 @@ const user = {
   updatedAt: new Date().toISOString(),
 };
 
+function sessionResponse(activeOrganizationId: string | null) {
+  return {
+    session: {
+      id: "session-id",
+      userId: user.id,
+      activeOrganizationId,
+      token: "session-token",
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    },
+    user,
+  };
+}
+
+async function mockApplicationApis(page: Page) {
+  await page.route("**/api/agents/options", (route) =>
+    route.fulfill({ json: { accounts: [], resources: [], repositories: [] } }),
+  );
+  await page.route("**/api/integrations", (route) =>
+    route.fulfill({ json: { integrations: [] } }),
+  );
+  await page.route("**/api/billing", (route) =>
+    route.fulfill({
+      json: {
+        configured: false,
+        enabled: false,
+        payAsYouGo: false,
+        remaining: 0,
+      },
+    }),
+  );
+}
+
 test("opens agent creation after creating a workspace", async ({ page }) => {
   let activeOrganizationId: string | null = null;
 
@@ -26,20 +60,7 @@ test("opens agent creation after creating a workspace", async ({ page }) => {
     const path = new URL(route.request().url()).pathname;
 
     if (path.endsWith("/get-session")) {
-      await route.fulfill({
-        json: {
-          session: {
-            id: "session-id",
-            userId: user.id,
-            activeOrganizationId,
-            token: "session-token",
-            expiresAt: new Date(Date.now() + 60_000).toISOString(),
-            createdAt: new Date().toISOString(),
-            updatedAt: new Date().toISOString(),
-          },
-          user,
-        },
-      });
+      await route.fulfill({ json: sessionResponse(activeOrganizationId) });
       return;
     }
 
@@ -66,22 +87,7 @@ test("opens agent creation after creating a workspace", async ({ page }) => {
 
     await route.fulfill({ json: null });
   });
-  await page.route("**/api/agents/options", (route) =>
-    route.fulfill({ json: { accounts: [], resources: [], repositories: [] } }),
-  );
-  await page.route("**/api/integrations", (route) =>
-    route.fulfill({ json: { integrations: [] } }),
-  );
-  await page.route("**/api/billing", (route) =>
-    route.fulfill({
-      json: {
-        configured: false,
-        enabled: false,
-        payAsYouGo: false,
-        remaining: 0,
-      },
-    }),
-  );
+  await mockApplicationApis(page);
 
   await page.goto("/agents");
   await expect(page.getByRole("heading", { name: "Create a workspace" })).toBeVisible();
@@ -96,11 +102,23 @@ test("opens agent creation after creating a workspace", async ({ page }) => {
 test("keeps an invitation link open while the recipient signs in", async ({
   page,
 }) => {
+  let signedIn = false;
+
   await page.route("**/api/auth/**", async (route) => {
     const path = new URL(route.request().url()).pathname;
 
     if (path.endsWith("/get-session")) {
-      await route.fulfill({ json: null });
+      await route.fulfill({
+        json: signedIn ? sessionResponse(null) : null,
+      });
+      return;
+    }
+
+    if (path.endsWith("/sign-in/email")) {
+      signedIn = true;
+      await route.fulfill({
+        json: { redirect: false, token: "session-token", user },
+      });
       return;
     }
 
@@ -112,6 +130,15 @@ test("keeps an invitation link open while the recipient signs in", async ({
 
   await expect(page).toHaveURL(new RegExp(`/invite/${invitationId}$`));
   await expect(page.getByRole("heading", { name: "Welcome back" })).toBeVisible();
+
+  await page.getByLabel("Email").fill(user.email);
+  await page.getByLabel("Password").fill("correct-horse-battery-staple");
+  await page.getByRole("button", { name: "Sign in" }).click();
+
+  await expect(page).toHaveURL(new RegExp(`/invite/${invitationId}$`));
+  await expect(
+    page.getByRole("heading", { name: "Join this workspace" }),
+  ).toBeVisible();
 });
 
 test("accepts an invitation and opens its workspace", async ({ page }) => {
@@ -123,20 +150,7 @@ test("accepts an invitation and opens its workspace", async ({ page }) => {
     const path = new URL(route.request().url()).pathname;
 
     if (path.endsWith("/get-session")) {
-      await route.fulfill({
-        json: {
-          session: {
-            id: "session-id",
-            userId: user.id,
-            activeOrganizationId,
-            token: "session-token",
-            expiresAt: new Date(Date.now() + 60_000).toISOString(),
-            createdAt: new Date().toISOString(),
-            updatedAt: new Date().toISOString(),
-          },
-          user,
-        },
-      });
+      await route.fulfill({ json: sessionResponse(activeOrganizationId) });
       return;
     }
 
@@ -176,22 +190,7 @@ test("accepts an invitation and opens its workspace", async ({ page }) => {
 
     await route.fulfill({ json: null });
   });
-  await page.route("**/api/agents/options", (route) =>
-    route.fulfill({ json: { accounts: [], resources: [], repositories: [] } }),
-  );
-  await page.route("**/api/integrations", (route) =>
-    route.fulfill({ json: { integrations: [] } }),
-  );
-  await page.route("**/api/billing", (route) =>
-    route.fulfill({
-      json: {
-        configured: false,
-        enabled: false,
-        payAsYouGo: false,
-        remaining: 0,
-      },
-    }),
-  );
+  await mockApplicationApis(page);
 
   await page.goto(`/invite/${invitationId}`);
   await expect(
@@ -203,4 +202,21 @@ test("accepts an invitation and opens its workspace", async ({ page }) => {
   await expect(page).toHaveURL(/\/agents$/);
   expect(acceptedInvitationId).toBe(invitationId);
   expect(activeOrganizationId).toBe(organization.id);
+});
+
+test("redirects malformed invitation links", async ({ page }) => {
+  await page.route("**/api/auth/**", async (route) => {
+    const path = new URL(route.request().url()).pathname;
+
+    if (path.endsWith("/get-session")) {
+      await route.fulfill({ json: sessionResponse(organization.id) });
+      return;
+    }
+
+    await route.fulfill({ json: null });
+  });
+
+  await page.goto("/invite/xyz");
+
+  await expect(page).toHaveURL(/\/$/);
 });

--- a/apps/control-plane/e2e/workspace-onboarding.spec.ts
+++ b/apps/control-plane/e2e/workspace-onboarding.spec.ts
@@ -35,6 +35,9 @@ function sessionResponse(activeOrganizationId: string | null) {
 }
 
 async function mockApplicationApis(page: Page) {
+  await page.route("**/api/agents", (route) =>
+    route.fulfill({ json: { agents: [] } }),
+  );
   await page.route("**/api/agents/options", (route) =>
     route.fulfill({ json: { accounts: [], resources: [], repositories: [] } }),
   );
@@ -52,6 +55,10 @@ async function mockApplicationApis(page: Page) {
     }),
   );
 }
+
+test.beforeEach(async ({ page }) => {
+  await mockApplicationApis(page);
+});
 
 test("opens agent creation after creating a workspace", async ({ page }) => {
   let activeOrganizationId: string | null = null;
@@ -87,8 +94,6 @@ test("opens agent creation after creating a workspace", async ({ page }) => {
 
     await route.fulfill({ json: null });
   });
-  await mockApplicationApis(page);
-
   await page.goto("/agents");
   await expect(page.getByRole("heading", { name: "Create a workspace" })).toBeVisible();
 
@@ -190,8 +195,6 @@ test("accepts an invitation and opens its workspace", async ({ page }) => {
 
     await route.fulfill({ json: null });
   });
-  await mockApplicationApis(page);
-
   await page.goto(`/invite/${invitationId}`);
   await expect(
     page.getByRole("heading", { name: "Join this workspace" }),
@@ -218,5 +221,8 @@ test("redirects malformed invitation links", async ({ page }) => {
 
   await page.goto("/invite/xyz");
 
-  await expect(page).toHaveURL(/\/$/);
+  await expect(page).toHaveURL(/\/agents$/);
+  await expect(
+    page.getByRole("heading", { name: "Agents", exact: true }),
+  ).toBeVisible();
 });

--- a/apps/control-plane/e2e/workspace-onboarding.spec.ts
+++ b/apps/control-plane/e2e/workspace-onboarding.spec.ts
@@ -92,3 +92,115 @@ test("opens agent creation after creating a workspace", async ({ page }) => {
   await expect(page).toHaveURL(/\/agents\/new$/);
   await expect(page.getByRole("heading", { name: "Create agent" })).toBeVisible();
 });
+
+test("keeps an invitation link open while the recipient signs in", async ({
+  page,
+}) => {
+  await page.route("**/api/auth/**", async (route) => {
+    const path = new URL(route.request().url()).pathname;
+
+    if (path.endsWith("/get-session")) {
+      await route.fulfill({ json: null });
+      return;
+    }
+
+    await route.fulfill({ json: null });
+  });
+
+  const invitationId = "33333333-3333-4333-8333-333333333333";
+  await page.goto(`/invite/${invitationId}`);
+
+  await expect(page).toHaveURL(new RegExp(`/invite/${invitationId}$`));
+  await expect(page.getByRole("heading", { name: "Welcome back" })).toBeVisible();
+});
+
+test("accepts an invitation and opens its workspace", async ({ page }) => {
+  const invitationId = "33333333-3333-4333-8333-333333333333";
+  let activeOrganizationId: string | null = null;
+  let acceptedInvitationId: string | null = null;
+
+  await page.route("**/api/auth/**", async (route) => {
+    const path = new URL(route.request().url()).pathname;
+
+    if (path.endsWith("/get-session")) {
+      await route.fulfill({
+        json: {
+          session: {
+            id: "session-id",
+            userId: user.id,
+            activeOrganizationId,
+            token: "session-token",
+            expiresAt: new Date(Date.now() + 60_000).toISOString(),
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+          },
+          user,
+        },
+      });
+      return;
+    }
+
+    if (path.endsWith("/organization/accept-invitation")) {
+      const request = route.request().postDataJSON() as { invitationId: string };
+      acceptedInvitationId = request.invitationId;
+      await route.fulfill({
+        json: {
+          invitation: {
+            id: invitationId,
+            organizationId: organization.id,
+            email: user.email,
+            role: "member",
+            status: "accepted",
+          },
+          member: {
+            id: "44444444-4444-4444-8444-444444444444",
+            organizationId: organization.id,
+            userId: user.id,
+            role: "member",
+          },
+        },
+      });
+      return;
+    }
+
+    if (path.endsWith("/organization/set-active")) {
+      activeOrganizationId = organization.id;
+      await route.fulfill({ json: null });
+      return;
+    }
+
+    if (path.endsWith("/organization/get-full-organization")) {
+      await route.fulfill({ json: organization });
+      return;
+    }
+
+    await route.fulfill({ json: null });
+  });
+  await page.route("**/api/agents/options", (route) =>
+    route.fulfill({ json: { accounts: [], resources: [], repositories: [] } }),
+  );
+  await page.route("**/api/integrations", (route) =>
+    route.fulfill({ json: { integrations: [] } }),
+  );
+  await page.route("**/api/billing", (route) =>
+    route.fulfill({
+      json: {
+        configured: false,
+        enabled: false,
+        payAsYouGo: false,
+        remaining: 0,
+      },
+    }),
+  );
+
+  await page.goto(`/invite/${invitationId}`);
+  await expect(
+    page.getByRole("heading", { name: "Join this workspace" }),
+  ).toBeVisible();
+
+  await page.getByRole("button", { name: "Accept invitation" }).click();
+
+  await expect(page).toHaveURL(/\/agents$/);
+  expect(acceptedInvitationId).toBe(invitationId);
+  expect(activeOrganizationId).toBe(organization.id);
+});

--- a/apps/control-plane/src/app.tsx
+++ b/apps/control-plane/src/app.tsx
@@ -36,7 +36,10 @@ export function App() {
       ) : null}
       <Route element={<ProtectedApp />}>
         <Route element={<Navigate replace to="/agents" />} path="/app" />
-        <Route element={null} path="/invite/:invitationId" />
+        <Route
+          element={<Navigate replace to="/" />}
+          path="/invite/:invitationId"
+        />
         <Route element={<AgentsPage />} path="/agents" />
         <Route element={<IssuesPage />} path="/issues" />
         <Route element={<IssueDetailPage />} path="/issues/:issueId" />

--- a/apps/control-plane/src/app.tsx
+++ b/apps/control-plane/src/app.tsx
@@ -36,6 +36,7 @@ export function App() {
       ) : null}
       <Route element={<ProtectedApp />}>
         <Route element={<Navigate replace to="/agents" />} path="/app" />
+        <Route element={null} path="/invite/:invitationId" />
         <Route element={<AgentsPage />} path="/agents" />
         <Route element={<IssuesPage />} path="/issues" />
         <Route element={<IssueDetailPage />} path="/issues/:issueId" />


### PR DESCRIPTION
## Summary

- register workspace invitation URLs with the protected application router
- preserve invitation URLs through recipient authentication
- verify invitation acceptance activates the invited workspace and opens the agents page
- redirect malformed invitation URLs without rendering a blank page

## Root cause

Invitation links used `/invite/:invitationId`, but that path was not declared in the client router. The wildcard route therefore redirected recipients to the landing page before the invitation gate could handle the link.

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test` (389 tests)
- `pnpm build`
- `pnpm exec playwright test apps/control-plane/e2e/workspace-onboarding.spec.ts` (4 tests)