### PR TITLE
Make remediation failures diagnosable

### DIFF
--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -42,7 +42,10 @@ import {
   runInvestigationAgent,
   safeInvestigationError,
 } from "./investigate.js";
-import { runRemediationAgent } from "./remediate.js";
+import {
+  remediationRunDiagnostics,
+  runRemediationAgent,
+} from "./remediate.js";
 import { runLinearTicketJob } from "./linear-ticket-job.js";
 import {
   InvestigationReplayRequestProcessingError,
@@ -254,7 +257,9 @@ await boss.work(investigationQueue, { localConcurrency: 1 }, async ([job]) => {
       );
     } catch (error) {
       const message = safeInvestigationError(error);
+      const diagnostics = remediationRunDiagnostics(error, process.env);
       await reportWorkerException(error, {
+        ...(diagnostics ? { diagnostics: { ...diagnostics } } : {}),
         investigationId: payload.investigationId,
         jobId: job.id,
         operation: "remediation",
@@ -264,6 +269,7 @@ await boss.work(investigationQueue, { localConcurrency: 1 }, async ([job]) => {
       await failIssuePullRequest(payload.remediationRequestId, message);
       console.error(
         JSON.stringify({
+          ...(diagnostics ? { diagnostics } : {}),
           error: message,
           event: "remediation_job_failed",
           jobId: job.id,

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -257,7 +257,12 @@ await boss.work(investigationQueue, { localConcurrency: 1 }, async ([job]) => {
       );
     } catch (error) {
       const message = safeInvestigationError(error);
-      const diagnostics = remediationRunDiagnostics(error, process.env);
+      let diagnostics: ReturnType<typeof remediationRunDiagnostics>;
+      try {
+        diagnostics = remediationRunDiagnostics(error, process.env);
+      } catch {
+        diagnostics = undefined;
+      }
       await reportWorkerException(error, {
         ...(diagnostics ? { diagnostics: { ...diagnostics } } : {}),
         investigationId: payload.investigationId,

--- a/apps/worker/src/monitoring.test.ts
+++ b/apps/worker/src/monitoring.test.ts
@@ -205,4 +205,44 @@ describe("worker error monitoring", () => {
     });
     expect(sentryMocks.captureException).toHaveBeenCalledWith(error);
   });
+
+  it("stores structured remediation diagnostics separately from identifiers", async () => {
+    const monitoring = await import("./monitoring.js");
+    monitoring.initializeErrorMonitoring({
+      SENTRY_DSN: "https://public@example.invalid/1",
+    });
+    const error = new Error("Max turns (40) exceeded");
+
+    await monitoring.reportWorkerException(error, {
+      diagnostics: {
+        applyPatchFailures: [
+          {
+            error: "Invalid Context",
+            operation: "update_file",
+            path: "/workspace/repositories/example/app/src/app.ts",
+          },
+        ],
+        completedTurns: 40,
+        maxTurns: 40,
+      },
+      operation: "remediation",
+      requestId: "request-1",
+    });
+
+    expect(sentryMocks.scope.setContext).toHaveBeenCalledWith("responder", {
+      operation: "remediation",
+      requestId: "request-1",
+    });
+    expect(sentryMocks.scope.setContext).toHaveBeenCalledWith("diagnostics", {
+      applyPatchFailures: [
+        {
+          error: "Invalid Context",
+          operation: "update_file",
+          path: "/workspace/repositories/example/app/src/app.ts",
+        },
+      ],
+      completedTurns: 40,
+      maxTurns: 40,
+    });
+  });
 });

--- a/apps/worker/src/monitoring.ts
+++ b/apps/worker/src/monitoring.ts
@@ -20,6 +20,7 @@ export interface WorkerErrorContext {
   requestId?: string;
   sandboxId?: string;
   sourceInvestigationId?: string;
+  diagnostics?: Record<string, unknown>;
 }
 
 let errorMonitoringEnabled = false;
@@ -132,8 +133,12 @@ export async function reportWorkerException(
 
   try {
     Sentry.withScope((scope) => {
+      const { diagnostics, ...responderContext } = context;
       scope.setTag("responder.operation", context.operation);
-      scope.setContext("responder", { ...context });
+      scope.setContext("responder", responderContext);
+      if (diagnostics) {
+        scope.setContext("diagnostics", diagnostics);
+      }
       if (context.operation === "slack_delivery") {
         scope.setContext("slack", slackErrorLogFields(error));
       }

--- a/apps/worker/src/remediate.test.ts
+++ b/apps/worker/src/remediate.test.ts
@@ -6,7 +6,9 @@ import {
   remediationRunDiagnostics,
 } from "./remediate.js";
 
-function maxTurnsError() {
+function maxTurnsError(
+  patchOutput = "Invalid Context 0:\nworkspace-secret-value",
+) {
   return new MaxTurnsExceededError(
     "Max turns (40) exceeded",
     {
@@ -28,10 +30,10 @@ function maxTurnsError() {
           },
           {
             agent: { name: "Responder issue fixer" },
-            output: "Invalid Context containing daytona-secret",
+            output: patchOutput,
             rawItem: {
               callId: "patch-1",
-              output: "Invalid Context containing daytona-secret",
+              output: patchOutput,
               status: "failed",
               type: "apply_patch_call_output",
             },
@@ -40,6 +42,17 @@ function maxTurnsError() {
         ],
         maxTurns: 40,
       }),
+    } as never,
+  );
+}
+
+function unreadableMaxTurnsError() {
+  return new MaxTurnsExceededError(
+    "Max turns (40) exceeded",
+    {
+      toJSON: () => {
+        throw new Error("state serialization failed");
+      },
     } as never,
   );
 }
@@ -58,7 +71,7 @@ describe("remediation agent", () => {
     );
   });
 
-  it("retains failed apply_patch details with secrets redacted", () => {
+  it("retains a safe apply_patch failure category without raw output", () => {
     expect(
       remediationRunDiagnostics(maxTurnsError(), {
         DAYTONA_API_KEY: "daytona-secret",
@@ -67,7 +80,7 @@ describe("remediation agent", () => {
       applyPatchFailures: [
         {
           callId: "patch-1",
-          error: "Invalid Context containing [redacted]",
+          error: "Invalid Context 0",
           operation: "update_file",
           path: "/home/daytona/workspace/repositories/example/app/src/app.ts",
         },
@@ -77,7 +90,18 @@ describe("remediation agent", () => {
     });
   });
 
+  it("does not retain unclassified apply_patch output", () => {
+    expect(
+      remediationRunDiagnostics(maxTurnsError("workspace-secret-value"))
+        ?.applyPatchFailures[0]?.error,
+    ).toBe("Unclassified apply_patch failure");
+  });
+
   it("ignores errors without resumable run state", () => {
     expect(remediationRunDiagnostics(new Error("failed"))).toBeUndefined();
+  });
+
+  it("does not let unreadable diagnostics mask the remediation failure", () => {
+    expect(remediationRunDiagnostics(unreadableMaxTurnsError())).toBeUndefined();
   });
 });

--- a/apps/worker/src/remediate.test.ts
+++ b/apps/worker/src/remediate.test.ts
@@ -1,0 +1,83 @@
+import { MaxTurnsExceededError } from "@openai/agents";
+import { describe, expect, it } from "vitest";
+import {
+  remediationApplyPatchPathInstruction,
+  remediationMaxTurns,
+  remediationRunDiagnostics,
+} from "./remediate.js";
+
+function maxTurnsError() {
+  return new MaxTurnsExceededError(
+    "Max turns (40) exceeded",
+    {
+      toJSON: () => ({
+        currentTurn: 41,
+        generatedItems: [
+          {
+            agent: { name: "Responder issue fixer" },
+            rawItem: {
+              callId: "patch-1",
+              operation: {
+                diff: "@@\n-old\n+new",
+                path: "/home/daytona/workspace/repositories/example/app/src/app.ts",
+                type: "update_file",
+              },
+              type: "apply_patch_call",
+            },
+            type: "tool_call_item",
+          },
+          {
+            agent: { name: "Responder issue fixer" },
+            output: "Invalid Context containing daytona-secret",
+            rawItem: {
+              callId: "patch-1",
+              output: "Invalid Context containing daytona-secret",
+              status: "failed",
+              type: "apply_patch_call_output",
+            },
+            type: "tool_call_output_item",
+          },
+        ],
+        maxTurns: 40,
+      }),
+    } as never,
+  );
+}
+
+describe("remediation agent", () => {
+  it("allows forty model turns", () => {
+    expect(remediationMaxTurns).toBe(40);
+  });
+
+  it("requires absolute paths for native patches", () => {
+    expect(remediationApplyPatchPathInstruction).toContain(
+      "full absolute checkout path",
+    );
+    expect(remediationApplyPatchPathInstruction).toContain(
+      "Repository-relative paths",
+    );
+  });
+
+  it("retains failed apply_patch details with secrets redacted", () => {
+    expect(
+      remediationRunDiagnostics(maxTurnsError(), {
+        DAYTONA_API_KEY: "daytona-secret",
+      }),
+    ).toEqual({
+      applyPatchFailures: [
+        {
+          callId: "patch-1",
+          error: "Invalid Context containing [redacted]",
+          operation: "update_file",
+          path: "/home/daytona/workspace/repositories/example/app/src/app.ts",
+        },
+      ],
+      completedTurns: 40,
+      maxTurns: 40,
+    });
+  });
+
+  it("ignores errors without resumable run state", () => {
+    expect(remediationRunDiagnostics(new Error("failed"))).toBeUndefined();
+  });
+});

--- a/apps/worker/src/remediate.test.ts
+++ b/apps/worker/src/remediate.test.ts
@@ -97,6 +97,13 @@ describe("remediation agent", () => {
     ).toBe("Unclassified apply_patch failure");
   });
 
+  it("categorizes an empty apply_patch failure", () => {
+    expect(
+      remediationRunDiagnostics(maxTurnsError(""))?.applyPatchFailures[0]
+        ?.error,
+    ).toBe("apply_patch failed without an error message");
+  });
+
   it("ignores errors without resumable run state", () => {
     expect(remediationRunDiagnostics(new Error("failed"))).toBeUndefined();
   });

--- a/apps/worker/src/remediate.ts
+++ b/apps/worker/src/remediate.ts
@@ -1,4 +1,9 @@
-import { run, setDefaultOpenAIKey, setTracingDisabled } from "@openai/agents";
+import {
+  MaxTurnsExceededError,
+  run,
+  setDefaultOpenAIKey,
+  setTracingDisabled,
+} from "@openai/agents";
 import { Capabilities, SandboxAgent } from "@openai/agents/sandbox";
 import {
   DaytonaSandboxClient,
@@ -9,7 +14,10 @@ import { getRuntimeWorkspaceSecrets } from "@responder/core/db/workspace-secrets
 import { daytonaClientOptions } from "@responder/core/daytona-config";
 import type { RemediationJob } from "@responder/core/jobs";
 import { renderIssueFixPrompt } from "@responder/core/investigations/report";
-import { sandboxAgentConfig } from "./investigate.js";
+import {
+  safeInvestigationError,
+  sandboxAgentConfig,
+} from "./investigate.js";
 import { createPullRequestTool } from "./pull-request.js";
 import { checkoutRuntimeRepositories } from "./repositories.js";
 import {
@@ -21,6 +29,86 @@ import {
   redactDaytonaSecretPlaceholders,
   workspaceSecretUsageInstructions,
 } from "./secret-safety.js";
+
+export const remediationMaxTurns = 40;
+export const remediationApplyPatchPathInstruction =
+  "When using apply_patch, use the full absolute checkout path shown above. Repository-relative paths are resolved from the workspace root and may target the wrong location.";
+
+export interface RemediationApplyPatchFailure {
+  callId: string;
+  error: string;
+  operation?: "create_file" | "delete_file" | "update_file";
+  path?: string;
+}
+
+export interface RemediationRunDiagnostics {
+  applyPatchFailures: RemediationApplyPatchFailure[];
+  completedTurns: number;
+  maxTurns: number | null;
+}
+
+const maxStoredApplyPatchFailures = 10;
+
+export function remediationRunDiagnostics(
+  error: unknown,
+  environment: NodeJS.ProcessEnv = process.env,
+): RemediationRunDiagnostics | undefined {
+  if (!(error instanceof MaxTurnsExceededError) || !error.state) {
+    return undefined;
+  }
+
+  const state = error.state.toJSON();
+  const operations = new Map<
+    string,
+    {
+      operation: "create_file" | "delete_file" | "update_file";
+      path: string;
+    }
+  >();
+
+  for (const item of state.generatedItems) {
+    if (
+      item.type !== "tool_call_item" ||
+      item.rawItem.type !== "apply_patch_call"
+    ) {
+      continue;
+    }
+    operations.set(item.rawItem.callId, {
+      operation: item.rawItem.operation.type,
+      path: item.rawItem.operation.path,
+    });
+  }
+
+  const applyPatchFailures = state.generatedItems
+    .flatMap((item): RemediationApplyPatchFailure[] => {
+      if (
+        item.type !== "tool_call_output_item" ||
+        item.rawItem.type !== "apply_patch_call_output" ||
+        item.rawItem.status !== "failed"
+      ) {
+        return [];
+      }
+      const operation = operations.get(item.rawItem.callId);
+      const output =
+        item.rawItem.output ||
+        (typeof item.output === "string" ? item.output : undefined) ||
+        "apply_patch failed without an error message";
+      return [
+        {
+          callId: item.rawItem.callId,
+          error: safeInvestigationError(new Error(output), environment),
+          ...(operation ?? {}),
+        },
+      ];
+    })
+    .slice(-maxStoredApplyPatchFailures);
+
+  return {
+    applyPatchFailures,
+    completedTurns: Math.max(0, state.currentTurn - 1),
+    maxTurns: state.maxTurns,
+  };
+}
 
 export async function runRemediationAgent(
   job: RemediationJob,
@@ -68,6 +156,7 @@ export async function runRemediationAgent(
           (repository) =>
             `- ${repository.repository}: ${repository.path} (${repository.branch} at ${repository.sha})`,
         ),
+        remediationApplyPatchPathInstruction,
         "Inspect the relevant code, make the smallest safe fix in exactly one selected repository, and run the narrowest useful checks.",
         `Then call create_pull_request with issue ID ${job.issue.id}. Do not finish without creating the pull request or clearly explaining why no safe code fix is possible.`,
         "Do not expose credentials or secret values. The pull request is the only allowed external change.",
@@ -79,7 +168,7 @@ export async function runRemediationAgent(
       tools: [pullRequestTool],
     });
     const result = await run(agent, renderIssueFixPrompt(job.issue), {
-      maxTurns: 20,
+      maxTurns: remediationMaxTurns,
       sandbox: { session },
     });
     if (typeof result.finalOutput !== "string" || !result.finalOutput.trim()) {

--- a/apps/worker/src/remediate.ts
+++ b/apps/worker/src/remediate.ts
@@ -49,6 +49,61 @@ export interface RemediationRunDiagnostics {
 
 const maxStoredApplyPatchFailures = 10;
 
+function safeApplyPatchFailure(
+  output: string,
+  environment: NodeJS.ProcessEnv,
+): string {
+  const safeOutput = safeInvestigationError(new Error(output), environment);
+  const invalidEofContext = safeOutput.match(
+    /^Invalid EOF Context(?:\s+(\d+))?(?::|$)/,
+  );
+  if (invalidEofContext) {
+    return `Invalid EOF Context${invalidEofContext[1] ? ` ${invalidEofContext[1]}` : ""}`;
+  }
+
+  const invalidContext = safeOutput.match(
+    /^Invalid Context(?:\s+(\d+))?(?::|$)/,
+  );
+  if (invalidContext) {
+    return `Invalid Context${invalidContext[1] ? ` ${invalidContext[1]}` : ""}`;
+  }
+
+  if (/^Invalid Add File Line:/.test(safeOutput)) {
+    return "Invalid add-file patch line";
+  }
+  if (/^Invalid Line:/.test(safeOutput)) {
+    return "Invalid patch line";
+  }
+  if (/^Cannot create file because it already exists:/.test(safeOutput)) {
+    return "File already exists";
+  }
+  if (/^Nothing in this section/.test(safeOutput)) {
+    return "Patch section did not match";
+  }
+  if (/^applyDiff: chunk\.origIndex/.test(safeOutput)) {
+    return "Invalid patch chunk position";
+  }
+  if (/overlapping (?:patch )?chunks/i.test(safeOutput)) {
+    return "Overlapping patch chunks";
+  }
+  if (/not a regular file/i.test(safeOutput)) {
+    return "Patch target is not a regular file";
+  }
+  if (/workspace escape/i.test(safeOutput)) {
+    return "Patch target is outside the workspace";
+  }
+  if (/directory target/i.test(safeOutput)) {
+    return "Patch target is a directory";
+  }
+  if (/remote editor operation failed/i.test(safeOutput)) {
+    return "Remote editor operation failed";
+  }
+  if (!safeOutput.trim()) {
+    return "apply_patch failed without an error message";
+  }
+  return "Unclassified apply_patch failure";
+}
+
 export function remediationRunDiagnostics(
   error: unknown,
   environment: NodeJS.ProcessEnv = process.env,
@@ -57,57 +112,61 @@ export function remediationRunDiagnostics(
     return undefined;
   }
 
-  const state = error.state.toJSON();
-  const operations = new Map<
-    string,
-    {
-      operation: "create_file" | "delete_file" | "update_file";
-      path: string;
-    }
-  >();
-
-  for (const item of state.generatedItems) {
-    if (
-      item.type !== "tool_call_item" ||
-      item.rawItem.type !== "apply_patch_call"
-    ) {
-      continue;
-    }
-    operations.set(item.rawItem.callId, {
-      operation: item.rawItem.operation.type,
-      path: item.rawItem.operation.path,
-    });
-  }
-
-  const applyPatchFailures = state.generatedItems
-    .flatMap((item): RemediationApplyPatchFailure[] => {
-      if (
-        item.type !== "tool_call_output_item" ||
-        item.rawItem.type !== "apply_patch_call_output" ||
-        item.rawItem.status !== "failed"
-      ) {
-        return [];
+  try {
+    const state = error.state.toJSON();
+    const operations = new Map<
+      string,
+      {
+        operation: "create_file" | "delete_file" | "update_file";
+        path: string;
       }
-      const operation = operations.get(item.rawItem.callId);
-      const output =
-        item.rawItem.output ||
-        (typeof item.output === "string" ? item.output : undefined) ||
-        "apply_patch failed without an error message";
-      return [
-        {
-          callId: item.rawItem.callId,
-          error: safeInvestigationError(new Error(output), environment),
-          ...(operation ?? {}),
-        },
-      ];
-    })
-    .slice(-maxStoredApplyPatchFailures);
+    >();
 
-  return {
-    applyPatchFailures,
-    completedTurns: Math.max(0, state.currentTurn - 1),
-    maxTurns: state.maxTurns,
-  };
+    for (const item of state.generatedItems) {
+      if (
+        item.type !== "tool_call_item" ||
+        item.rawItem.type !== "apply_patch_call"
+      ) {
+        continue;
+      }
+      operations.set(item.rawItem.callId, {
+        operation: item.rawItem.operation.type,
+        path: item.rawItem.operation.path,
+      });
+    }
+
+    const applyPatchFailures = state.generatedItems
+      .flatMap((item): RemediationApplyPatchFailure[] => {
+        if (
+          item.type !== "tool_call_output_item" ||
+          item.rawItem.type !== "apply_patch_call_output" ||
+          item.rawItem.status !== "failed"
+        ) {
+          return [];
+        }
+        const operation = operations.get(item.rawItem.callId);
+        const output =
+          item.rawItem.output ||
+          (typeof item.output === "string" ? item.output : undefined) ||
+          "apply_patch failed without an error message";
+        return [
+          {
+            callId: item.rawItem.callId,
+            error: safeApplyPatchFailure(output, environment),
+            ...(operation ?? {}),
+          },
+        ];
+      })
+      .slice(-maxStoredApplyPatchFailures);
+
+    return {
+      applyPatchFailures,
+      completedTurns: Math.max(0, state.currentTurn - 1),
+      maxTurns: state.maxTurns,
+    };
+  } catch {
+    return undefined;
+  }
 }
 
 export async function runRemediationAgent(

--- a/apps/worker/src/remediate.ts
+++ b/apps/worker/src/remediate.ts
@@ -50,9 +50,12 @@ export interface RemediationRunDiagnostics {
 const maxStoredApplyPatchFailures = 10;
 
 function safeApplyPatchFailure(
-  output: string,
+  output: string | undefined,
   environment: NodeJS.ProcessEnv,
 ): string {
+  if (!output?.trim()) {
+    return "apply_patch failed without an error message";
+  }
   const safeOutput = safeInvestigationError(new Error(output), environment);
   const invalidEofContext = safeOutput.match(
     /^Invalid EOF Context(?:\s+(\d+))?(?::|$)/,
@@ -97,9 +100,6 @@ function safeApplyPatchFailure(
   }
   if (/remote editor operation failed/i.test(safeOutput)) {
     return "Remote editor operation failed";
-  }
-  if (!safeOutput.trim()) {
-    return "apply_patch failed without an error message";
   }
   return "Unclassified apply_patch failure";
 }
@@ -147,8 +147,7 @@ export function remediationRunDiagnostics(
         const operation = operations.get(item.rawItem.callId);
         const output =
           item.rawItem.output ||
-          (typeof item.output === "string" ? item.output : undefined) ||
-          "apply_patch failed without an error message";
+          (typeof item.output === "string" ? item.output : undefined);
         return [
           {
             callId: item.rawItem.callId,


### PR DESCRIPTION
## Summary

- raise remediation runs from 20 to 40 model turns
- retain failed native `apply_patch` messages, operations, call IDs, and paths in structured Sentry context and worker logs
- redact configured API secrets without enabling blanket sensitive tool logging
- tell remediation agents to use the absolute repository checkout path for native patches

## Root cause

The worker stopped remediation at a fixed 20-turn boundary. Native patch failures were returned to the model for recovery, but the SDK log reduced those failures to `object`; when the run exhausted its budget, the worker retained only the max-turn message and deleted the sandbox.

## Impact

Longer bounded runs can finish, and any future max-turn failure will retain actionable patch diagnostics without globally logging raw model or tool data.

## Validation

- `pnpm test` (499 tests)
- `pnpm typecheck`
- `pnpm lint`
- focused remediation and monitoring tests

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allows more remediation runs to finish and makes failures diagnosable. Previously runs stopped at 20 turns and `apply_patch` failures were lost; now runs allow 40 turns and we record redacted, structured diagnostics (without raw tool output) to Sentry and logs, isolated from identifiers in a separate “diagnostics” context.

- Increases `@openai/agents` remediation max turns to 40 and records `completedTurns` and `maxTurns`.
- Captures structured diagnostics for failed native `apply_patch` calls (callId, operation, path, classified error; last 10) and sends them to a separate Sentry “diagnostics” context and worker logs.
- Classifies common patch failures and redacts configured API secrets; unclassified outputs are not retained.
- Adds an explicit agent instruction to use absolute repository checkout paths for `apply_patch`.

**Review and rollout**
- Review `apps/worker/src/remediate.ts` (`remediationRunDiagnostics`, `remediationMaxTurns`, classification, and the prompt change), `apps/worker/src/monitoring.ts` (separate `diagnostics` context), and `apps/worker/src/index.ts` (wiring diagnostics into Sentry and logs).
- Watch remediation job duration and cost; 40-turn runs are longer.
- Sentry will include a separate “diagnostics” context on remediation failures; no migration required.

<sup>Written for commit fc94ce79be53e46ca5cc70936ea77535e221ddf9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/responder-oss/pull/32?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

