### PR TITLE
Show provider logos in auth buttons

### DIFF
--- a/apps/control-plane/src/components/icons.test.ts
+++ b/apps/control-plane/src/components/icons.test.ts
@@ -4,14 +4,16 @@ import { describe, expect, it } from "vitest";
 import { ProviderGlyph } from "./icons";
 
 describe("ProviderGlyph", () => {
-  it("announces the provider when the glyph carries meaning", () => {
+  it("renders the GitHub logo and announces the provider when it carries meaning", () => {
     const markup = renderToStaticMarkup(
       createElement(ProviderGlyph, { provider: "github" }),
     );
 
     expect(markup).toContain('aria-label="GitHub"');
     expect(markup).toContain('role="img"');
-    expect(markup).toContain(">GH</span>");
+    expect(markup).toContain("<svg");
+    expect(markup).toContain('fill="currentColor"');
+    expect(markup).not.toContain(">GH</span>");
   });
 
   it("stays decorative when adjacent copy already names the provider", () => {
@@ -23,7 +25,17 @@ describe("ProviderGlyph", () => {
     );
 
     expect(markup).toContain('aria-hidden="true"');
+    expect(markup).toContain("<svg");
+    expect(markup).toContain('fill="#4285f4"');
     expect(markup).not.toContain("aria-label");
     expect(markup).not.toContain("role=");
+  });
+
+  it("keeps text glyphs as a fallback for providers without a logo", () => {
+    const markup = renderToStaticMarkup(
+      createElement(ProviderGlyph, { provider: "datadog" }),
+    );
+
+    expect(markup).toContain(">DD</span>");
   });
 });

--- a/apps/control-plane/src/components/icons.tsx
+++ b/apps/control-plane/src/components/icons.tsx
@@ -46,11 +46,10 @@ function GoogleLogo() {
   );
 }
 
-function ProviderLogo({ provider }: { provider: ProviderGlyphId }) {
-  if (provider === "github") return <GithubLogo />;
-  if (provider === "google") return <GoogleLogo />;
-  return providerGlyphs[provider].text;
-}
+const providerLogos = {
+  github: GithubLogo,
+  google: GoogleLogo,
+} as const;
 
 export function ProviderGlyph({
   className,
@@ -58,6 +57,7 @@ export function ProviderGlyph({
   provider,
 }: ProviderGlyphProps) {
   const glyph = providerGlyphs[provider];
+  const Logo = "logo" in glyph ? providerLogos[glyph.logo] : null;
   return (
     <span
       aria-hidden={decorative ? true : undefined}
@@ -65,7 +65,7 @@ export function ProviderGlyph({
       className={`providerGlyph${className ? ` ${className}` : ""}`}
       role={decorative ? undefined : "img"}
     >
-      <ProviderLogo provider={provider} />
+      {Logo ? <Logo /> : "text" in glyph ? glyph.text : null}
     </span>
   );
 }

--- a/apps/control-plane/src/components/icons.tsx
+++ b/apps/control-plane/src/components/icons.tsx
@@ -51,13 +51,20 @@ const providerLogos = {
   google: GoogleLogo,
 } as const;
 
+function ProviderGlyphContent({ provider }: { provider: ProviderGlyphId }) {
+  const glyph = providerGlyphs[provider];
+  if (!("logo" in glyph)) return glyph.text;
+
+  const Logo = providerLogos[glyph.logo];
+  return <Logo />;
+}
+
 export function ProviderGlyph({
   className,
   decorative = false,
   provider,
 }: ProviderGlyphProps) {
   const glyph = providerGlyphs[provider];
-  const Logo = "logo" in glyph ? providerLogos[glyph.logo] : null;
   return (
     <span
       aria-hidden={decorative ? true : undefined}
@@ -65,7 +72,7 @@ export function ProviderGlyph({
       className={`providerGlyph${className ? ` ${className}` : ""}`}
       role={decorative ? undefined : "img"}
     >
-      {Logo ? <Logo /> : "text" in glyph ? glyph.text : null}
+      <ProviderGlyphContent provider={provider} />
     </span>
   );
 }

--- a/apps/control-plane/src/components/icons.tsx
+++ b/apps/control-plane/src/components/icons.tsx
@@ -12,6 +12,46 @@ interface ProviderGlyphProps {
   provider: ProviderGlyphId;
 }
 
+function GithubLogo() {
+  return (
+    <svg aria-hidden="true" focusable="false" viewBox="0 0 24 24">
+      <path
+        d="M12 .3a12 12 0 0 0-3.8 23.4c.6.1.8-.3.8-.6v-2.3c-3.3.7-4-1.4-4-1.4-.5-1.4-1.3-1.8-1.3-1.8-1.1-.7.1-.7.1-.7 1.2.1 1.8 1.2 1.8 1.2 1.1 1.8 2.8 1.3 3.5 1 .1-.8.4-1.3.8-1.6-2.7-.3-5.5-1.3-5.5-5.9 0-1.3.5-2.4 1.2-3.2-.1-.3-.5-1.5.1-3.2 0 0 1-.3 3.3 1.2a11.5 11.5 0 0 1 6 0C16 5 17 5.3 17 5.3c.7 1.7.3 2.9.1 3.2.8.8 1.2 1.9 1.2 3.2 0 4.6-2.8 5.6-5.5 5.9.4.4.8 1.1.8 2.2v3.3c0 .3.2.7.8.6A12 12 0 0 0 12 .3Z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+}
+
+function GoogleLogo() {
+  return (
+    <svg aria-hidden="true" focusable="false" viewBox="0 0 24 24">
+      <path
+        d="M22.6 12.3c0-.8-.1-1.5-.2-2.3H12v4.3h5.9a5 5 0 0 1-2.2 3.3v2.8h3.6c2.1-2 3.3-4.8 3.3-8.1Z"
+        fill="#4285f4"
+      />
+      <path
+        d="M12 23c3 0 5.5-1 7.3-2.7l-3.6-2.8c-1 .7-2.2 1.1-3.7 1.1a6.5 6.5 0 0 1-6.2-4.5H2.2V17A11 11 0 0 0 12 23Z"
+        fill="#34a853"
+      />
+      <path
+        d="M5.8 14.1A6.6 6.6 0 0 1 5.5 12c0-.7.1-1.4.3-2.1V7.1H2.2A11 11 0 0 0 1 12c0 1.8.4 3.5 1.2 4.9l3.6-2.8Z"
+        fill="#fbbc05"
+      />
+      <path
+        d="M12 5.4c1.6 0 3.1.6 4.2 1.6l3.2-3.1A10.6 10.6 0 0 0 12 1a11 11 0 0 0-9.8 6.1l3.6 2.8A6.5 6.5 0 0 1 12 5.4Z"
+        fill="#ea4335"
+      />
+    </svg>
+  );
+}
+
+function ProviderLogo({ provider }: { provider: ProviderGlyphId }) {
+  if (provider === "github") return <GithubLogo />;
+  if (provider === "google") return <GoogleLogo />;
+  return providerGlyphs[provider].text;
+}
+
 export function ProviderGlyph({
   className,
   decorative = false,
@@ -25,7 +65,7 @@ export function ProviderGlyph({
       className={`providerGlyph${className ? ` ${className}` : ""}`}
       role={decorative ? undefined : "img"}
     >
-      {glyph.text}
+      <ProviderLogo provider={provider} />
     </span>
   );
 }

--- a/apps/control-plane/src/components/provider-glyphs.ts
+++ b/apps/control-plane/src/components/provider-glyphs.ts
@@ -2,8 +2,8 @@ export const providerGlyphs = {
   clickstack: { label: "ClickStack", text: "CS" },
   custom_mcp: { label: "Custom MCP", text: "MCP" },
   datadog: { label: "Datadog", text: "DD" },
-  github: { label: "GitHub", text: "GH" },
-  google: { label: "Google", text: "GO" },
+  github: { label: "GitHub", logo: "github" },
+  google: { label: "Google", logo: "google" },
   sentry: { label: "Sentry", text: "SE" },
   slack: { label: "Slack", text: "SL" },
 } as const;

--- a/apps/control-plane/src/styles.css
+++ b/apps/control-plane/src/styles.css
@@ -717,6 +717,12 @@ button:disabled {
   text-transform: uppercase;
 }
 
+.providerGlyph > svg {
+  width: 18px;
+  height: 18px;
+  display: block;
+}
+
 .socialAuth__button {
   height: 42px;
   padding: 0 14px;


### PR DESCRIPTION
## Summary

- replace the Google and GitHub text abbreviations with proper inline SVG logos
- retain text glyph fallbacks for providers without dedicated artwork
- preserve accessible labeling and size the new marks consistently across provider surfaces

## Why

The sign-in buttons rendered `GO` and `GH` because the shared provider glyph component only emitted text abbreviations. That made the expected provider logos appear to be missing.

## Impact

The sign-in screen now displays recognizable Google and GitHub marks without depending on external image paths. Other integrations keep their existing fallback behavior.

## Validation

- `pnpm typecheck`
- focused component tests and lint
- `pnpm test` (390 tests)
- `pnpm build`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show Google and GitHub logos in auth buttons instead of “GO”/“GH”. This restores recognizable branding, keeps accessible behavior, and preserves text fallbacks for other providers.

- `ProviderGlyph` reads a `logo` key from centralized `provider-glyphs` metadata and renders inline `GithubLogo`/`GoogleLogo`; otherwise it renders the text glyph.
- Adds `GithubLogo` (currentColor) and `GoogleLogo` (brand colors) SVGs and a `providerLogos` map; extracts `ProviderGlyphContent` to choose SVG vs text.
- Sizes `.providerGlyph > svg` to 18×18 for consistent button layout.
- Accessibility: non-decorative glyphs use role="img" with aria-label; decorative glyphs set aria-hidden="true".
- Tests assert SVG rendering, GitHub `currentColor` fill, Google brand colors, and text fallbacks for providers without a logo.

<sup>Written for commit 41bb198893257211e55ddf395d8acbe062dc9f5a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/responder-oss/pull/16?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

