### PR TITLE
Add slugged blog article route

### DIFF
--- a/apps/control-plane/scripts/prerender.mjs
+++ b/apps/control-plane/scripts/prerender.mjs
@@ -3,6 +3,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import {
   editionSeoMetadataForPath,
+  publicDocumentRoutes,
   renderPublicRoute,
 } from "../.prerender/prerender-entry.js";
 
@@ -47,18 +48,9 @@ function renderDocument(pathname, metadata) {
     .replace('<div id="root"></div>', `<div id="root">${markup}</div>`);
 }
 
-const routes = [
-  { output: "index.html", pathname: "/" },
-  { output: "blog/index.html", pathname: "/blog" },
-  {
-    output: "blog/kill-alert-fatigue-automating-on-call-with-ai/index.html",
-    pathname: "/blog/kill-alert-fatigue-automating-on-call-with-ai",
-  },
-];
-
 await writeFile(path.join(distRoot, "app.html"), shell);
 
-for (const route of routes) {
+for (const route of publicDocumentRoutes) {
   const metadata = editionSeoMetadataForPath(route.pathname);
   const output = path.join(distRoot, route.output);
   await mkdir(path.dirname(output), { recursive: true });

--- a/apps/control-plane/scripts/prerender.mjs
+++ b/apps/control-plane/scripts/prerender.mjs
@@ -50,6 +50,10 @@ function renderDocument(pathname, metadata) {
 const routes = [
   { output: "index.html", pathname: "/" },
   { output: "blog/index.html", pathname: "/blog" },
+  {
+    output: "blog/kill-alert-fatigue-automating-on-call-with-ai/index.html",
+    pathname: "/blog/kill-alert-fatigue-automating-on-call-with-ai",
+  },
 ];
 
 await writeFile(path.join(distRoot, "app.html"), shell);

--- a/apps/control-plane/src/app.tsx
+++ b/apps/control-plane/src/app.tsx
@@ -9,7 +9,12 @@ import { InvestigationDetailPage } from "./pages/investigation-detail";
 import { IssueDetailPage } from "./pages/issue-detail";
 import { IssuesPage } from "./pages/issues";
 import { editionSeoMetadataForPath } from "./edition-metadata";
-import { BlogPage, HomePage, PricingPage } from "./edition-pages";
+import {
+  BlogArticlePage,
+  BlogIndexPage,
+  HomePage,
+  PricingPage,
+} from "./edition-pages";
 import { SettingsPage } from "./pages/settings";
 import { SuperuserUsersPage } from "./pages/superuser-users";
 import { WorkspaceSettingsPage } from "./pages/workspace-settings";
@@ -36,7 +41,11 @@ export function App() {
     <Routes>
       <Route element={<HomePage />} path="/" />
       <Route element={<PricingPage />} path="/pricing" />
-      <Route element={<BlogPage />} path="/blog" />
+      <Route element={<BlogIndexPage />} path="/blog" />
+      <Route
+        element={<BlogArticlePage />}
+        path="/blog/kill-alert-fatigue-automating-on-call-with-ai"
+      />
       {import.meta.env.DEV ? (
         <Route element={<DesignLibraryPage />} path="/_design" />
       ) : null}

--- a/apps/control-plane/src/app.tsx
+++ b/apps/control-plane/src/app.tsx
@@ -18,6 +18,7 @@ import {
 import { SettingsPage } from "./pages/settings";
 import { SuperuserUsersPage } from "./pages/superuser-users";
 import { WorkspaceSettingsPage } from "./pages/workspace-settings";
+import { blogArticlePath } from "./public-routes";
 import { usePageMetadata } from "./use-page-metadata";
 
 function ProtectedApp() {
@@ -44,7 +45,7 @@ export function App() {
       <Route element={<BlogIndexPage />} path="/blog" />
       <Route
         element={<BlogArticlePage />}
-        path="/blog/kill-alert-fatigue-automating-on-call-with-ai"
+        path={blogArticlePath}
       />
       {import.meta.env.DEV ? (
         <Route element={<DesignLibraryPage />} path="/_design" />

--- a/apps/control-plane/src/edition-pages.tsx
+++ b/apps/control-plane/src/edition-pages.tsx
@@ -9,6 +9,10 @@ export function PricingPage() {
   return <Navigate replace to="/agents" />;
 }
 
-export function BlogPage() {
+export function BlogIndexPage() {
+  return <Navigate replace to="/agents" />;
+}
+
+export function BlogArticlePage() {
   return <Navigate replace to="/agents" />;
 }

--- a/apps/control-plane/src/prerender-entry.tsx
+++ b/apps/control-plane/src/prerender-entry.tsx
@@ -2,8 +2,9 @@ import { renderToString } from "react-dom/server";
 import { StaticRouter } from "react-router-dom";
 import { App } from "./app";
 import { editionSeoMetadataForPath } from "./edition-metadata";
+import { publicDocumentRoutes } from "./public-routes";
 
-export { editionSeoMetadataForPath };
+export { editionSeoMetadataForPath, publicDocumentRoutes };
 
 export function renderPublicRoute(pathname: string) {
   return renderToString(

--- a/apps/control-plane/src/public-routes.ts
+++ b/apps/control-plane/src/public-routes.ts
@@ -1,0 +1,15 @@
+export const blogArticlePath =
+  "/blog/kill-alert-fatigue-automating-on-call-with-ai";
+
+export const publicDocumentRoutes = [
+  { output: "index.html", pathname: "/" },
+  { output: "blog/index.html", pathname: "/blog" },
+  {
+    output: "blog/kill-alert-fatigue-automating-on-call-with-ai/index.html",
+    pathname: blogArticlePath,
+  },
+] as const;
+
+export const publicDocumentPathnames = publicDocumentRoutes.map(
+  ({ pathname }) => pathname,
+);

--- a/apps/control-plane/vite.config.ts
+++ b/apps/control-plane/vite.config.ts
@@ -3,6 +3,7 @@ import { sentryVitePlugin } from "@sentry/vite-plugin";
 import tailwindcss from "@tailwindcss/vite";
 import { fileURLToPath, URL } from "node:url";
 import { defineConfig, type Plugin } from "vite";
+import { publicDocumentPathnames } from "./src/public-routes.js";
 
 const webPort = Number(
   process.env.PORT ?? process.env.CONTROL_PLANE_WEB_PORT ?? 3000,
@@ -19,6 +20,7 @@ const uploadsSentrySourceMaps = Boolean(
 );
 const buildsSentrySourceMaps =
   uploadsSentrySourceMaps || process.env.SENTRY_BUILD_SOURCEMAPS === "true";
+const publicDocumentPaths: ReadonlySet<string> = new Set(publicDocumentPathnames);
 
 const previewDocumentRoutes: Plugin = {
   configurePreviewServer(server) {
@@ -32,11 +34,7 @@ const previewDocumentRoutes: Plugin = {
         return;
       }
       const publicDocumentPath = url.pathname.replace(/\/$/, "");
-      if (
-        publicDocumentPath === "/blog" ||
-        publicDocumentPath ===
-          "/blog/kill-alert-fatigue-automating-on-call-with-ai"
-      ) {
+      if (publicDocumentPath !== "/" && publicDocumentPaths.has(publicDocumentPath)) {
         request.url = `${publicDocumentPath}/index.html${url.search}`;
       } else if (
         url.pathname !== "/" &&

--- a/apps/control-plane/vite.config.ts
+++ b/apps/control-plane/vite.config.ts
@@ -31,8 +31,13 @@ const previewDocumentRoutes: Plugin = {
         response.end();
         return;
       }
-      if (url.pathname === "/blog" || url.pathname === "/blog/") {
-        request.url = `/blog/index.html${url.search}`;
+      const publicDocumentPath = url.pathname.replace(/\/$/, "");
+      if (
+        publicDocumentPath === "/blog" ||
+        publicDocumentPath ===
+          "/blog/kill-alert-fatigue-automating-on-call-with-ai"
+      ) {
+        request.url = `${publicDocumentPath}/index.html${url.search}`;
       } else if (
         url.pathname !== "/" &&
         url.pathname !== "/api" &&

--- a/apps/control-plane/vite.config.ts
+++ b/apps/control-plane/vite.config.ts
@@ -33,7 +33,8 @@ const previewDocumentRoutes: Plugin = {
         response.end();
         return;
       }
-      const publicDocumentPath = url.pathname.replace(/\/$/, "");
+      const publicDocumentPath =
+        url.pathname === "/" ? "/" : url.pathname.replace(/\/$/, "");
       if (publicDocumentPath !== "/" && publicDocumentPaths.has(publicDocumentPath)) {
         request.url = `${publicDocumentPath}/index.html${url.search}`;
       } else if (


### PR DESCRIPTION
## Summary

- add a dedicated static route for the slugged blog article
- keep the blog index and article as separate page components
- pre-render and preview the nested article document

## Validation

- pnpm typecheck
- pnpm lint
- pnpm test (432 tests)
- pnpm build:app
- Playwright direct-route checks for the blog index and article

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a static route for the slugged blog article and centralizes public document routing for prerender and preview. Behavior remains the same: both the blog index and the article redirect to /agents; the article path is now pre-rendered and previewable.

- Pre-renders /blog/kill-alert-fatigue-automating-on-call-with-ai/index.html and exposes routes via `publicDocumentRoutes` and `publicDocumentPathnames`; consumed by `prerender.mjs`, `prerender-entry.tsx`, and Vite.
- Splits `BlogPage` into `BlogIndexPage` and `BlogArticlePage`; the router uses `blogArticlePath`.
- Vite preview serves static documents for public routes and preserves root ("/") routing.
- No migrations required; existing /blog links continue to work.

<sup>Written for commit a93f1c2e4baf1c29bafc73367200cfd150e61aa8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/responder-oss/pull/21?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

