### PR TITLE
Preserve worker exception stack traces

### DIFF
--- a/apps/worker/src/monitoring.test.ts
+++ b/apps/worker/src/monitoring.test.ts
@@ -59,7 +59,12 @@ describe("worker error monitoring", () => {
     };
 
     expect(monitoring.initializeErrorMonitoring(environment)).toBe(true);
-    expect(monitoring.initializeErrorMonitoring(environment)).toBe(true);
+    expect(
+      monitoring.initializeErrorMonitoring({
+        ...environment,
+        DAYTONA_API_KEY: "rotated-daytona-secret",
+      }),
+    ).toBe(true);
 
     expect(sentryMocks.init).not.toHaveBeenCalled();
     expect(sentryMocks.addEventProcessor).toHaveBeenCalledOnce();
@@ -67,7 +72,7 @@ describe("worker error monitoring", () => {
       event: Record<string, unknown>,
     ) => Record<string, unknown>;
     expect(
-      processor({ message: "request failed for daytona-secret" }),
+      processor({ message: "request failed for rotated-daytona-secret" }),
     ).toEqual({ message: "request failed for [redacted]" });
   });
 

--- a/apps/worker/src/monitoring.test.ts
+++ b/apps/worker/src/monitoring.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const sentryMocks = vi.hoisted(() => ({
+  addEventProcessor: vi.fn(),
   captureException: vi.fn(),
   flush: vi.fn().mockResolvedValue(true),
   init: vi.fn(),
@@ -13,6 +14,7 @@ const sentryMocks = vi.hoisted(() => ({
 }));
 
 vi.mock("@sentry/node", () => ({
+  addEventProcessor: sentryMocks.addEventProcessor,
   captureException: sentryMocks.captureException,
   flush: sentryMocks.flush,
   init: sentryMocks.init,
@@ -26,6 +28,7 @@ vi.mock("@sentry/node", () => ({
 describe("worker error monitoring", () => {
   beforeEach(() => {
     vi.resetModules();
+    sentryMocks.addEventProcessor.mockClear();
     sentryMocks.captureException.mockClear();
     sentryMocks.flush.mockClear();
     sentryMocks.init.mockClear();
@@ -45,6 +48,27 @@ describe("worker error monitoring", () => {
 
     expect(sentryMocks.init).not.toHaveBeenCalled();
     expect(sentryMocks.captureException).not.toHaveBeenCalled();
+  });
+
+  it("configures secret redaction when Sentry is already initialized", async () => {
+    sentryMocks.isInitialized.mockReturnValue(true);
+    const monitoring = await import("./monitoring.js");
+    const environment = {
+      DAYTONA_API_KEY: "daytona-secret",
+      SENTRY_DSN: "https://public@example.invalid/1",
+    };
+
+    expect(monitoring.initializeErrorMonitoring(environment)).toBe(true);
+    expect(monitoring.initializeErrorMonitoring(environment)).toBe(true);
+
+    expect(sentryMocks.init).not.toHaveBeenCalled();
+    expect(sentryMocks.addEventProcessor).toHaveBeenCalledOnce();
+    const processor = sentryMocks.addEventProcessor.mock.calls[0]?.[0] as (
+      event: Record<string, unknown>,
+    ) => Record<string, unknown>;
+    expect(
+      processor({ message: "request failed for daytona-secret" }),
+    ).toEqual({ message: "request failed for [redacted]" });
   });
 
   it("reports the original exception and redacts its serialized event", async () => {
@@ -80,10 +104,10 @@ describe("worker error monitoring", () => {
         sendDefaultPii: false,
       }),
     );
-    const beforeSend = sentryMocks.init.mock.calls[0]?.[0]?.beforeSend as (
+    const eventProcessor = sentryMocks.addEventProcessor.mock.calls[0]?.[0] as (
       event: Record<string, unknown>,
     ) => Record<string, unknown>;
-    const serializedEvent = beforeSend({
+    const serializedEvent = eventProcessor({
       exception: {
         values: [
           {

--- a/apps/worker/src/monitoring.test.ts
+++ b/apps/worker/src/monitoring.test.ts
@@ -47,7 +47,7 @@ describe("worker error monitoring", () => {
     expect(sentryMocks.captureException).not.toHaveBeenCalled();
   });
 
-  it("reports a redacted exception without flushing the error path", async () => {
+  it("reports the original exception and redacts its serialized event", async () => {
     const monitoring = await import("./monitoring.js");
     const environment = {
       DAYTONA_API_KEY: "daytona-secret",
@@ -56,15 +56,19 @@ describe("worker error monitoring", () => {
       SENTRY_RELEASE: "abc123",
     };
 
+    const originalError = new TypeError("request failed for daytona-secret");
+    originalError.stack =
+      "TypeError: request failed for daytona-secret\n" +
+      "    at runInvestigation (/app/apps/worker/src/investigate.ts:10:2)";
+
     expect(monitoring.initializeErrorMonitoring(environment)).toBe(true);
     await monitoring.reportWorkerException(
-      new Error("request failed for daytona-secret"),
+      originalError,
       {
         investigationId: "investigation-1",
         operation: "investigation",
         organizationId: "organization-1",
       },
-      environment,
     );
 
     expect(sentryMocks.init).toHaveBeenCalledWith(
@@ -76,15 +80,54 @@ describe("worker error monitoring", () => {
         sendDefaultPii: false,
       }),
     );
+    const beforeSend = sentryMocks.init.mock.calls[0]?.[0]?.beforeSend as (
+      event: Record<string, unknown>,
+    ) => Record<string, unknown>;
+    const serializedEvent = beforeSend({
+      exception: {
+        values: [
+          {
+            stacktrace: {
+              frames: [
+                {
+                  context_line: "request failed for daytona-secret",
+                  filename: "/app/apps/worker/src/investigate.ts",
+                },
+              ],
+            },
+            type: "TypeError",
+            value: "request failed for daytona-secret",
+          },
+        ],
+      },
+      extra: { diagnostic: "request failed for daytona-secret" },
+    });
+
+    expect(serializedEvent).toEqual(
+      expect.objectContaining({
+        exception: {
+          values: [
+            expect.objectContaining({
+              stacktrace: {
+                frames: [
+                  expect.objectContaining({
+                    context_line: "request failed for [redacted]",
+                  }),
+                ],
+              },
+              type: "TypeError",
+              value: "request failed for [redacted]",
+            }),
+          ],
+        },
+        extra: { diagnostic: "request failed for [redacted]" },
+      }),
+    );
     expect(sentryMocks.scope.setContext).toHaveBeenCalledWith(
       "responder",
       expect.objectContaining({ investigationId: "investigation-1" }),
     );
-    expect(sentryMocks.captureException).toHaveBeenCalledWith(
-      expect.objectContaining({
-        message: "request failed for [redacted]",
-      }),
-    );
+    expect(sentryMocks.captureException).toHaveBeenCalledWith(originalError);
     expect(sentryMocks.flush).not.toHaveBeenCalled();
 
     await expect(monitoring.flushWorkerMonitoring()).resolves.toBe(true);

--- a/apps/worker/src/monitoring.ts
+++ b/apps/worker/src/monitoring.ts
@@ -1,5 +1,5 @@
 import * as Sentry from "@sentry/node";
-import type { ErrorEvent } from "@sentry/node";
+import type { Event } from "@sentry/node";
 import {
   sentryEnvironment,
   sentryRelease,
@@ -16,6 +16,7 @@ export interface WorkerErrorContext {
 }
 
 let errorMonitoringEnabled = false;
+let eventScrubbingConfigured = false;
 
 const secretEnvironmentNames = [
   "OPENAI_API_KEY",
@@ -54,9 +55,9 @@ function redactEventValue(
 }
 
 function scrubWorkerSentryEvent(
-  event: ErrorEvent,
+  event: Event,
   environment: NodeJS.ProcessEnv,
-): ErrorEvent {
+): Event {
   const secrets = secretEnvironmentNames.flatMap((name) => {
     const value = environment[name];
     return value ? [value] : [];
@@ -76,6 +77,12 @@ export function initializeErrorMonitoring(
 ): boolean {
   const dsn = environment.SENTRY_DSN?.trim();
   if (!dsn) return false;
+  if (!eventScrubbingConfigured) {
+    Sentry.addEventProcessor((event) =>
+      scrubWorkerSentryEvent(event, environment),
+    );
+    eventScrubbingConfigured = true;
+  }
   if (Sentry.isInitialized()) {
     errorMonitoringEnabled = true;
     return true;
@@ -83,7 +90,6 @@ export function initializeErrorMonitoring(
 
   try {
     Sentry.init({
-      beforeSend: (event) => scrubWorkerSentryEvent(event, environment),
       defaultIntegrations: false,
       dsn,
       environment: sentryEnvironment(environment),

--- a/apps/worker/src/monitoring.ts
+++ b/apps/worker/src/monitoring.ts
@@ -17,6 +17,7 @@ export interface WorkerErrorContext {
 
 let errorMonitoringEnabled = false;
 let eventScrubbingConfigured = false;
+let eventScrubbingEnvironment: NodeJS.ProcessEnv = process.env;
 
 const secretEnvironmentNames = [
   "OPENAI_API_KEY",
@@ -72,18 +73,23 @@ function scrubWorkerSentryEvent(
   return event;
 }
 
+function configureEventScrubbing(environment: NodeJS.ProcessEnv): void {
+  eventScrubbingEnvironment = environment;
+  if (eventScrubbingConfigured) return;
+
+  Sentry.addEventProcessor((event) =>
+    scrubWorkerSentryEvent(event, eventScrubbingEnvironment),
+  );
+  eventScrubbingConfigured = true;
+}
+
 export function initializeErrorMonitoring(
   environment: NodeJS.ProcessEnv = process.env,
 ): boolean {
   const dsn = environment.SENTRY_DSN?.trim();
   if (!dsn) return false;
-  if (!eventScrubbingConfigured) {
-    Sentry.addEventProcessor((event) =>
-      scrubWorkerSentryEvent(event, environment),
-    );
-    eventScrubbingConfigured = true;
-  }
   if (Sentry.isInitialized()) {
+    configureEventScrubbing(environment);
     errorMonitoringEnabled = true;
     return true;
   }
@@ -97,6 +103,7 @@ export function initializeErrorMonitoring(
       sendDefaultPii: false,
       tracesSampleRate: 0,
     });
+    configureEventScrubbing(environment);
     errorMonitoringEnabled = true;
     return true;
   } catch (error) {

--- a/apps/worker/src/monitoring.ts
+++ b/apps/worker/src/monitoring.ts
@@ -1,4 +1,5 @@
 import * as Sentry from "@sentry/node";
+import type { ErrorEvent } from "@sentry/node";
 import {
   sentryEnvironment,
   sentryRelease,
@@ -16,6 +17,60 @@ export interface WorkerErrorContext {
 
 let errorMonitoringEnabled = false;
 
+const secretEnvironmentNames = [
+  "OPENAI_API_KEY",
+  "DAYTONA_API_KEY",
+  "DATABASE_PASSWORD",
+  "CREDENTIAL_ENCRYPTION_KEY",
+  "INTERNAL_INGEST_TOKEN",
+] as const;
+
+function redactEventValue(
+  value: unknown,
+  secrets: readonly string[],
+  seen: WeakSet<object>,
+): unknown {
+  if (typeof value === "string") {
+    return secrets.reduce(
+      (redacted, secret) => redacted.replaceAll(secret, "[redacted]"),
+      value,
+    );
+  }
+  if (!value || typeof value !== "object" || seen.has(value)) return value;
+
+  seen.add(value);
+  if (Array.isArray(value)) {
+    for (const [index, item] of value.entries()) {
+      value[index] = redactEventValue(item, secrets, seen);
+    }
+    return value;
+  }
+
+  const record = value as Record<string, unknown>;
+  for (const [key, item] of Object.entries(record)) {
+    record[key] = redactEventValue(item, secrets, seen);
+  }
+  return record;
+}
+
+function scrubWorkerSentryEvent(
+  event: ErrorEvent,
+  environment: NodeJS.ProcessEnv,
+): ErrorEvent {
+  const secrets = secretEnvironmentNames.flatMap((name) => {
+    const value = environment[name];
+    return value ? [value] : [];
+  });
+  redactEventValue(event, secrets, new WeakSet());
+
+  for (const exception of event.exception?.values ?? []) {
+    if (exception.value && exception.value.length > 2_000) {
+      exception.value = exception.value.slice(0, 2_000);
+    }
+  }
+  return event;
+}
+
 export function initializeErrorMonitoring(
   environment: NodeJS.ProcessEnv = process.env,
 ): boolean {
@@ -28,6 +83,7 @@ export function initializeErrorMonitoring(
 
   try {
     Sentry.init({
+      beforeSend: (event) => scrubWorkerSentryEvent(event, environment),
       defaultIntegrations: false,
       dsn,
       environment: sentryEnvironment(environment),
@@ -48,28 +104,9 @@ export function initializeErrorMonitoring(
   }
 }
 
-function sanitizedError(
-  error: unknown,
-  environment: NodeJS.ProcessEnv,
-): Error {
-  let message = error instanceof Error ? error.message : String(error);
-  for (const name of [
-    "OPENAI_API_KEY",
-    "DAYTONA_API_KEY",
-    "DATABASE_PASSWORD",
-    "CREDENTIAL_ENCRYPTION_KEY",
-    "INTERNAL_INGEST_TOKEN",
-  ] as const) {
-    const value = environment[name];
-    if (value) message = message.replaceAll(value, "[redacted]");
-  }
-  return new Error(message.slice(0, 2_000));
-}
-
 export async function reportWorkerException(
   error: unknown,
   context: WorkerErrorContext,
-  environment: NodeJS.ProcessEnv = process.env,
 ): Promise<void> {
   if (!errorMonitoringEnabled) return;
 
@@ -77,7 +114,7 @@ export async function reportWorkerException(
     Sentry.withScope((scope) => {
       scope.setTag("responder.operation", context.operation);
       scope.setContext("responder", { ...context });
-      Sentry.captureException(sanitizedError(error, environment));
+      Sentry.captureException(error);
     });
   } catch (reportingError) {
     console.error(


### PR DESCRIPTION
## Summary

- send original worker exceptions to Sentry so default stack-based grouping works
- redact configured secret values from the serialized event in `beforeSend`
- retain the existing 2,000-character exception-message limit and investigation context

## Root cause

The worker created a new `Error` inside the monitoring helper after redacting the message. That discarded the original exception type and stack, causing unrelated failures to share the monitoring helper's stack and be grouped together.

## Validation

- `pnpm exec vitest run apps/worker/src/monitoring.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test` (434 tests)
- `pnpm build`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the original worker exception type and stack by capturing the thrown error and moves secret redaction to a global `@sentry/node` event processor. Redaction scrubs secrets from the serialized event (exception value, stack frame context, extra), enforces the 2,000‑character message limit, and stays active even if Sentry was pre‑initialized.

- Registers one processor via `Sentry.addEventProcessor`; later `initializeErrorMonitoring` calls refresh the scrubbing environment so rotated secrets are redacted without duplicating processors.
- Sends Sentry the original exception for correct stack‑based grouping; no wrapper error is created.

**Migration**
- Stop passing `environment` to `reportWorkerException`. Pass the env once to `initializeErrorMonitoring(environment)`; call it again after secret rotation to refresh redaction.

<sup>Written for commit f45d3059dc0cb5738d3b375f90ec2e3c97059790. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/responder-oss/pull/27?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

