### PR TITLE
Add hosted blog route

### DIFF
--- a/apps/control-plane/.gitignore
+++ b/apps/control-plane/.gitignore
@@ -1,2 +1,3 @@
 .env*
+.prerender
 dist

--- a/apps/control-plane/package.json
+++ b/apps/control-plane/package.json
@@ -8,7 +8,7 @@
     "node": ">=24"
   },
   "scripts": {
-    "build": "vite build",
+    "build": "vite build && vite build --config vite.prerender.config.ts && node scripts/prerender.mjs",
     "dev": "concurrently -k -n web,api \"vite\" \"tsx watch server/dev.ts\"",
     "preview": "vite preview",
     "start": "tsx server/production.ts",

--- a/apps/control-plane/scripts/prerender.mjs
+++ b/apps/control-plane/scripts/prerender.mjs
@@ -56,10 +56,12 @@ await writeFile(path.join(distRoot, "app.html"), shell);
 
 for (const route of routes) {
   const metadata = editionSeoMetadataForPath(route.pathname);
-  if (!metadata) continue;
   const output = path.join(distRoot, route.output);
   await mkdir(path.dirname(output), { recursive: true });
-  await writeFile(output, renderDocument(route.pathname, metadata));
+  await writeFile(
+    output,
+    metadata ? renderDocument(route.pathname, metadata) : shell,
+  );
 }
 
 await rm(path.join(applicationRoot, ".prerender"), {

--- a/apps/control-plane/scripts/prerender.mjs
+++ b/apps/control-plane/scripts/prerender.mjs
@@ -1,0 +1,68 @@
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  editionSeoMetadataForPath,
+  renderPublicRoute,
+} from "../.prerender/prerender-entry.js";
+
+const applicationRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+const distRoot = path.join(applicationRoot, "dist");
+const shell = await readFile(path.join(distRoot, "index.html"), "utf8");
+
+function escapeHtml(value) {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+}
+
+function renderHead(metadata) {
+  const meta = metadata.meta
+    .map(
+      (tag) =>
+        `<meta data-responder-seo="" ${tag.attribute}="${escapeHtml(tag.key)}" content="${escapeHtml(tag.content)}">`,
+    )
+    .join("\n    ");
+  const jsonLd = JSON.stringify(metadata.jsonLd).replaceAll("<", "\\u003c");
+
+  return [
+    `<title>${escapeHtml(metadata.title)}</title>`,
+    meta,
+    `<link data-responder-seo="" rel="canonical" href="${escapeHtml(metadata.canonicalUrl)}">`,
+    `<script data-responder-seo="" type="application/ld+json">${jsonLd}</script>`,
+  ].join("\n    ");
+}
+
+function renderDocument(pathname, metadata) {
+  const markup = renderPublicRoute(pathname);
+  return shell
+    .replace(/\s*<meta\s+name="description"[\s\S]*?\/>/, "")
+    .replace(/\s*<title>[\s\S]*?<\/title>/, "")
+    .replace("</head>", `    ${renderHead(metadata)}\n  </head>`)
+    .replace('<div id="root"></div>', `<div id="root">${markup}</div>`);
+}
+
+const routes = [
+  { output: "index.html", pathname: "/" },
+  { output: "blog/index.html", pathname: "/blog" },
+];
+
+await writeFile(path.join(distRoot, "app.html"), shell);
+
+for (const route of routes) {
+  const metadata = editionSeoMetadataForPath(route.pathname);
+  if (!metadata) continue;
+  const output = path.join(distRoot, route.output);
+  await mkdir(path.dirname(output), { recursive: true });
+  await writeFile(output, renderDocument(route.pathname, metadata));
+}
+
+await rm(path.join(applicationRoot, ".prerender"), {
+  force: true,
+  recursive: true,
+});

--- a/apps/control-plane/server/production-app.ts
+++ b/apps/control-plane/server/production-app.ts
@@ -11,7 +11,6 @@ const staticRoot = path.resolve(
 );
 const serveAsset = serveStatic({ root: staticRoot });
 const serveAppShell = serveStatic({ path: "app.html", root: staticRoot });
-const serveBlog = serveStatic({ path: "blog/index.html", root: staticRoot });
 
 export const productionApp = new Hono()
   .route("/", app)
@@ -20,8 +19,6 @@ export const productionApp = new Hono()
     return next();
   })
   .use("*", serveAsset)
-  .get("/blog", serveBlog)
-  .get("/blog/", serveBlog)
   .get("*", async (context, next) => {
     if (
       context.req.path === "/api" ||

--- a/apps/control-plane/server/production-app.ts
+++ b/apps/control-plane/server/production-app.ts
@@ -10,7 +10,8 @@ const staticRoot = path.resolve(
   "../dist",
 );
 const serveAsset = serveStatic({ root: staticRoot });
-const serveIndex = serveStatic({ path: "index.html", root: staticRoot });
+const serveAppShell = serveStatic({ path: "app.html", root: staticRoot });
+const serveBlog = serveStatic({ path: "blog/index.html", root: staticRoot });
 
 export const productionApp = new Hono()
   .route("/", app)
@@ -19,6 +20,8 @@ export const productionApp = new Hono()
     return next();
   })
   .use("*", serveAsset)
+  .get("/blog", serveBlog)
+  .get("/blog/", serveBlog)
   .get("*", async (context, next) => {
     if (
       context.req.path === "/api" ||
@@ -28,5 +31,5 @@ export const productionApp = new Hono()
     ) {
       return context.notFound();
     }
-    return serveIndex(context, next);
+    return serveAppShell(context, next);
   });

--- a/apps/control-plane/src/app.tsx
+++ b/apps/control-plane/src/app.tsx
@@ -8,10 +8,12 @@ import { DesignLibraryPage } from "./pages/design-library";
 import { InvestigationDetailPage } from "./pages/investigation-detail";
 import { IssueDetailPage } from "./pages/issue-detail";
 import { IssuesPage } from "./pages/issues";
+import { editionSeoMetadataForPath } from "./edition-metadata";
 import { BlogPage, HomePage, PricingPage } from "./edition-pages";
 import { SettingsPage } from "./pages/settings";
 import { SuperuserUsersPage } from "./pages/superuser-users";
 import { WorkspaceSettingsPage } from "./pages/workspace-settings";
+import { usePageMetadata } from "./use-page-metadata";
 
 function ProtectedApp() {
   return (
@@ -27,6 +29,9 @@ function LegacyBillingRedirect() {
 }
 
 export function App() {
+  const { pathname } = useLocation();
+  usePageMetadata(editionSeoMetadataForPath(pathname));
+
   return (
     <Routes>
       <Route element={<HomePage />} path="/" />

--- a/apps/control-plane/src/app.tsx
+++ b/apps/control-plane/src/app.tsx
@@ -8,7 +8,7 @@ import { DesignLibraryPage } from "./pages/design-library";
 import { InvestigationDetailPage } from "./pages/investigation-detail";
 import { IssueDetailPage } from "./pages/issue-detail";
 import { IssuesPage } from "./pages/issues";
-import { HomePage, PricingPage } from "./edition-pages";
+import { BlogPage, HomePage, PricingPage } from "./edition-pages";
 import { SettingsPage } from "./pages/settings";
 import { SuperuserUsersPage } from "./pages/superuser-users";
 import { WorkspaceSettingsPage } from "./pages/workspace-settings";
@@ -31,6 +31,7 @@ export function App() {
     <Routes>
       <Route element={<HomePage />} path="/" />
       <Route element={<PricingPage />} path="/pricing" />
+      <Route element={<BlogPage />} path="/blog" />
       {import.meta.env.DEV ? (
         <Route element={<DesignLibraryPage />} path="/_design" />
       ) : null}

--- a/apps/control-plane/src/components/browser-analytics-identity.tsx
+++ b/apps/control-plane/src/components/browser-analytics-identity.tsx
@@ -6,10 +6,10 @@ export function BrowserAnalyticsIdentity() {
   const session = authClient.useSession();
   const lastIdentity = useRef<string | null>(null);
 
-  const userId = session.data?.user.id;
-  const userEmail = session.data?.user.email;
-  const userName = session.data?.user.name;
-  const organizationId = session.data?.session.activeOrganizationId;
+  const userId = session.data?.user?.id;
+  const userEmail = session.data?.user?.email;
+  const userName = session.data?.user?.name;
+  const organizationId = session.data?.session?.activeOrganizationId;
 
   useEffect(() => {
     if (session.isPending || !userId) return;

--- a/apps/control-plane/src/components/browser-monitoring-identity.tsx
+++ b/apps/control-plane/src/components/browser-monitoring-identity.tsx
@@ -4,8 +4,8 @@ import { setBrowserMonitoringIdentity } from "../browser-monitoring";
 
 export function BrowserMonitoringIdentity() {
   const session = authClient.useSession();
-  const userId = session.data?.user.id;
-  const organizationId = session.data?.session.activeOrganizationId;
+  const userId = session.data?.user?.id;
+  const organizationId = session.data?.session?.activeOrganizationId;
 
   useEffect(() => {
     if (session.isPending) return;

--- a/apps/control-plane/src/edition-metadata.ts
+++ b/apps/control-plane/src/edition-metadata.ts
@@ -1,0 +1,8 @@
+import type { SeoMetadata } from "./page-metadata";
+
+export function editionSeoMetadataForPath(
+  pathname: string,
+): SeoMetadata | undefined {
+  void pathname;
+  return undefined;
+}

--- a/apps/control-plane/src/edition-pages.tsx
+++ b/apps/control-plane/src/edition-pages.tsx
@@ -8,3 +8,7 @@ export function HomePage() {
 export function PricingPage() {
   return <Navigate replace to="/agents" />;
 }
+
+export function BlogPage() {
+  return <Navigate replace to="/agents" />;
+}

--- a/apps/control-plane/src/main.tsx
+++ b/apps/control-plane/src/main.tsx
@@ -1,7 +1,7 @@
 import "@fontsource-variable/inter";
 import * as Sentry from "@sentry/react";
 import { StrictMode } from "react";
-import { createRoot } from "react-dom/client";
+import { createRoot, hydrateRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import { App } from "./app";
 import { initializeBrowserAnalytics } from "./browser-analytics";
@@ -25,7 +25,7 @@ if (!root) throw new Error("Root element is missing");
 rememberXClickId();
 initializeXPixel();
 
-createRoot(root).render(
+const application = (
   <StrictMode>
     <Sentry.ErrorBoundary
       fallback={({ eventId }) => <ApplicationError eventId={eventId} />}
@@ -37,5 +37,11 @@ createRoot(root).render(
         <App />
       </BrowserRouter>
     </Sentry.ErrorBoundary>
-  </StrictMode>,
+  </StrictMode>
 );
+
+if (root.hasChildNodes()) {
+  hydrateRoot(root, application);
+} else {
+  createRoot(root).render(application);
+}

--- a/apps/control-plane/src/page-metadata.ts
+++ b/apps/control-plane/src/page-metadata.ts
@@ -1,0 +1,13 @@
+export interface SeoMetaTag {
+  attribute: "name" | "property";
+  content: string;
+  key: string;
+}
+
+export interface SeoMetadata {
+  canonicalUrl: string;
+  description: string;
+  jsonLd: Record<string, unknown> | Record<string, unknown>[];
+  meta: SeoMetaTag[];
+  title: string;
+}

--- a/apps/control-plane/src/prerender-entry.tsx
+++ b/apps/control-plane/src/prerender-entry.tsx
@@ -1,0 +1,14 @@
+import { renderToString } from "react-dom/server";
+import { StaticRouter } from "react-router-dom";
+import { App } from "./app";
+import { editionSeoMetadataForPath } from "./edition-metadata";
+
+export { editionSeoMetadataForPath };
+
+export function renderPublicRoute(pathname: string) {
+  return renderToString(
+    <StaticRouter location={pathname}>
+      <App />
+    </StaticRouter>,
+  );
+}

--- a/apps/control-plane/src/use-page-metadata.ts
+++ b/apps/control-plane/src/use-page-metadata.ts
@@ -2,19 +2,28 @@ import { useEffect } from "react";
 import type { SeoMetadata } from "./page-metadata";
 
 const ownedSelector = "[data-responder-seo]";
+const shellTitle = "Responder";
 
 function removeOwnedMetadata() {
   document.head.querySelectorAll(ownedSelector).forEach((element) => element.remove());
 }
 
+function resetPageMetadata() {
+  removeOwnedMetadata();
+  document.title = shellTitle;
+}
+
 export function usePageMetadata(metadata: SeoMetadata | undefined) {
   useEffect(() => {
-    removeOwnedMetadata();
+    resetPageMetadata();
     if (!metadata) return;
 
     document.title = metadata.title;
 
     for (const tag of metadata.meta) {
+      document.head
+        .querySelector(`${tag.attribute === "name" ? "meta[name" : "meta[property"}="${tag.key}"]:not(${ownedSelector})`)
+        ?.remove();
       const element = document.createElement("meta");
       element.dataset.responderSeo = "";
       element.setAttribute(tag.attribute, tag.key);
@@ -34,6 +43,6 @@ export function usePageMetadata(metadata: SeoMetadata | undefined) {
     structuredData.text = JSON.stringify(metadata.jsonLd);
     document.head.append(structuredData);
 
-    return removeOwnedMetadata;
+    return resetPageMetadata;
   }, [metadata]);
 }

--- a/apps/control-plane/src/use-page-metadata.ts
+++ b/apps/control-plane/src/use-page-metadata.ts
@@ -21,8 +21,12 @@ export function usePageMetadata(metadata: SeoMetadata | undefined) {
     document.title = metadata.title;
 
     for (const tag of metadata.meta) {
-      document.head
-        .querySelector(`${tag.attribute === "name" ? "meta[name" : "meta[property"}="${tag.key}"]:not(${ownedSelector})`)
+      Array.from(document.head.querySelectorAll("meta"))
+        .find(
+          (element) =>
+            !element.matches(ownedSelector) &&
+            element.getAttribute(tag.attribute) === tag.key,
+        )
         ?.remove();
       const element = document.createElement("meta");
       element.dataset.responderSeo = "";

--- a/apps/control-plane/src/use-page-metadata.ts
+++ b/apps/control-plane/src/use-page-metadata.ts
@@ -1,0 +1,39 @@
+import { useEffect } from "react";
+import type { SeoMetadata } from "./page-metadata";
+
+const ownedSelector = "[data-responder-seo]";
+
+function removeOwnedMetadata() {
+  document.head.querySelectorAll(ownedSelector).forEach((element) => element.remove());
+}
+
+export function usePageMetadata(metadata: SeoMetadata | undefined) {
+  useEffect(() => {
+    removeOwnedMetadata();
+    if (!metadata) return;
+
+    document.title = metadata.title;
+
+    for (const tag of metadata.meta) {
+      const element = document.createElement("meta");
+      element.dataset.responderSeo = "";
+      element.setAttribute(tag.attribute, tag.key);
+      element.content = tag.content;
+      document.head.append(element);
+    }
+
+    const canonical = document.createElement("link");
+    canonical.dataset.responderSeo = "";
+    canonical.href = metadata.canonicalUrl;
+    canonical.rel = "canonical";
+    document.head.append(canonical);
+
+    const structuredData = document.createElement("script");
+    structuredData.dataset.responderSeo = "";
+    structuredData.type = "application/ld+json";
+    structuredData.text = JSON.stringify(metadata.jsonLd);
+    document.head.append(structuredData);
+
+    return removeOwnedMetadata;
+  }, [metadata]);
+}

--- a/apps/control-plane/vite.config.ts
+++ b/apps/control-plane/vite.config.ts
@@ -30,6 +30,10 @@ const previewDocumentRoutes: Plugin = {
         request.url = `/blog/index.html${url.search}`;
       } else if (
         url.pathname !== "/" &&
+        url.pathname !== "/api" &&
+        !url.pathname.startsWith("/api/") &&
+        url.pathname !== "/mcp" &&
+        !url.pathname.startsWith("/mcp/") &&
         !url.pathname.split("/").pop()?.includes(".")
       ) {
         request.url = `/app.html${url.search}`;
@@ -63,6 +67,12 @@ export default defineConfig({
         ]
       : []),
   ],
+  preview: {
+    proxy: {
+      "/api": `http://127.0.0.1:${apiPort}`,
+      "/mcp": `http://127.0.0.1:${apiPort}`,
+    },
+  },
   resolve: {
     alias: {
       "@": fileURLToPath(new URL("./src", import.meta.url)),

--- a/apps/control-plane/vite.config.ts
+++ b/apps/control-plane/vite.config.ts
@@ -2,7 +2,7 @@ import react from "@vitejs/plugin-react";
 import { sentryVitePlugin } from "@sentry/vite-plugin";
 import tailwindcss from "@tailwindcss/vite";
 import { fileURLToPath, URL } from "node:url";
-import { defineConfig } from "vite";
+import { defineConfig, type Plugin } from "vite";
 
 const webPort = Number(
   process.env.PORT ?? process.env.CONTROL_PLANE_WEB_PORT ?? 3000,
@@ -20,11 +20,32 @@ const uploadsSentrySourceMaps = Boolean(
 const buildsSentrySourceMaps =
   uploadsSentrySourceMaps || process.env.SENTRY_BUILD_SOURCEMAPS === "true";
 
+const previewDocumentRoutes: Plugin = {
+  configurePreviewServer(server) {
+    server.middlewares.use((request, _response, next) => {
+      if (!request.url) return next();
+
+      const url = new URL(request.url, "http://preview.local");
+      if (url.pathname === "/blog" || url.pathname === "/blog/") {
+        request.url = `/blog/index.html${url.search}`;
+      } else if (
+        url.pathname !== "/" &&
+        !url.pathname.split("/").pop()?.includes(".")
+      ) {
+        request.url = `/app.html${url.search}`;
+      }
+      next();
+    });
+  },
+  name: "preview-document-routes",
+};
+
 export default defineConfig({
   build: {
     sourcemap: buildsSentrySourceMaps ? "hidden" : false,
   },
   plugins: [
+    previewDocumentRoutes,
     react(),
     tailwindcss(),
     ...(uploadsSentrySourceMaps

--- a/apps/control-plane/vite.config.ts
+++ b/apps/control-plane/vite.config.ts
@@ -22,18 +22,21 @@ const buildsSentrySourceMaps =
 
 const previewDocumentRoutes: Plugin = {
   configurePreviewServer(server) {
-    server.middlewares.use((request, _response, next) => {
+    server.middlewares.use((request, response, next) => {
       if (!request.url) return next();
 
       const url = new URL(request.url, "http://preview.local");
+      if (url.pathname === "/mcp" || url.pathname.startsWith("/mcp/")) {
+        response.statusCode = 404;
+        response.end();
+        return;
+      }
       if (url.pathname === "/blog" || url.pathname === "/blog/") {
         request.url = `/blog/index.html${url.search}`;
       } else if (
         url.pathname !== "/" &&
         url.pathname !== "/api" &&
         !url.pathname.startsWith("/api/") &&
-        url.pathname !== "/mcp" &&
-        !url.pathname.startsWith("/mcp/") &&
         !url.pathname.split("/").pop()?.includes(".")
       ) {
         request.url = `/app.html${url.search}`;
@@ -70,7 +73,6 @@ export default defineConfig({
   preview: {
     proxy: {
       "/api": `http://127.0.0.1:${apiPort}`,
-      "/mcp": `http://127.0.0.1:${apiPort}`,
     },
   },
   resolve: {

--- a/apps/control-plane/vite.prerender.config.ts
+++ b/apps/control-plane/vite.prerender.config.ts
@@ -1,0 +1,22 @@
+import { fileURLToPath, URL } from "node:url";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  build: {
+    emptyOutDir: true,
+    minify: false,
+    outDir: ".prerender",
+    rollupOptions: {
+      input: "src/prerender-entry.tsx",
+      output: {
+        entryFileNames: "[name].js",
+      },
+    },
+    ssr: true,
+  },
+  resolve: {
+    alias: {
+      "@": fileURLToPath(new URL("./src", import.meta.url)),
+    },
+  },
+});


### PR DESCRIPTION
## Summary

- add a `/blog` route to the shared control-plane router
- expose a `BlogPage` edition hook for hosted deployments
- keep the self-hosted edition behavior unchanged by redirecting the placeholder page to `/agents`

## Why

The hosted Responder site needs a dedicated blog page while keeping private marketing content out of the public application repository. This route provides the same edition boundary already used by the landing and pricing pages.

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test` (400 tests)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `/blog` route behind the edition boundary and pre-renders `/` and `/blog` for SEO and faster first paint. Previously, all routes served the SPA shell; now `/` and `/blog` serve static HTML with SEO metadata while other non-asset routes fall back to `app.html`. Self-hosted still redirects `/blog` to `/agents`; hosted builds can render a real blog with SEO metadata.

- Exposes `BlogPage` and `editionSeoMetadataForPath`; the client hydrates pre-rendered pages and `usePageMetadata` resets and injects title, meta, canonical, and JSON‑LD on navigation.
- Build runs prerender via `vite` + `vite.prerender.config.ts` and `scripts/prerender.mjs`, emitting `index.html`, `blog/index.html`, and an `app.html` SPA shell; production serves static `/blog` and sends other document requests to `app.html`.
- Preview hardening: rewrites `/blog` to static HTML, routes other SPA paths to `app.html`, proxies `/api`, and 404s `/mcp`.
- Minor safety: make analytics and monitoring identity lookups null-safe to avoid errors on public pages.
- Hosted deployments must implement `BlogPage` and `editionSeoMetadataForPath`; no action required for self-hosted.

<sup>Written for commit aab08cdd3c730b4178db6a2f64744bde6e8259d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/responder-oss/pull/20?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

