### PR TITLE
Send workspace invitation emails

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,6 +59,12 @@ AUTH_GOOGLE_CLIENT_SECRET=
 AUTH_GITHUB_CLIENT_ID=
 AUTH_GITHUB_CLIENT_SECRET=
 
+# Workspace invitation email. In development, invitations are still created
+# when RESEND_API_KEY is omitted and their secure links remain copyable.
+RESEND_API_KEY=
+RESPONDER_FROM_EMAIL=Responder <no-reply@superlog.sh>
+RESPONDER_REPLY_TO_EMAIL=
+
 # Product analytics. Use the same PostHog project token in both processes.
 POSTHOG_PROJECT_TOKEN=
 POSTHOG_HOST=https://eu.i.posthog.com

--- a/apps/control-plane/e2e/workspace-onboarding.spec.ts
+++ b/apps/control-plane/e2e/workspace-onboarding.spec.ts
@@ -134,7 +134,19 @@ test("keeps an invitation link open while the recipient signs in", async ({
   await page.goto(`/invite/${invitationId}`);
 
   await expect(page).toHaveURL(new RegExp(`/invite/${invitationId}$`));
-  await expect(page.getByRole("heading", { name: "Welcome back" })).toBeVisible();
+  await expect(page.getByText("Workspace invitation")).toBeVisible();
+  await expect(page.getByRole("heading", { name: "You're invited" })).toBeVisible();
+  await expect(
+    page.getByText(
+      "Sign in or create an account with the invited email to join this workspace.",
+    ),
+  ).toBeVisible();
+
+  await page.getByRole("button", { name: "New to Responder? Create an account" }).click();
+  await expect(
+    page.getByRole("heading", { name: "Create your account to join" }),
+  ).toBeVisible();
+  await page.getByRole("button", { name: "Already have an account? Sign in" }).click();
 
   await page.getByLabel("Email").fill(user.email);
   await page.getByLabel("Password").fill("correct-horse-battery-staple");

--- a/apps/control-plane/package.json
+++ b/apps/control-plane/package.json
@@ -30,6 +30,7 @@
     "react-dom": "19.2.6",
     "react-markdown": "^10.1.0",
     "react-router-dom": "7.18.2",
+    "resend": "6.12.3",
     "tsx": "4.20.6",
     "zod": "4.4.3"
   },

--- a/apps/control-plane/server/auth.ts
+++ b/apps/control-plane/server/auth.ts
@@ -228,14 +228,33 @@ export function createResponderAuth() {
             organizationName: organization.name,
             role,
           });
-          await sendEmail({
-            ...body,
-            idempotencyKey: `workspace-invitation/${id}/${new Date(
-              invitation.expiresAt,
-            ).getTime()}`,
-            subject: `You're invited to ${organization.name} in Responder`,
-            to: email,
-          });
+          try {
+            await sendEmail({
+              ...body,
+              idempotencyKey: `workspace-invitation/${id}/${new Date(
+                invitation.expiresAt,
+              ).getTime()}`,
+              subject: `You're invited to ${organization.name} in Responder`,
+              to: email,
+            });
+            console.info(
+              JSON.stringify({
+                event: "invitation_email_delivery_success",
+                invitationId: id,
+                organizationId: organization.id,
+              }),
+            );
+          } catch (error) {
+            console.error(
+              JSON.stringify({
+                errorCode:
+                  error instanceof Error ? error.constructor.name : "unknown",
+                event: "invitation_email_delivery_failed",
+                invitationId: id,
+                organizationId: organization.id,
+              }),
+            );
+          }
         },
         organizationHooks: {
           afterCreateOrganization: async ({ organization, user }) => {

--- a/apps/control-plane/server/auth.ts
+++ b/apps/control-plane/server/auth.ts
@@ -249,6 +249,7 @@ export function createResponderAuth() {
               JSON.stringify({
                 errorCode:
                   error instanceof Error ? error.constructor.name : "unknown",
+                errorMessage: authHandlerErrorMessage(error),
                 event: "invitation_email_delivery_failed",
                 invitationId: id,
                 organizationId: organization.id,

--- a/apps/control-plane/server/auth.ts
+++ b/apps/control-plane/server/auth.ts
@@ -21,6 +21,7 @@ import {
   adminAc as organizationAdminAc,
   memberAc as organizationMemberAc,
 } from "better-auth/plugins/organization/access";
+import { sendEmail, workspaceInvitationEmailBody } from "./email.js";
 
 export const superuserRoles = {
   superuser: superuserAc,
@@ -207,6 +208,34 @@ export function createResponderAuth() {
         roles: {
           admin: organizationAdminAc,
           member: organizationMemberAc,
+        },
+        sendInvitationEmail: async ({
+          email,
+          id,
+          invitation,
+          inviter,
+          organization,
+          role,
+        }) => {
+          const invitationUrl = new URL(
+            `/invite/${encodeURIComponent(id)}`,
+            baseURL,
+          ).toString();
+          const body = workspaceInvitationEmailBody({
+            invitationUrl,
+            inviterEmail: inviter.user.email,
+            inviterName: inviter.user.name,
+            organizationName: organization.name,
+            role,
+          });
+          await sendEmail({
+            ...body,
+            idempotencyKey: `workspace-invitation/${id}/${new Date(
+              invitation.expiresAt,
+            ).getTime()}`,
+            subject: `You're invited to ${organization.name} in Responder`,
+            to: email,
+          });
         },
         organizationHooks: {
           afterCreateOrganization: async ({ organization, user }) => {

--- a/apps/control-plane/server/email.test.ts
+++ b/apps/control-plane/server/email.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { sendEmail, workspaceInvitationEmailBody } from "./email.js";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("workspaceInvitationEmailBody", () => {
+  it("includes invitation context in both email formats", () => {
+    const invitationUrl =
+      "https://responder.superlog.sh/invite/11111111-1111-4111-8111-111111111111";
+    const body = workspaceInvitationEmailBody({
+      invitationUrl,
+      inviterEmail: "ada@example.com",
+      inviterName: "Ada",
+      organizationName: "Acme",
+      role: "member",
+    });
+
+    expect(body.text).toContain(
+      "Ada invited you to join the Acme workspace in Responder as a member.",
+    );
+    expect(body.text).toContain(`Accept invitation: ${invitationUrl}`);
+    expect(body.html).toContain("<strong>Acme</strong>");
+    expect(body.html).toContain(`href="${invitationUrl}"`);
+  });
+
+  it("escapes user-controlled values in the HTML body", () => {
+    const body = workspaceInvitationEmailBody({
+      invitationUrl: 'https://example.com/invite/a"><script>',
+      inviterEmail: "ada@example.com",
+      inviterName: "<b>Ada</b>",
+      organizationName: '<img src="x">',
+      role: "<admin>",
+    });
+
+    expect(body.html).not.toContain("<script>");
+    expect(body.html).not.toContain("<b>Ada</b>");
+    expect(body.html).not.toContain("<img");
+    expect(body.html).toContain("&lt;b&gt;Ada&lt;/b&gt;");
+    expect(body.html).toContain("&lt;admin&gt;");
+    expect(body.html).toContain("&quot;");
+  });
+});
+
+describe("sendEmail", () => {
+  const message = {
+    html: "<p>Invitation</p>",
+    idempotencyKey: "workspace-invitation/invitation-id/1234",
+    subject: "You're invited",
+    text: "Invitation",
+    to: "grace@example.com",
+  };
+
+  it("sends the configured Resend payload with an idempotency key", async () => {
+    const deliver = vi.fn(async () => ({
+      data: { id: "email-id" },
+      error: null,
+      headers: null,
+    }));
+
+    await sendEmail(message, {
+      deliver,
+      environment: {
+        RESEND_API_KEY: "test-key",
+        RESPONDER_FROM_EMAIL: "Responder <invite@example.com>",
+        RESPONDER_REPLY_TO_EMAIL: "support@example.com",
+      } as NodeJS.ProcessEnv,
+    });
+
+    expect(deliver).toHaveBeenCalledWith(
+      {
+        from: "Responder <invite@example.com>",
+        html: message.html,
+        replyTo: "support@example.com",
+        subject: message.subject,
+        text: message.text,
+        to: [message.to],
+      },
+      { idempotencyKey: message.idempotencyKey },
+    );
+  });
+
+  it("fails closed when production email is not configured", async () => {
+    await expect(
+      sendEmail(message, {
+        environment: { NODE_ENV: "production" } as NodeJS.ProcessEnv,
+      }),
+    ).rejects.toThrow("RESEND_API_KEY is required");
+  });
+
+  it("keeps local invitation links usable without Resend", async () => {
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await sendEmail(message, { environment: {} as NodeJS.ProcessEnv });
+
+    expect(warning).toHaveBeenCalledWith(
+      JSON.stringify({
+        event: "invitation_email_skipped",
+        reason: "resend_not_configured",
+      }),
+    );
+  });
+
+  it("surfaces Resend delivery failures", async () => {
+    const deliver = vi.fn(async () => ({
+      data: null,
+      error: {
+        message: "Sender domain is not verified",
+        name: "validation_error" as const,
+        statusCode: 422,
+      },
+      headers: null,
+    }));
+
+    await expect(
+      sendEmail(message, {
+        deliver,
+        environment: { RESEND_API_KEY: "test-key" } as NodeJS.ProcessEnv,
+      }),
+    ).rejects.toThrow("Sender domain is not verified");
+  });
+});

--- a/apps/control-plane/server/email.ts
+++ b/apps/control-plane/server/email.ts
@@ -1,0 +1,97 @@
+import {
+  Resend,
+  type CreateEmailOptions,
+  type CreateEmailRequestOptions,
+  type CreateEmailResponse,
+} from "resend";
+
+const defaultFrom = "Responder <no-reply@superlog.sh>";
+
+type EmailDelivery = (
+  message: CreateEmailOptions,
+  options?: CreateEmailRequestOptions,
+) => Promise<CreateEmailResponse>;
+
+export interface EmailMessage {
+  html: string;
+  idempotencyKey: string;
+  subject: string;
+  text: string;
+  to: string;
+}
+
+interface SendEmailOptions {
+  deliver?: EmailDelivery;
+  environment?: NodeJS.ProcessEnv;
+}
+
+export async function sendEmail(
+  message: EmailMessage,
+  options: SendEmailOptions = {},
+): Promise<void> {
+  const environment = options.environment ?? process.env;
+  const apiKey = environment.RESEND_API_KEY?.trim();
+  if (!apiKey) {
+    if (environment.NODE_ENV === "production") {
+      throw new Error("RESEND_API_KEY is required to send invitation emails");
+    }
+    console.warn(
+      JSON.stringify({
+        event: "invitation_email_skipped",
+        reason: "resend_not_configured",
+      }),
+    );
+    return;
+  }
+
+  const deliver =
+    options.deliver ??
+    ((payload: CreateEmailOptions, requestOptions?: CreateEmailRequestOptions) => {
+      const resend = new Resend(apiKey);
+      return resend.emails.send(payload, requestOptions);
+    });
+  const { error } = await deliver(
+    {
+      from: environment.RESPONDER_FROM_EMAIL?.trim() || defaultFrom,
+      html: message.html,
+      replyTo: environment.RESPONDER_REPLY_TO_EMAIL?.trim() || undefined,
+      subject: message.subject,
+      text: message.text,
+      to: [message.to],
+    },
+    { idempotencyKey: message.idempotencyKey },
+  );
+
+  if (error) {
+    throw new Error(`Resend could not send the invitation: ${error.message}`);
+  }
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+export function workspaceInvitationEmailBody(args: {
+  invitationUrl: string;
+  inviterEmail: string;
+  inviterName?: string | null;
+  organizationName: string;
+  role: string;
+}): { html: string; text: string } {
+  const inviter = args.inviterName?.trim() || args.inviterEmail;
+  const safeInviter = escapeHtml(inviter);
+  const safeOrganization = escapeHtml(args.organizationName);
+  const safeRole = escapeHtml(args.role);
+  const safeUrl = escapeHtml(args.invitationUrl);
+
+  return {
+    text: `${inviter} invited you to join the ${args.organizationName} workspace in Responder as a ${args.role}.\n\nAccept invitation: ${args.invitationUrl}\n\nIf you weren't expecting this invitation, you can ignore this email.`,
+    html: `<p>${safeInviter} invited you to join the <strong>${safeOrganization}</strong> workspace in Responder as a ${safeRole}.</p>
+<p><a href="${safeUrl}">Accept invitation</a></p>
+<p style="color:#888">If you weren't expecting this invitation, you can ignore this email.</p>`,
+  };
+}

--- a/apps/control-plane/src/components/auth-gate.tsx
+++ b/apps/control-plane/src/components/auth-gate.tsx
@@ -38,6 +38,17 @@ function SignIn({ isInvitation = false }: { isInvitation?: boolean }) {
   const [error, setError] = useState<string | null>(() =>
     socialAuthErrorMessage(window.location.search),
   );
+  let heading = isCreatingAccount ? "Create your account" : "Welcome back";
+  let description = isCreatingAccount
+    ? "Start a workspace for your incident response agents."
+    : "Sign in to manage your agents and investigations.";
+  if (isInvitation) {
+    heading = isCreatingAccount
+      ? "Create your account to join"
+      : "You're invited";
+    description =
+      "Sign in or create an account with the invited email to join this workspace.";
+  }
 
   async function socialSignIn(provider: "github" | "google") {
     setError(null);
@@ -120,22 +131,8 @@ function SignIn({ isInvitation = false }: { isInvitation?: boolean }) {
         {isInvitation ? (
           <span className="invitationLabel">Workspace invitation</span>
         ) : null}
-        <h1>
-          {isInvitation
-            ? isCreatingAccount
-              ? "Create your account to join"
-              : "You're invited"
-            : isCreatingAccount
-              ? "Create your account"
-              : "Welcome back"}
-        </h1>
-        <p>
-          {isInvitation
-            ? "Sign in or create an account with the invited email to join this workspace."
-            : isCreatingAccount
-            ? "Start a workspace for your incident response agents."
-            : "Sign in to manage your agents and investigations."}
-        </p>
+        <h1>{heading}</h1>
+        <p>{description}</p>
       </div>
       <div className="socialAuth">
         <button

--- a/apps/control-plane/src/components/auth-gate.tsx
+++ b/apps/control-plane/src/components/auth-gate.tsx
@@ -29,7 +29,7 @@ function AuthFrame({ children }: AuthGateProps) {
   );
 }
 
-function SignIn() {
+function SignIn({ isInvitation = false }: { isInvitation?: boolean }) {
   const [isCreatingAccount, setIsCreatingAccount] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [socialProvider, setSocialProvider] = useState<"github" | "google" | null>(
@@ -117,9 +117,22 @@ function SignIn() {
   return (
     <>
       <div className="authIntro">
-        <h1>{isCreatingAccount ? "Create your account" : "Welcome back"}</h1>
+        {isInvitation ? (
+          <span className="invitationLabel">Workspace invitation</span>
+        ) : null}
+        <h1>
+          {isInvitation
+            ? isCreatingAccount
+              ? "Create your account to join"
+              : "You're invited"
+            : isCreatingAccount
+              ? "Create your account"
+              : "Welcome back"}
+        </h1>
         <p>
-          {isCreatingAccount
+          {isInvitation
+            ? "Sign in or create an account with the invited email to join this workspace."
+            : isCreatingAccount
             ? "Start a workspace for your incident response agents."
             : "Sign in to manage your agents and investigations."}
         </p>
@@ -501,7 +514,7 @@ export function AuthGate({ children }: AuthGateProps) {
   if (!session.data) {
     return (
       <AuthFrame>
-        <SignIn />
+        <SignIn isInvitation={Boolean(invitationMatch?.[1])} />
       </AuthFrame>
     );
   }

--- a/apps/control-plane/src/pages/workspace-settings.tsx
+++ b/apps/control-plane/src/pages/workspace-settings.tsx
@@ -107,7 +107,7 @@ export function WorkspaceSettingsPage() {
     );
     const link = invitationUrl(result.data.id);
     setLatestInvitation(link);
-    setNotice(`Invitation created for ${result.data.email}.`);
+    setNotice(`Invitation sent to ${result.data.email}.`);
     form.reset();
     setInvitationRole("member");
     await organization.refetch();
@@ -272,7 +272,7 @@ export function WorkspaceSettingsPage() {
           <form className="inviteForm" onSubmit={invite}>
             <div>
               <h3>Invite a teammate</h3>
-              <p>Create a secure link to share with the person you invite.</p>
+              <p>Email an invitation, with a secure link you can also copy.</p>
             </div>
             <div className="inviteForm__controls">
               <input

--- a/apps/control-plane/src/pages/workspace-settings.tsx
+++ b/apps/control-plane/src/pages/workspace-settings.tsx
@@ -107,7 +107,9 @@ export function WorkspaceSettingsPage() {
     );
     const link = invitationUrl(result.data.id);
     setLatestInvitation(link);
-    setNotice(`Invitation sent to ${result.data.email}.`);
+    setNotice(
+      `Invitation created for ${result.data.email}. Copy the link if they don't receive the email.`,
+    );
     form.reset();
     setInvitationRole("member");
     await organization.refetch();

--- a/apps/control-plane/src/styles.css
+++ b/apps/control-plane/src/styles.css
@@ -676,6 +676,21 @@ button:disabled {
   margin-bottom: 28px;
 }
 
+.invitationLabel {
+  width: fit-content;
+  margin-bottom: 12px;
+  padding: 4px 8px;
+  display: block;
+  border: 1px solid var(--border-logo);
+  border-radius: 999px;
+  color: var(--secondary);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  line-height: 16px;
+  text-transform: uppercase;
+}
+
 .authIntro h1 {
   margin: 0;
   font-size: 30px;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,6 +119,9 @@ importers:
       react-router-dom:
         specifier: 7.18.2
         version: 7.18.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      resend:
+        specifier: 6.12.3
+        version: 6.12.3
       tsx:
         specifier: 4.20.6
         version: 4.20.6
@@ -1567,6 +1570,9 @@ packages:
   '@socket.io/component-emitter@3.1.2':
     resolution: {integrity: sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==}
 
+  '@stablelib/base64@1.0.1':
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -2558,6 +2564,9 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
+
   fast-uri@3.1.5:
     resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
@@ -3379,6 +3388,9 @@ packages:
     os: [darwin, linux, win32]
     hasBin: true
 
+  postal-mime@2.7.4:
+    resolution: {integrity: sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==}
+
   postcss@8.5.26:
     resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
     engines: {node: ^10 || ^12 || >=14}
@@ -3525,6 +3537,15 @@ packages:
     resolution: {integrity: sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==}
     engines: {node: '>=9.3.0 || >=8.10.0 <9.0.0'}
 
+  resend@6.12.3:
+    resolution: {integrity: sha512-FkEi6YPnVL96/LvH8+QP7NaeaBy5brYXwlRqUCqZZeNL0/iyKij18IPmyPXYauT/2ODn1JG04qKz+qlJfzqzTw==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@react-email/render': '*'
+    peerDependenciesMeta:
+      '@react-email/render':
+        optional: true
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -3663,6 +3684,9 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
+  standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
+
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
@@ -3708,6 +3732,9 @@ packages:
   supports-color@8.1.1:
     resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
     engines: {node: '>=10'}
+
+  svix@1.92.2:
+    resolution: {integrity: sha512-ZmuA3UVvlnF9EgxlzmPtF7CKjQb64Z6OFlyfdDfU0sdcC7dJa+3aOYX5B9mA+RS6ch1AxBa4UP/l6KmqfGtWBQ==}
 
   tagged-tag@1.0.0:
     resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
@@ -5537,6 +5564,8 @@ snapshots:
 
   '@socket.io/component-emitter@3.1.2': {}
 
+  '@stablelib/base64@1.0.1': {}
+
   '@standard-schema/spec@1.1.0': {}
 
   '@tailwindcss/node@4.3.3':
@@ -6541,6 +6570,8 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-sha256@1.3.0: {}
+
   fast-uri@3.1.5: {}
 
   fastq@1.20.1:
@@ -7365,6 +7396,8 @@ snapshots:
 
   portless@0.15.1: {}
 
+  postal-mime@2.7.4: {}
+
   postcss@8.5.26:
     dependencies:
       nanoid: 3.3.18
@@ -7531,6 +7564,11 @@ snapshots:
       module-details-from-path: 1.0.4
     transitivePeerDependencies:
       - supports-color
+
+  resend@6.12.3:
+    dependencies:
+      postal-mime: 2.7.4
+      svix: 1.92.2
 
   resolve-from@4.0.0: {}
 
@@ -7701,6 +7739,11 @@ snapshots:
 
   stackback@0.0.2: {}
 
+  standardwebhooks@1.0.0:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
+
   statuses@2.0.2: {}
 
   std-env@4.2.0: {}
@@ -7748,6 +7791,10 @@ snapshots:
   supports-color@8.1.1:
     dependencies:
       has-flag: 4.0.0
+
+  svix@1.92.2:
+    dependencies:
+      standardwebhooks: 1.0.0
 
   tagged-tag@1.0.0: {}
 


### PR DESCRIPTION
## Summary

- show invitation-specific context before recipients authenticate
- send workspace invitation emails through Resend from Better Auth's invitation callback
- retain the copyable invitation link as a fallback for inviters
- document the optional local and required production email configuration

## Root cause

Invitation creation only persisted Better Auth's invitation record. No `sendInvitationEmail` callback was configured, so the API never attempted email delivery. Signed-out recipients also entered the generic authentication screen because invitation context was only rendered after a session existed.

## User impact

Inviters now get a sent confirmation and a copyable fallback link. Recipients receive an email containing the inviter, workspace, role, and acceptance link, and the link opens a clearly labeled invitation screen throughout sign-in or account creation.

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
- `pnpm exec playwright test apps/control-plane/e2e/workspace-onboarding.spec.ts`
- `pnpm build`
- Resend delivery check using its test recipient

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sends workspace invitation emails via `resend` and keeps invitation context visible during authentication. Previously no email was sent and recipients saw a generic sign-in screen; now Better Auth’s invitation callback delivers emails, logs outcomes, and email failures don’t block invitation creation or the copyable link.

**Details**
- Adds `sendInvitationEmail` that builds an acceptance URL, uses an idempotency key per invitation, and sends XSS-safe HTML/text via `workspaceInvitationEmailBody`.
- Classifies and logs delivery results: success (`invitation_email_delivery_success`), failure (`invitation_email_delivery_failed` with `errorCode` and `errorMessage`), and local skip when `RESEND_API_KEY` is unset (`invitation_email_skipped`).
- In production, missing `RESEND_API_KEY` causes send to fail; the callback catches and logs the failure so invitations and copyable links still work.
- Updates auth UI to show a “Workspace invitation” label and invitation-aware headings during sign-in/sign-up; updates e2e accordingly. Adds `resend` and unit tests for escaping, payload/idempotency, and failure handling.

**Rollout**
- Set `RESEND_API_KEY` and `RESPONDER_FROM_EMAIL` (optional: `RESPONDER_REPLY_TO_EMAIL`) in production, and verify the sender domain in Resend.
- No data migration required; invitation links remain copyable if email delivery fails.

<sup>Written for commit 8daa0a19abf4cba78100590ccd733d56c969cd6b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/responder-oss/pull/17?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

