### PR TITLE
Render Slack alert emoji in plan titles

### DIFF
--- a/packages/core/src/integrations/slack-live-card.test.ts
+++ b/packages/core/src/integrations/slack-live-card.test.ts
@@ -112,6 +112,28 @@ describe("Slack live investigation card", () => {
     ]);
   });
 
+  it("renders ClickStack's alert shortcode as an emoji in the plan title", () => {
+    vi.stubEnv("RESPONDER_APP_URL", "https://responder.example");
+
+    const message = slackInvestigationCard({
+      agentId: context.agentId,
+      detail: "Inspecting the alert.",
+      investigationId: context.investigationId,
+      status: "in_progress",
+      title: '*:rotating_light: Alert for "Errors"*',
+    });
+
+    expect(message.blocks).toEqual([
+      expect.objectContaining({
+        type: "plan",
+        title: '🚨 Alert for "Errors"',
+      }),
+    ]);
+    expect(message.text).toBe(
+      '🚨 Alert for "Errors" — Inspecting the alert.',
+    );
+  });
+
   it("updates the task card and refreshes Slack's rotating loading state", async () => {
     vi.mocked(getSlackInvestigationLiveContext).mockResolvedValue(context);
     vi.mocked(decryptCredentials).mockReturnValue({ accessToken: "xoxb-test" });

--- a/packages/core/src/integrations/slack-live-card.ts
+++ b/packages/core/src/integrations/slack-live-card.ts
@@ -707,7 +707,13 @@ export function slackInvestigationCard(input: {
   title: string;
   traceItems?: SlackInvestigationTraceItem[];
 }): { blocks: unknown[]; text: string } {
-  const title = truncate(input.title.trim() || "Investigation", 180);
+  const rawTitle = input.title.trim() || "Investigation";
+  const title = truncate(
+    rawTitle
+      .replace(/^\*([^\n]+)\*$/u, "$1")
+      .replace(/:rotating_light:/giu, "🚨"),
+    180,
+  );
   const source = {
     type: "url",
     text: "View investigation",


### PR DESCRIPTION
## What changed

- normalize Slack plan titles before rendering them as plain text
- convert ClickStack's rotating-light shortcode to the native alarm emoji
- remove surrounding Slack bold markers from plan titles

## Why

Slack plan-block titles do not interpret mrkdwn or emoji shortcodes. ClickStack alert titles such as `*:rotating_light: Alert for "Errors"*` were therefore displayed literally instead of as `🚨 Alert for "Errors"`.

## Validation

- `pnpm test -- packages/core/src/integrations/slack-live-card.test.ts`
- `pnpm exec eslint packages/core/src/integrations/slack-live-card.ts packages/core/src/integrations/slack-live-card.test.ts`
- `pnpm typecheck`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalizes Slack plan titles and renders ClickStack’s alert shortcode as an emoji so titles display correctly in plan blocks. Previously Slack showed `*:rotating_light: Alert for "Errors"*` literally; now we strip surrounding bold markers, convert `:rotating_light:` to 🚨, and keep the 180-character truncation. The message text mirrors the rendered title.

<sup>Written for commit 054c3a2402f6f476809df2d34e9ea1c9f5811040. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/responder-oss/pull/23?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

