### PR TITLE
Fix Slack investigation card delivery

### DIFF
--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -252,6 +252,7 @@ await boss.work(investigationQueue, { localConcurrency: 1 }, async ([job]) => {
 
   let finalizingSlackCard = false;
   let lastSlackProgressAt = 0;
+  let slackProgressFailureReported = false;
   let slackTraceItems: SlackInvestigationTraceItem[] = [];
 
   try {
@@ -271,7 +272,16 @@ await boss.work(investigationQueue, { localConcurrency: 1 }, async ([job]) => {
           payload.investigationId,
           progress.detail,
           slackTraceItems,
-        ).catch(() => undefined);
+        ).catch(async (error: unknown) => {
+          if (slackProgressFailureReported) return;
+          slackProgressFailureReported = true;
+          await reportWorkerException(error, {
+            investigationId: payload.investigationId,
+            jobId: job.id,
+            operation: "slack_delivery",
+            organizationId: payload.config.organizationId,
+          });
+        });
         if (progress.finalizing) finalizingSlackCard = true;
       },
       { jobId: job.id },
@@ -344,6 +354,18 @@ await boss.work(investigationQueue, { localConcurrency: 1 }, async ([job]) => {
           investigationId: payload.investigationId,
         }),
       );
+      await reportWorkerException(
+        new AggregateError(
+          deliveryWarnings.map((warning) => new Error(warning)),
+          "Slack investigation delivery incomplete",
+        ),
+        {
+          investigationId: payload.investigationId,
+          jobId: job.id,
+          operation: "slack_delivery",
+          organizationId: payload.config.organizationId,
+        },
+      );
     }
     console.log(
       JSON.stringify({
@@ -382,6 +404,18 @@ await boss.work(investigationQueue, { localConcurrency: 1 }, async ([job]) => {
           event: "investigation_slack_delivery_incomplete",
           investigationId: payload.investigationId,
         }),
+      );
+      await reportWorkerException(
+        new AggregateError(
+          deliveryWarnings.map((warning) => new Error(warning)),
+          "Slack investigation delivery incomplete",
+        ),
+        {
+          investigationId: payload.investigationId,
+          jobId: job.id,
+          operation: "slack_delivery",
+          organizationId: payload.config.organizationId,
+        },
       );
     }
     if (!payload.replay && investigationFailed) {

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -159,6 +159,34 @@ function drainLinearTicketRequests(): Promise<void> {
   return linearTicketDrain;
 }
 
+async function reportIncompleteSlackDelivery(input: {
+  deliveryWarnings: string[];
+  investigationId: string;
+  jobId: string;
+  organizationId: string;
+}): Promise<void> {
+  if (input.deliveryWarnings.length === 0) return;
+  console.error(
+    JSON.stringify({
+      deliveryWarnings: input.deliveryWarnings,
+      event: "investigation_slack_delivery_incomplete",
+      investigationId: input.investigationId,
+    }),
+  );
+  await reportWorkerException(
+    new AggregateError(
+      input.deliveryWarnings.map((warning) => new Error(warning)),
+      "Slack investigation delivery incomplete",
+    ),
+    {
+      investigationId: input.investigationId,
+      jobId: input.jobId,
+      operation: "slack_delivery",
+      organizationId: input.organizationId,
+    },
+  );
+}
+
 boss.on("error", (error) => {
   console.error(
     JSON.stringify({
@@ -346,27 +374,12 @@ await boss.work(investigationQueue, { localConcurrency: 1 }, async ([job]) => {
       replay: payload.replay,
       report,
     });
-    if (deliveryWarnings.length > 0) {
-      console.error(
-        JSON.stringify({
-          deliveryWarnings,
-          event: "investigation_slack_delivery_incomplete",
-          investigationId: payload.investigationId,
-        }),
-      );
-      await reportWorkerException(
-        new AggregateError(
-          deliveryWarnings.map((warning) => new Error(warning)),
-          "Slack investigation delivery incomplete",
-        ),
-        {
-          investigationId: payload.investigationId,
-          jobId: job.id,
-          operation: "slack_delivery",
-          organizationId: payload.config.organizationId,
-        },
-      );
-    }
+    await reportIncompleteSlackDelivery({
+      deliveryWarnings,
+      investigationId: payload.investigationId,
+      jobId: job.id,
+      organizationId: payload.config.organizationId,
+    });
     console.log(
       JSON.stringify({
         event: "investigation_job_complete",
@@ -397,27 +410,12 @@ await boss.work(investigationQueue, { localConcurrency: 1 }, async ([job]) => {
       investigationId: payload.investigationId,
       replay: payload.replay,
     });
-    if (deliveryWarnings.length > 0) {
-      console.error(
-        JSON.stringify({
-          deliveryWarnings,
-          event: "investigation_slack_delivery_incomplete",
-          investigationId: payload.investigationId,
-        }),
-      );
-      await reportWorkerException(
-        new AggregateError(
-          deliveryWarnings.map((warning) => new Error(warning)),
-          "Slack investigation delivery incomplete",
-        ),
-        {
-          investigationId: payload.investigationId,
-          jobId: job.id,
-          operation: "slack_delivery",
-          organizationId: payload.config.organizationId,
-        },
-      );
-    }
+    await reportIncompleteSlackDelivery({
+      deliveryWarnings,
+      investigationId: payload.investigationId,
+      jobId: job.id,
+      organizationId: payload.config.organizationId,
+    });
     if (!payload.replay && investigationFailed) {
       await failInvestigationSlackCard(
         payload.investigationId,

--- a/apps/worker/src/monitoring.test.ts
+++ b/apps/worker/src/monitoring.test.ts
@@ -162,4 +162,47 @@ describe("worker error monitoring", () => {
     await expect(monitoring.flushWorkerMonitoring()).resolves.toBe(true);
     expect(sentryMocks.flush).toHaveBeenCalledWith(2_000);
   });
+
+  it("attaches safe Slack diagnostics to delivery failures", async () => {
+    const monitoring = await import("./monitoring.js");
+    const { SlackApiError } = await import(
+      "@responder/core/integrations/slack"
+    );
+    monitoring.initializeErrorMonitoring({
+      SENTRY_DSN: "https://public@example.invalid/1",
+    });
+    const error = new AggregateError(
+      [
+        new SlackApiError("chat.update", "invalid_blocks", [
+          "must be more than 0 characters: /0/tasks/1/output",
+        ]),
+      ],
+      "Slack investigation delivery incomplete",
+    );
+
+    await monitoring.reportWorkerException(error, {
+      investigationId: "investigation-1",
+      operation: "slack_delivery",
+      organizationId: "organization-1",
+    });
+
+    expect(sentryMocks.scope.setTag).toHaveBeenCalledWith(
+      "responder.operation",
+      "slack_delivery",
+    );
+    expect(sentryMocks.scope.setContext).toHaveBeenCalledWith("slack", {
+      causes: ["Slack chat.update failed (invalid_blocks)"],
+      error: "Slack investigation delivery incomplete",
+      slackErrors: [
+        {
+          code: "invalid_blocks",
+          diagnostics: [
+            "must be more than 0 characters: /0/tasks/1/output",
+          ],
+          method: "chat.update",
+        },
+      ],
+    });
+    expect(sentryMocks.captureException).toHaveBeenCalledWith(error);
+  });
 });

--- a/apps/worker/src/monitoring.ts
+++ b/apps/worker/src/monitoring.ts
@@ -4,6 +4,7 @@ import {
   sentryEnvironment,
   sentryRelease,
 } from "@responder/core/observability/sentry";
+import { slackErrorLogFields } from "@responder/core/integrations/slack-live-card";
 
 export interface WorkerErrorContext {
   operation:
@@ -11,6 +12,7 @@ export interface WorkerErrorContext {
     | "linear_ticket"
     | "remediation"
     | "sandbox_cleanup"
+    | "slack_delivery"
     | "worker";
   investigationId?: string;
   jobId?: string;
@@ -132,6 +134,9 @@ export async function reportWorkerException(
     Sentry.withScope((scope) => {
       scope.setTag("responder.operation", context.operation);
       scope.setContext("responder", { ...context });
+      if (context.operation === "slack_delivery") {
+        scope.setContext("slack", slackErrorLogFields(error));
+      }
       Sentry.captureException(error);
     });
   } catch (reportingError) {

--- a/packages/core/src/integrations/slack-live-card.test.ts
+++ b/packages/core/src/integrations/slack-live-card.test.ts
@@ -2,7 +2,11 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { decryptCredentials } from "../credentials/encryption.js";
 import { recordInvestigationSlackTrace } from "../db/investigations.js";
 import { getSlackInvestigationLiveContext } from "../db/issues.js";
-import { setSlackThreadStatus, updateSlackMessage } from "./slack.js";
+import {
+  SlackApiError,
+  setSlackThreadStatus,
+  updateSlackMessage,
+} from "./slack.js";
 import {
   failInvestigationSlackCard,
   slackCardFailureMetricEvent,
@@ -20,7 +24,8 @@ vi.mock("../db/investigations.js", () => ({
 vi.mock("../db/issues.js", () => ({
   getSlackInvestigationLiveContext: vi.fn(),
 }));
-vi.mock("./slack.js", () => ({
+vi.mock("./slack.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./slack.js")>()),
   setSlackThreadStatus: vi.fn(),
   updateSlackMessage: vi.fn(),
 }));
@@ -55,6 +60,33 @@ describe("Slack live investigation card", () => {
     ).toEqual({
       error: "Slack progress failed",
       causes: ["message update failed", "status update failed"],
+    });
+  });
+
+  it("retains safe Slack validation diagnostics in structured log fields", () => {
+    expect(
+      slackErrorLogFields(
+        new AggregateError(
+          [
+            new SlackApiError("chat.update", "invalid_blocks", [
+              "must be more than 0 characters: /0/tasks/1/output",
+            ]),
+          ],
+          "Slack progress failed",
+        ),
+      ),
+    ).toEqual({
+      error: "Slack progress failed",
+      causes: ["Slack chat.update failed (invalid_blocks)"],
+      slackErrors: [
+        {
+          code: "invalid_blocks",
+          diagnostics: [
+            "must be more than 0 characters: /0/tasks/1/output",
+          ],
+          method: "chat.update",
+        },
+      ],
     });
   });
 
@@ -861,6 +893,41 @@ describe("Slack live investigation card", () => {
     expect(message.text).toBe(
       `${context.title} — Investigation complete`,
     );
+  });
+
+  it("renders empty structured tool output as valid non-empty rich text", () => {
+    const message = slackInvestigationCard({
+      agentId: context.agentId,
+      detail: "Reviewing search results.",
+      investigationId: context.investigationId,
+      status: "in_progress",
+      title: context.title,
+      traceItems: [
+        {
+          detail: JSON.stringify({ pattern: "missing" }),
+          id: "call-empty-grep",
+          output: JSON.stringify({ content: "" }),
+          status: "complete",
+          title: "grep",
+        },
+      ],
+    });
+
+    expect(message.blocks).toEqual([
+      expect.objectContaining({
+        tasks: expect.arrayContaining([
+          expect.objectContaining({
+            output: expect.objectContaining({
+              elements: [
+                expect.objectContaining({
+                  elements: [{ text: "No output.", type: "text" }],
+                }),
+              ],
+            }),
+          }),
+        ]),
+      }),
+    ]);
   });
 
   it("moves the card to an error state and clears the spinner", async () => {

--- a/packages/core/src/integrations/slack-live-card.ts
+++ b/packages/core/src/integrations/slack-live-card.ts
@@ -3,7 +3,11 @@ import { z } from "zod";
 import { decryptCredentials } from "../credentials/encryption.js";
 import { recordInvestigationSlackTrace } from "../db/investigations.js";
 import { getSlackInvestigationLiveContext } from "../db/issues.js";
-import { setSlackThreadStatus, updateSlackMessage } from "./slack.js";
+import {
+  SlackApiError,
+  setSlackThreadStatus,
+  updateSlackMessage,
+} from "./slack.js";
 import type { SlackInvestigationTraceItem } from "./slack-live-progress.js";
 
 const slackCredentialsSchema = z.object({
@@ -20,6 +24,15 @@ function truncate(value: string, maximum: number): string {
   return value.length > maximum
     ? `${value.slice(0, maximum - 1).trimEnd()}…`
     : value;
+}
+
+function nonEmptyText(
+  value: string,
+  maximum: number,
+  fallback: string,
+): string {
+  const rendered = truncate(value, maximum);
+  return rendered.trim().length > 0 ? rendered : fallback;
 }
 
 function investigationUrl(agentId: string, investigationId: string): string {
@@ -46,7 +59,12 @@ function richText(value: string, preformatted = false) {
     elements: [
       {
         type: preformatted ? "rich_text_preformatted" : "rich_text_section",
-        elements: [{ type: "text", text: truncate(value, 1_500) }],
+        elements: [
+          {
+            type: "text",
+            text: nonEmptyText(value, 1_500, "No content."),
+          },
+        ],
       },
     ],
   };
@@ -194,7 +212,7 @@ function objectDetails(
       },
       {
         type: "text" as const,
-        text: truncate(displayValue(value), 500),
+        text: nonEmptyText(displayValue(value), 500, "—"),
       },
     ];
   });
@@ -283,7 +301,12 @@ function preformatted(value: string, language?: string) {
       {
         type: "rich_text_preformatted",
         ...(language ? { language } : {}),
-        elements: [{ type: "text", text: truncate(value, 1_500) }],
+        elements: [
+          {
+            type: "text",
+            text: nonEmptyText(value, 1_500, "No output."),
+          },
+        ],
       },
     ],
   };
@@ -304,7 +327,7 @@ function issueLinkList(
             {
               type: "link",
               url: issueUrl(issue.id),
-              text: issue.title,
+              text: nonEmptyText(issue.title, 2_000, "Untitled issue"),
             },
           ],
         })),
@@ -454,11 +477,20 @@ function formattedTraceTask(
     }
     const details = [
       { type: "text" as const, text: "Query: ", style: { bold: true } },
-      { type: "text" as const, text: String(query ?? "") },
+      {
+        type: "text" as const,
+        text: nonEmptyText(String(query ?? ""), 1_500, "—"),
+      },
       { type: "text" as const, text: "\nFrom: ", style: { bold: true } },
-      { type: "text" as const, text: String(from ?? "") },
+      {
+        type: "text" as const,
+        text: nonEmptyText(String(from ?? ""), 1_500, "—"),
+      },
       { type: "text" as const, text: "\nTo: ", style: { bold: true } },
-      { type: "text" as const, text: String(to ?? "") },
+      {
+        type: "text" as const,
+        text: nonEmptyText(String(to ?? ""), 1_500, "—"),
+      },
       ...(Array.isArray(extraFields)
         ? [
             {
@@ -466,7 +498,10 @@ function formattedTraceTask(
               text: "\nExtra fields: ",
               style: { bold: true },
             },
-            { type: "text" as const, text: extraFields.join(", ") },
+            {
+              type: "text" as const,
+              text: nonEmptyText(extraFields.join(", "), 1_500, "—"),
+            },
           ]
         : []),
     ];
@@ -727,7 +762,7 @@ export function slackInvestigationCard(input: {
         ? "Investigation complete"
         : input.status === "error"
           ? "Investigation stopped"
-          : truncate(input.detail, 180),
+          : nonEmptyText(input.detail, 180, "Investigation in progress"),
     status: input.status,
     ...(input.status === "error" ? { output: richText(input.detail) } : {}),
     sources: [source],
@@ -824,7 +859,22 @@ async function slackInvestigationLiveContext(investigationId: string) {
 export function slackErrorLogFields(error: unknown): {
   causes?: string[];
   error: string;
+  slackErrors?: Array<{
+    code: string;
+    diagnostics: string[];
+    method: string;
+  }>;
 } {
+  const slackErrors: SlackApiError[] = [];
+  const collectSlackErrors = (value: unknown): void => {
+    if (value instanceof SlackApiError) slackErrors.push(value);
+    if (value instanceof AggregateError) {
+      for (const cause of value.errors) collectSlackErrors(cause);
+    } else if (value instanceof Error && value.cause) {
+      collectSlackErrors(value.cause);
+    }
+  };
+  collectSlackErrors(error);
   return {
     error: error instanceof Error ? error.message : String(error),
     ...(error instanceof AggregateError
@@ -832,6 +882,15 @@ export function slackErrorLogFields(error: unknown): {
           causes: error.errors.map((cause: unknown) =>
             cause instanceof Error ? cause.message : String(cause),
           ),
+      }
+      : {}),
+    ...(slackErrors.length > 0
+      ? {
+          slackErrors: slackErrors.map(({ code, diagnostics, method }) => ({
+            code,
+            diagnostics,
+            method,
+          })),
         }
       : {}),
   };

--- a/packages/core/src/integrations/slack.test.ts
+++ b/packages/core/src/integrations/slack.test.ts
@@ -88,6 +88,39 @@ describe("Slack delivery client", () => {
     );
   });
 
+  it("retains bounded Slack validation diagnostics on API errors", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        Response.json({
+          error: "invalid_blocks",
+          ok: false,
+          response_metadata: {
+            messages: [
+              "[ERROR] must be more than 0 characters [json-pointer:/blocks/0/tasks/1/output]",
+            ],
+          },
+        }),
+      ),
+    );
+
+    const failure = updateSlackMessage({
+      accessToken: "xoxb-test",
+      blocks: [{ type: "plan" }],
+      channelId: "C123",
+      text: "Investigating",
+      timestamp: "1785500001.000200",
+    });
+
+    await expect(failure).rejects.toMatchObject({
+      code: "invalid_blocks",
+      diagnostics: [
+        "[ERROR] must be more than 0 characters [json-pointer:/blocks/0/tasks/1/output]",
+      ],
+      method: "chat.update",
+    });
+  });
+
   it("sets Slack's native rotating investigation status", async () => {
     const fetchMock = vi.fn().mockResolvedValue(Response.json({ ok: true }));
     vi.stubGlobal("fetch", fetchMock);

--- a/packages/core/src/integrations/slack.ts
+++ b/packages/core/src/integrations/slack.ts
@@ -4,14 +4,44 @@ const slackResponseSchema = z
   .object({
     ok: z.boolean(),
     error: z.string().optional(),
+    errors: z
+      .array(
+        z
+          .object({
+            code: z.string().optional(),
+            message: z.string().optional(),
+            pointer: z.string().optional(),
+          })
+          .passthrough(),
+      )
+      .optional(),
+    response_metadata: z
+      .object({ messages: z.array(z.string()).optional() })
+      .passthrough()
+      .optional(),
     ts: z.string().optional(),
   })
   .passthrough();
+
+function slackErrorDiagnostics(
+  response: z.infer<typeof slackResponseSchema>,
+): string[] {
+  return [
+    ...(response.errors ?? []).map((error) =>
+      [error.code, error.pointer, error.message].filter(Boolean).join(": "),
+    ),
+    ...(response.response_metadata?.messages ?? []),
+  ]
+    .filter((message) => message.trim().length > 0)
+    .slice(0, 8)
+    .map((message) => message.replaceAll(/\s+/g, " ").slice(0, 500));
+}
 
 export class SlackApiError extends Error {
   constructor(
     public readonly method: string,
     public readonly code: string,
+    public readonly diagnostics: string[] = [],
   ) {
     super(`Slack ${method} failed (${code})`);
     this.name = "SlackApiError";
@@ -38,7 +68,11 @@ async function callSlackApi(
     const code = parsed.success
       ? parsed.data.error ?? `http_${response.status}`
       : `http_${response.status}`;
-    throw new SlackApiError(method, code);
+    throw new SlackApiError(
+      method,
+      code,
+      parsed.success ? slackErrorDiagnostics(parsed.data) : [],
+    );
   }
   return parsed.data;
 }


### PR DESCRIPTION
## What changed

- prevent empty tool results and other blank values from producing invalid Slack rich-text nodes
- retain bounded Slack validation diagnostics in structured logs
- report the first progress-card failure and incomplete final delivery to Sentry with Slack-specific context

## Why

Production `chat.update` calls failed with `invalid_blocks` when a tool returned an empty structured result. The renderer emitted a rich-text `text` leaf with zero characters, which Slack rejects. These failures were caught and logged, so they never reached Sentry.

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test` (494 tests)
- focused Slack and monitoring tests (28 tests)
- Slack `blocks.validate` accepts the repaired empty-output payload

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents zero-length Slack rich-text nodes and reports Slack delivery failures with bounded diagnostics. Previously, empty tool output yielded invalid_blocks on chat.update and failures were only logged.

- Rendering: replaces empty strings across rich text, preformatted blocks, object details, issue titles, card status, and trace task fields (Query/From/To/Extra) with short defaults while keeping truncation consistent; `blocks.validate` now accepts these payloads.
- Slack client (`@responder/core/integrations/slack`): `SlackApiError` includes sanitized, capped diagnostics from `errors` and `response_metadata.messages`.
- Monitoring (`apps/worker`): reports the first progress-card failure and any incomplete final delivery to Sentry with `operation="slack_delivery"` and Slack context via `slackErrorLogFields` from `@responder/core/integrations/slack-live-card`; deduplicates progress failure reporting and centralizes incomplete-delivery reporting.
- Logging and tests: structured logs include safe Slack validation diagnostics; new tests cover diagnostics extraction and empty-output rendering.

<sup>Written for commit b777ede46701127c354aa788e62bc6ff1cb9cd03. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/responder-oss/pull/30?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

