### PR TITLE
Harden application security boundaries

### DIFF
--- a/apps/control-plane/package.json
+++ b/apps/control-plane/package.json
@@ -32,7 +32,7 @@
     "react-markdown": "^10.1.0",
     "react-router-dom": "7.18.2",
     "resend": "6.12.3",
-    "tsx": "4.20.6",
+    "tsx": "4.23.12",
     "zod": "4.4.3"
   },
   "devDependencies": {

--- a/apps/control-plane/server/app.ts
+++ b/apps/control-plane/server/app.ts
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import { bodyLimit } from "hono/body-limit";
 import * as Sentry from "@sentry/hono/node";
 import { createHash } from "node:crypto";
 import { verifyBearerToken } from "../../../packages/core/src/auth/internal.js";
@@ -10,6 +11,7 @@ import {
   canImpersonateSupportUser,
   configuredSuperuserEmails,
   getAuth,
+  platformRoleForIdentity,
 } from "./auth.js";
 import { billingRoutes } from "./billing/routes.js";
 import { integrationRoutes } from "./integrations/routes.js";
@@ -22,6 +24,11 @@ import { slackWebhookRoutes } from "./webhooks/slack.js";
 
 const sessionCookiePattern =
   /(?:^|[;,]\s*)(?:__Secure-)?(?:better-auth|responder-auth)\.session_token=/;
+
+export const MAX_REQUEST_BODY_BYTES = 1024 * 1024;
+// GitHub accepts webhook deliveries up to 25 MiB. Keep signed provider
+// callbacks compatible while retaining a finite in-process buffering bound.
+export const MAX_WEBHOOK_REQUEST_BODY_BYTES = 25 * 1024 * 1024;
 
 export function sessionCookieFingerprint(cookieHeader: string): string {
   const match =
@@ -80,7 +87,10 @@ async function handleAuthRequest(request: Request): Promise<Response> {
   if (
     requiresSuperuser &&
     (!sessionBefore ||
-      !configuredSuperuserEmails().has(sessionBefore.user.email.toLowerCase()))
+      platformRoleForIdentity(
+        sessionBefore.user,
+        configuredSuperuserEmails(),
+      ) !== "superuser")
   ) {
     console.info(
       JSON.stringify({
@@ -211,6 +221,36 @@ async function handleAuthRequest(request: Request): Promise<Response> {
 }
 
 const instrumentedApp = new Hono();
+function requestBodyLimit(maxSize: number) {
+  return bodyLimit({
+    maxSize,
+    onError: (context) => {
+      console.warn(
+        JSON.stringify({
+          contentLength: context.req.header("content-length") ?? null,
+          event: "request_body_too_large",
+          maxBytes: maxSize,
+          pathname: context.req.path,
+        }),
+      );
+      return context.json({ error: "Request body too large" }, 413);
+    },
+  });
+}
+
+const apiBodyLimit = requestBodyLimit(MAX_REQUEST_BODY_BYTES);
+const githubWebhookBodyLimit = requestBodyLimit(
+  MAX_WEBHOOK_REQUEST_BODY_BYTES,
+);
+const githubWebhookPaths = new Set([
+  "/api/webhooks/github",
+  "/api/webhooks/github/",
+]);
+instrumentedApp.use("*", (context, next) =>
+  githubWebhookPaths.has(context.req.path)
+    ? githubWebhookBodyLimit(context, next)
+    : apiBodyLimit(context, next),
+);
 if (Sentry.isInitialized()) {
   instrumentedApp.use(Sentry.sentry(instrumentedApp));
   instrumentedApp.use(async (_context, next) => {
@@ -239,7 +279,7 @@ export const app = instrumentedApp
     const superuserEmails = configuredSuperuserEmails();
     if (
       !session ||
-      !superuserEmails.has(session.user.email.trim().toLowerCase())
+      platformRoleForIdentity(session.user, superuserEmails) !== "superuser"
     ) {
       return context.json({ error: "Forbidden" }, 403);
     }

--- a/apps/control-plane/server/auth.test.ts
+++ b/apps/control-plane/server/auth.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   canImpersonateSupportUser,
   configuredSuperuserEmails,
+  platformRoleForIdentity,
 } from "./auth.js";
 
 describe("configuredSuperuserEmails", () => {
@@ -39,5 +40,27 @@ describe("configuredSuperuserEmails", () => {
     expect(
       canImpersonateSupportUser(regularUser, new Set(["user@example.com"])),
     ).toBe(false);
+  });
+});
+
+describe("platformRoleForIdentity", () => {
+  const superuserEmails = new Set(["admin@example.com"]);
+
+  it("does not trust an allowlisted but unverified email address", () => {
+    expect(
+      platformRoleForIdentity(
+        { email: "admin@example.com", emailVerified: false },
+        superuserEmails,
+      ),
+    ).toBe("user");
+  });
+
+  it("grants the superuser role to a verified allowlisted identity", () => {
+    expect(
+      platformRoleForIdentity(
+        { email: " Admin@Example.com ", emailVerified: true },
+        superuserEmails,
+      ),
+    ).toBe("superuser");
   });
 });

--- a/apps/control-plane/server/auth.ts
+++ b/apps/control-plane/server/auth.ts
@@ -6,6 +6,7 @@ import {
   getAuthUserSupportIdentity,
   setPlatformRole,
   type AuthUserSupportIdentity,
+  type PlatformRole,
 } from "../../../packages/core/src/db/superusers.js";
 import {
   rememberedOrganizationId,
@@ -53,8 +54,18 @@ export function configuredSuperuserEmails(
   );
 }
 
+export function platformRoleForIdentity(
+  identity: Pick<AuthUserSupportIdentity, "email" | "emailVerified">,
+  superuserEmails: ReadonlySet<string>,
+): PlatformRole {
+  return identity.emailVerified &&
+    superuserEmails.has(identity.email.trim().toLowerCase())
+    ? "superuser"
+    : "user";
+}
+
 export function canImpersonateSupportUser(
-  target: AuthUserSupportIdentity | null,
+  target: Pick<AuthUserSupportIdentity, "banned" | "email" | "role"> | null,
   superuserEmails: ReadonlySet<string>,
 ): boolean {
   return Boolean(
@@ -68,11 +79,13 @@ export function canImpersonateSupportUser(
 async function synchronizeSuperuserRole(
   userId: string,
   email: string,
+  emailVerified: boolean,
   context: "session_create_before" | "user_create_after",
 ) {
-  const role = configuredSuperuserEmails().has(email.trim().toLowerCase())
-    ? "superuser"
-    : "user";
+  const role = platformRoleForIdentity(
+    { email, emailVerified },
+    configuredSuperuserEmails(),
+  );
   try {
     await setPlatformRole(userId, role);
   } catch (error) {
@@ -143,7 +156,12 @@ export function createResponderAuth() {
       user: {
         create: {
           after: async (user, context) => {
-            await synchronizeSuperuserRole(user.id, user.email, "user_create_after");
+            await synchronizeSuperuserRole(
+              user.id,
+              user.email,
+              user.emailVerified,
+              "user_create_after",
+            );
             const path = context?.path ?? "";
             const signupMethod = path.includes("google")
               ? "google"
@@ -177,6 +195,7 @@ export function createResponderAuth() {
               await synchronizeSuperuserRole(
                 session.userId,
                 identity.email,
+                identity.emailVerified,
                 "session_create_before",
               );
             }

--- a/apps/control-plane/server/index.test.ts
+++ b/apps/control-plane/server/index.test.ts
@@ -4,6 +4,7 @@ import {
   app,
   authHandlerErrorMessage,
   logAuthCallback,
+  MAX_REQUEST_BODY_BYTES,
   sessionCookieFingerprint,
 } from "./app.js";
 import {
@@ -108,6 +109,86 @@ describe("control-plane API", () => {
       service: "responder-control-plane",
       status: "ok",
     });
+  });
+
+  it("rejects oversized declared request bodies before auth parsing", async () => {
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const response = await app.request("/api/auth/admin/impersonate-user", {
+      body: "{}",
+      headers: {
+        "content-length": String(MAX_REQUEST_BODY_BYTES + 1),
+        "content-type": "application/json",
+      },
+      method: "POST",
+    });
+
+    expect(response.status).toBe(413);
+    await expect(response.json()).resolves.toEqual({
+      error: "Request body too large",
+    });
+    expect(warning).toHaveBeenCalledWith(
+      JSON.stringify({
+        contentLength: String(MAX_REQUEST_BODY_BYTES + 1),
+        event: "request_body_too_large",
+        maxBytes: MAX_REQUEST_BODY_BYTES,
+        pathname: "/api/auth/admin/impersonate-user",
+      }),
+    );
+  });
+
+  it("accepts signed webhook payloads larger than the API body limit", async () => {
+    vi.stubEnv("GITHUB_WEBHOOK_SECRET", "webhook-secret");
+    const body = JSON.stringify({
+      padding: "x".repeat(MAX_REQUEST_BODY_BYTES),
+    });
+    const signature = `sha256=${createHmac("sha256", "webhook-secret")
+      .update(body, "utf8")
+      .digest("hex")}`;
+
+    const response = await app.request("/api/webhooks/github", {
+      body,
+      headers: {
+        "content-type": "application/json",
+        "x-github-event": "ping",
+        "x-hub-signature-256": signature,
+      },
+      method: "POST",
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ ok: true, ignored: true });
+  });
+
+  it("keeps the 1 MiB streamed-body limit on non-GitHub webhooks", async () => {
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array(MAX_REQUEST_BODY_BYTES));
+        controller.enqueue(new Uint8Array(1));
+        controller.close();
+      },
+    });
+    const request = new Request("http://localhost/api/webhooks/slack", {
+      body,
+      headers: { "content-type": "application/json" },
+      method: "POST",
+      duplex: "half",
+    } as RequestInit & { duplex: "half" });
+
+    const response = await app.request(request);
+
+    expect(response.status).toBe(413);
+    await expect(response.json()).resolves.toEqual({
+      error: "Request body too large",
+    });
+    expect(warning).toHaveBeenCalledWith(
+      JSON.stringify({
+        contentLength: null,
+        event: "request_body_too_large",
+        maxBytes: MAX_REQUEST_BODY_BYTES,
+        pathname: "/api/webhooks/slack",
+      }),
+    );
   });
 
   it("routes the GitHub App setup callback to the integration flow", async () => {

--- a/apps/control-plane/server/integrations/clickstack.ts
+++ b/apps/control-plane/server/integrations/clickstack.ts
@@ -150,9 +150,12 @@ export { CLICKSTACK_CLOUD_MCP_URL };
 export async function clickStackAccount(input: {
   accessKey: string;
   mcpUrl: string;
-}) {
+}, fetchImpl: (
+  input: RequestInfo | URL,
+  init?: RequestInit,
+) => Promise<Response> = safeCustomMcpFetch) {
   const mcpUrl = normalizeClickStackMcpUrl(input.mcpUrl);
-  const response = await safeCustomMcpFetch(clickStackTeamUrl(mcpUrl), {
+  const response = await fetchImpl(clickStackTeamUrl(mcpUrl), {
     headers: {
       accept: "application/json",
       authorization: `Bearer ${input.accessKey}`,

--- a/apps/control-plane/server/integrations/github-routes.test.ts
+++ b/apps/control-plane/server/integrations/github-routes.test.ts
@@ -1,5 +1,5 @@
 import { Hono } from "hono";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { disableAgentsWithUnavailableRepositories } from "../../../../packages/core/src/db/agents.js";
 import {
   consumeIntegrationConnectionState,
@@ -68,6 +68,10 @@ function configureGitHub() {
 }
 
 describe("GitHub integration routing", () => {
+  beforeEach(() => {
+    vi.mocked(getActiveTenant).mockResolvedValue(tenant);
+  });
+
   afterEach(() => {
     vi.clearAllMocks();
     vi.unstubAllEnvs();

--- a/apps/control-plane/server/integrations/providers.test.ts
+++ b/apps/control-plane/server/integrations/providers.test.ts
@@ -36,6 +36,7 @@ import {
 import {
   exchangeVercelCode,
   getVercelAccount,
+  getVercelConfiguration,
   listVercelProjects,
   vercelInstallUrl,
 } from "./vercel.js";
@@ -152,21 +153,19 @@ describe("integration providers", () => {
       clickStackAccount({
         accessKey: "personal-access-key",
         mcpUrl: "https://clickstack.example.com/api/mcp",
-      }),
+      }, fetchMock),
     ).resolves.toEqual({
       displayName: "Production",
       externalAccountId: "https://clickstack.example.com:team-1",
       mcpUrl: "https://clickstack.example.com/api/mcp",
       teamId: "team-1",
     });
-    expect(fetchMock).toHaveBeenCalledWith(expect.any(Request), {
-      redirect: "manual",
-    });
-    const request = fetchMock.mock.calls[0]?.[0] as Request;
-    expect(request.url).toBe(
+    expect(fetchMock).toHaveBeenCalledWith(
       "https://clickstack.example.com/api/api/v2/team",
+      expect.objectContaining({ redirect: "manual" }),
     );
-    expect(request.headers.get("authorization")).toBe(
+    const requestInit = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    expect(new Headers(requestInit.headers).get("authorization")).toBe(
       "Bearer personal-access-key",
     );
     expect(infoLog).toHaveBeenCalledWith(
@@ -179,17 +178,16 @@ describe("integration providers", () => {
   });
 
   it("logs ClickStack team lookup failures without credentials", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockResolvedValue(new Response(null, { status: 503 })),
-    );
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response(null, { status: 503 }));
     const errorLog = vi.spyOn(console, "error").mockImplementation(() => {});
 
     await expect(
       clickStackAccount({
         accessKey: "personal-access-key",
         mcpUrl: "https://clickstack.example.com/api/mcp/",
-      }),
+      }, fetchMock),
     ).rejects.toThrow("Unable to load the ClickStack team");
     expect(errorLog).toHaveBeenCalledWith(
       JSON.stringify({
@@ -204,17 +202,16 @@ describe("integration providers", () => {
   });
 
   it("logs rejected ClickStack credentials without the access key", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockResolvedValue(new Response(null, { status: 401 })),
-    );
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response(null, { status: 401 }));
     const errorLog = vi.spyOn(console, "error").mockImplementation(() => {});
 
     await expect(
       clickStackAccount({
         accessKey: "rejected-access-key",
         mcpUrl: "https://clickstack.example.com/api/mcp",
-      }),
+      }, fetchMock),
     ).rejects.toThrow("ClickStack rejected the Personal API Access Key");
     expect(errorLog).toHaveBeenCalledWith(
       JSON.stringify({
@@ -558,6 +555,39 @@ describe("integration providers", () => {
     const secondProjectUrl = new URL(fetchMock.mock.calls[2]![0] as URL);
     expect(secondProjectUrl.searchParams.get("teamId")).toBe("team-1");
     expect(secondProjectUrl.searchParams.get("until")).toBe("123");
+  });
+
+  it("verifies a Vercel installation identity and selected projects", async () => {
+    vi.stubEnv("VERCEL_INTEGRATION_SLUG", "responder");
+    vi.stubEnv("VERCEL_CLIENT_ID", "vercel-client");
+    vi.stubEnv("VERCEL_CLIENT_SECRET", "vercel-secret");
+    const fetchMock = vi.fn().mockResolvedValue(
+      Response.json({
+        id: "icfg_1",
+        projectSelection: "selected",
+        projects: ["prj-1"],
+        scopes: ["read:deployment", "read:logs", "read:project"],
+        slug: "responder",
+        status: "ready",
+        teamId: "team-1",
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      getVercelConfiguration({
+        accessToken: "token",
+        configurationId: "icfg_1",
+        teamId: "team-1",
+      }),
+    ).resolves.toMatchObject({
+      id: "icfg_1",
+      projects: ["prj-1"],
+      scopes: ["read:deployment", "read:logs", "read:project"],
+    });
+    const requestUrl = new URL(fetchMock.mock.calls[0]![0] as URL);
+    expect(requestUrl.pathname).toBe("/v1/integrations/configuration/icfg_1");
+    expect(requestUrl.searchParams.get("teamId")).toBe("team-1");
   });
 
   it("connects project-scoped Vercel installations without Team read access", async () => {

--- a/apps/control-plane/server/integrations/routes.test.ts
+++ b/apps/control-plane/server/integrations/routes.test.ts
@@ -1,5 +1,5 @@
 import { Hono } from "hono";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   decryptCredentials,
   encryptCredentials,
@@ -122,6 +122,10 @@ function configureGitHub() {
 }
 
 describe("integration callback routing", () => {
+  beforeEach(() => {
+    vi.mocked(getActiveTenant).mockResolvedValue(tenant);
+  });
+
   afterEach(() => {
     vi.clearAllMocks();
     vi.restoreAllMocks();
@@ -205,12 +209,28 @@ describe("integration callback routing", () => {
         .mockResolvedValueOnce(
           Response.json({
             access_token: "vercel-token",
-            team_id: "team-1",
+            team_id: "team_1",
             user_id: "user-1",
           }),
         )
         .mockResolvedValueOnce(
-          Response.json({ id: "team-1", name: "Acme", slug: "acme" }),
+          Response.json({
+            id: "icfg_1",
+            projectSelection: "selected",
+            projects: ["prj-1"],
+            scopes: [
+              "read:deployment",
+              "read:domain",
+              "read:logs",
+              "read:project",
+            ],
+            slug: "responder",
+            status: "ready",
+            teamId: "team_1",
+          }),
+        )
+        .mockResolvedValueOnce(
+          Response.json({ id: "team_1", name: "Acme", slug: "acme" }),
         )
         .mockResolvedValueOnce(
           Response.json({
@@ -223,8 +243,8 @@ describe("integration callback routing", () => {
     const response = await app.request(
       "/api/integrations/vercel/callback" +
         "?code=one-time-code" +
-        "&configurationId=icfg-1" +
-        "&teamId=team-1" +
+        "&configurationId=icfg_1" +
+        "&teamId=team_1" +
         "&state=connection-state",
     );
 
@@ -237,15 +257,15 @@ describe("integration callback routing", () => {
     );
     expect(encryptCredentials).toHaveBeenCalledWith({
       accessToken: "vercel-token",
-      configurationId: "icfg-1",
-      teamId: "team-1",
+      configurationId: "icfg_1",
+      teamId: "team_1",
       userId: "user-1",
     });
     expect(upsertIntegrationAccount).toHaveBeenCalledWith(
       expect.objectContaining({
         organizationId: tenant.organizationId,
         provider: "vercel",
-        externalAccountId: "icfg-1",
+        externalAccountId: "icfg_1",
         displayName: "Acme",
         encryptedCredentials: "encrypted-credentials",
       }),
@@ -255,6 +275,107 @@ describe("integration callback routing", () => {
       "vercel_project",
       [expect.objectContaining({ externalId: "prj-1", displayName: "web" })],
     );
+    expect(consumeIntegrationConnectionState).toHaveBeenCalledWith(
+      "vercel",
+      "connection-state",
+      {
+        organizationId: tenant.organizationId,
+        userId: tenant.user.id,
+      },
+    );
+  });
+
+  it("authenticates and consumes a Vercel denial before returning to its initiating page", async () => {
+    vi.stubEnv("BETTER_AUTH_URL", "https://responder.example");
+    vi.mocked(consumeIntegrationConnectionState).mockResolvedValue({
+      organizationId: tenant.organizationId,
+      userId: tenant.user.id,
+      returnTo: "/agents/new",
+      codeVerifier: null,
+      metadata: {},
+    });
+
+    const response = await app.request(
+      "/api/integrations/vercel/callback" +
+        "?error=access_denied&state=connection-state",
+    );
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe(
+      "https://responder.example/agents/new" +
+        "?integration=vercel&status=error&reason=cancelled",
+    );
+    expect(consumeIntegrationConnectionState).toHaveBeenCalledWith(
+      "vercel",
+      "connection-state",
+      {
+        organizationId: tenant.organizationId,
+        userId: tenant.user.id,
+      },
+    );
+    expect(upsertIntegrationAccount).not.toHaveBeenCalled();
+  });
+
+  it("consumes Vercel state before rejecting malformed callback fields", async () => {
+    vi.stubEnv("BETTER_AUTH_URL", "https://responder.example");
+    vi.mocked(consumeIntegrationConnectionState).mockResolvedValue({
+      organizationId: tenant.organizationId,
+      userId: tenant.user.id,
+      returnTo: "/agents/new",
+      codeVerifier: null,
+      metadata: {},
+    });
+
+    const response = await app.request(
+      "/api/integrations/vercel/callback" +
+        "?configurationId=not-an-installation&state=connection-state",
+    );
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe(
+      "https://responder.example/agents/new" +
+        "?integration=vercel&status=error&reason=invalid_callback",
+    );
+    expect(consumeIntegrationConnectionState).toHaveBeenCalledWith(
+      "vercel",
+      "connection-state",
+      {
+        organizationId: tenant.organizationId,
+        userId: tenant.user.id,
+      },
+    );
+  });
+
+  it("rejects a Vercel callback whose team differs from the token", async () => {
+    vi.stubEnv("BETTER_AUTH_URL", "https://responder.example");
+    vi.stubEnv("VERCEL_INTEGRATION_SLUG", "responder");
+    vi.stubEnv("VERCEL_CLIENT_ID", "vercel-client");
+    vi.stubEnv("VERCEL_CLIENT_SECRET", "vercel-secret");
+    vi.mocked(consumeIntegrationConnectionState).mockResolvedValue({
+      organizationId: tenant.organizationId,
+      userId: tenant.user.id,
+      returnTo: "/agents/new",
+      codeVerifier: null,
+      metadata: {},
+    });
+    const fetchMock = vi.fn().mockResolvedValue(
+      Response.json({
+        access_token: "vercel-token",
+        team_id: "team_other",
+        user_id: "user-1",
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await app.request(
+      "/api/integrations/vercel/callback" +
+        "?code=one-time-code&configurationId=icfg_1" +
+        "&teamId=team_1&state=connection-state",
+    );
+
+    expect(response.status).toBe(302);
+    expect(upsertIntegrationAccount).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledOnce();
   });
 
   it("accepts Sentry's code-less verified-install completion redirect", async () => {
@@ -334,6 +455,7 @@ describe("integration callback routing", () => {
     vi.stubEnv("BETTER_AUTH_URL", "https://responder.example");
     vi.stubEnv("LINEAR_CLIENT_ID", "linear-client");
     vi.stubEnv("LINEAR_CLIENT_SECRET", "linear-secret");
+    vi.mocked(getActiveTenant).mockResolvedValue(tenant);
     vi.mocked(consumeIntegrationConnectionState).mockResolvedValue({
       organizationId: tenant.organizationId,
       userId: tenant.user.id,
@@ -382,11 +504,125 @@ describe("integration callback routing", () => {
     expect(upsertIntegrationAccount).toHaveBeenCalledWith(
       expect.objectContaining({
         displayName: "Example Linear",
+        externalAccountId: "linear-workspace-id",
         provider: "linear",
         status: "connected",
       }),
     );
     expect(getOrganizationIntegrationAccount).not.toHaveBeenCalled();
+  });
+
+  it("requires the same Responder identity to finish Linear account linking", async () => {
+    vi.stubEnv("BETTER_AUTH_URL", "https://responder.example");
+    vi.mocked(getActiveTenant).mockResolvedValue({
+      ...tenant,
+      user: {
+        ...tenant.user,
+        id: "20000000-0000-4000-8000-000000000099",
+      },
+    });
+    vi.mocked(consumeIntegrationConnectionState).mockResolvedValue({
+      organizationId: tenant.organizationId,
+      userId: tenant.user.id,
+      returnTo: "/agents/new",
+      codeVerifier: "pkce-verifier",
+      metadata: {},
+    });
+
+    const response = await app.request(
+      "/api/integrations/linear/callback?state=linear-state&code=linear-code",
+    );
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe(
+      "https://responder.example/settings" +
+        "?integration=linear&status=error&reason=invalid_state",
+    );
+    expect(exchangeLinearOAuthCode).not.toHaveBeenCalled();
+    expect(upsertIntegrationAccount).not.toHaveBeenCalled();
+  });
+
+  it("does not consume Linear connection state without a Responder session", async () => {
+    vi.stubEnv("BETTER_AUTH_URL", "https://responder.example");
+    vi.mocked(getActiveTenant).mockResolvedValue({
+      ok: false,
+      error: "Unauthorized",
+      status: 401,
+    });
+
+    const response = await app.request(
+      "/api/integrations/linear/callback?state=linear-state&code=linear-code",
+    );
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe(
+      "https://responder.example/settings" +
+        "?integration=linear&status=error&reason=invalid_state",
+    );
+    expect(consumeIntegrationConnectionState).not.toHaveBeenCalled();
+    expect(exchangeLinearOAuthCode).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [
+      "custom_mcp",
+      "/api/integrations/custom_mcp/callback?state=oauth-state&code=oauth-code",
+    ],
+    [
+      "linear",
+      "/api/integrations/linear/callback?state=oauth-state&code=oauth-code",
+    ],
+    [
+      "clickstack",
+      "/api/integrations/clickstack/callback?state=oauth-state&code=oauth-code",
+    ],
+    [
+      "sentry",
+      "/api/integrations/sentry/callback?state=oauth-state&code=oauth-code" +
+        "&installationId=40000000-0000-4000-8000-000000000000&orgSlug=example",
+    ],
+    [
+      "slack",
+      "/api/integrations/slack/callback?state=oauth-state&code=oauth-code",
+    ],
+    [
+      "github",
+      "/api/integrations/github/callback?state=oauth-state&code=oauth-code",
+    ],
+    [
+      "vercel",
+      "/api/integrations/vercel/callback?state=oauth-state&code=oauth-code" +
+        "&configurationId=icfg_1",
+    ],
+  ])("rejects a %s callback completed by a different Responder identity", async (
+    provider,
+    callbackUrl,
+  ) => {
+    vi.stubEnv("BETTER_AUTH_URL", "https://responder.example");
+    vi.mocked(consumeIntegrationConnectionState).mockResolvedValue({
+      organizationId: tenant.organizationId,
+      userId: "20000000-0000-4000-8000-000000000099",
+      returnTo: "/agents/new",
+      codeVerifier: "pkce-verifier",
+      metadata: {},
+    });
+
+    const response = await app.request(callbackUrl);
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe(
+      `https://responder.example/settings?integration=${provider}` +
+        "&status=error&reason=invalid_state",
+    );
+    expect(consumeIntegrationConnectionState).toHaveBeenCalledWith(
+      provider,
+      "oauth-state",
+      {
+        organizationId: tenant.organizationId,
+        userId: tenant.user.id,
+      },
+    );
+    expect(upsertIntegrationAccount).not.toHaveBeenCalled();
   });
 
   it("offers GitHub authorization when an installation already exists", async () => {

--- a/apps/control-plane/server/integrations/routes.ts
+++ b/apps/control-plane/server/integrations/routes.ts
@@ -84,6 +84,7 @@ import {
 import {
   exchangeVercelCode,
   getVercelAccount,
+  getVercelConfiguration,
   listVercelProjects,
   vercelInstallUrl,
 } from "./vercel.js";
@@ -163,6 +164,50 @@ const clickStackConnectionSchema = z.discriminatedUnion("deployment", [
     returnTo: z.string().max(2_048).optional(),
   }),
 ]);
+const vercelCallbackSchema = z.object({
+  code: z.string().trim().min(1).max(2_048),
+  configurationId: z.string().regex(/^icfg_[A-Za-z0-9]+$/u),
+  teamId: z.string().regex(/^team_[A-Za-z0-9]+$/u).optional(),
+});
+
+type BrowserOAuthProvider =
+  | "clickstack"
+  | "custom_mcp"
+  | "github"
+  | "linear"
+  | "sentry"
+  | "slack"
+  | "vercel";
+
+async function consumeBrowserOAuthConnectionState(input: {
+  headers: Headers;
+  provider: BrowserOAuthProvider;
+  state: string;
+}): Promise<Awaited<ReturnType<typeof consumeIntegrationConnectionState>>> {
+  // Provider state proves that the callback belongs to a flow, but it does not
+  // prove that the browser completing that flow is the Responder user who
+  // started it. Authenticate before consuming state so signed-out callbacks do
+  // not destroy a legitimate user's pending flow.
+  const tenant = await getActiveTenant(input.headers);
+  if (tenant.ok === false) return null;
+
+  const connectionState = await consumeIntegrationConnectionState(
+    input.provider,
+    input.state,
+    {
+      organizationId: tenant.organizationId,
+      userId: tenant.user.id,
+    },
+  );
+  if (
+    !connectionState ||
+    connectionState.userId !== tenant.user.id ||
+    connectionState.organizationId !== tenant.organizationId
+  ) {
+    return null;
+  }
+  return connectionState;
+}
 
 function callbackErrorReason(error: unknown): string {
   if (error instanceof GitHubOAuthError) {
@@ -960,10 +1005,11 @@ export const integrationRoutes = new Hono()
     let accountId: string | undefined;
     let callbackErrorLogged = false;
     try {
-      connectionState = await consumeIntegrationConnectionState(
-        "custom_mcp",
+      connectionState = await consumeBrowserOAuthConnectionState({
+        headers: context.req.raw.headers,
+        provider: "custom_mcp",
         state,
-      );
+      });
       if (!connectionState) {
         console.error(
           JSON.stringify({
@@ -1087,10 +1133,11 @@ export const integrationRoutes = new Hono()
       );
     }
 
-    const connectionState = await consumeIntegrationConnectionState(
-      "linear",
+    const connectionState = await consumeBrowserOAuthConnectionState({
+      headers: context.req.raw.headers,
+      provider: "linear",
       state,
-    );
+    });
     if (!connectionState) {
       return context.redirect(
         settingsRedirect("/settings", "linear", "error", "invalid_state"),
@@ -1116,7 +1163,10 @@ export const integrationRoutes = new Hono()
       const connectedAccountId = await upsertIntegrationAccount({
         organizationId: connectionState.organizationId,
         provider: "linear",
-        externalAccountId: LINEAR_MCP_URL,
+        // A workspace is the external account. Keying every connection by the
+        // shared MCP URL would overwrite credentials in-place and silently
+        // redirect existing immutable agent versions to another workspace.
+        externalAccountId: workspace.id,
         displayName: workspace.name,
         encryptedCredentials: encryptCredentials(credentials),
         credentialKeyVersion: 1,
@@ -1282,10 +1332,11 @@ export const integrationRoutes = new Hono()
       );
     }
 
-    const connectionState = await consumeIntegrationConnectionState(
-      "clickstack",
+    const connectionState = await consumeBrowserOAuthConnectionState({
+      headers: context.req.raw.headers,
+      provider: "clickstack",
       state,
-    );
+    });
     if (!connectionState) {
       return context.redirect(
         settingsRedirect("/settings", "clickstack", "error", "invalid_state"),
@@ -1422,19 +1473,17 @@ export const integrationRoutes = new Hono()
         settingsRedirect("/settings", "vercel", "error", "invalid_state"),
       );
     }
-    const connectionState = await consumeIntegrationConnectionState(
-      "vercel",
+    const connectionState = await consumeBrowserOAuthConnectionState({
+      headers: context.req.raw.headers,
+      provider: "vercel",
       state,
-    );
+    });
     if (!connectionState) {
       return context.redirect(
         settingsRedirect("/settings", "vercel", "error", "invalid_state"),
       );
     }
-
-    const code = context.req.query("code");
-    const configurationId = context.req.query("configurationId");
-    if (!code || !configurationId) {
+    if (context.req.query("error")) {
       return context.redirect(
         settingsRedirect(
           connectionState.returnTo,
@@ -1444,37 +1493,74 @@ export const integrationRoutes = new Hono()
         ),
       );
     }
+    const callback = vercelCallbackSchema.safeParse({
+      code: context.req.query("code"),
+      configurationId: context.req.query("configurationId"),
+      teamId: context.req.query("teamId"),
+    });
+    if (!callback.success) {
+      return context.redirect(
+        settingsRedirect(
+          connectionState.returnTo,
+          "vercel",
+          "error",
+          "invalid_callback",
+        ),
+      );
+    }
 
     try {
       const token = await exchangeVercelCode({
-        code,
+        code: callback.data.code,
         redirectUri: integrationCallbackUrl("vercel"),
       });
-      const teamId = token.team_id ?? context.req.query("teamId") ?? null;
+      const teamId = token.team_id ?? null;
+      if (teamId !== (callback.data.teamId ?? null)) {
+        throw new Error("The Vercel callback team did not match the token");
+      }
+      const configuration = await getVercelConfiguration({
+        accessToken: token.access_token,
+        configurationId: callback.data.configurationId,
+        teamId,
+      });
       const account = await getVercelAccount({
         accessToken: token.access_token,
         teamId,
         userId: token.user_id,
       });
-      const projects = await listVercelProjects({
+      let projects = await listVercelProjects({
         accessToken: token.access_token,
         teamId,
       });
+      if (configuration.projectSelection === "selected") {
+        const selectedProjectIds = new Set(configuration.projects);
+        projects = projects.filter((project) =>
+          selectedProjectIds.has(project.externalId),
+        );
+        if (
+          new Set(projects.map((project) => project.externalId)).size !==
+          selectedProjectIds.size
+        ) {
+          throw new Error("The Vercel selected-project set could not be verified");
+        }
+      }
       const accountId = await upsertIntegrationAccount({
         organizationId: connectionState.organizationId,
         provider: "vercel",
-        externalAccountId: configurationId,
+        externalAccountId: callback.data.configurationId,
         displayName: account.displayName,
         encryptedCredentials: encryptCredentials({
           accessToken: token.access_token,
-          configurationId,
+          configurationId: callback.data.configurationId,
           teamId,
           userId: token.user_id ?? null,
         }),
         credentialKeyVersion: 1,
         metadata: {
           ...account.metadata,
-          configurationId,
+          configurationId: callback.data.configurationId,
+          projectSelection: configuration.projectSelection,
+          scopes: configuration.scopes,
           scopeExternalAccountId: account.externalAccountId,
         },
       });
@@ -1497,7 +1583,7 @@ export const integrationRoutes = new Hono()
       );
     } catch (error) {
       logCallbackError("Vercel", error, {
-        configurationId,
+        configurationId: callback.data.configurationId,
         organizationId: connectionState.organizationId,
       });
       return context.redirect(
@@ -1544,10 +1630,11 @@ export const integrationRoutes = new Hono()
       );
     }
 
-    const connectionState = await consumeIntegrationConnectionState(
-      "sentry",
+    const connectionState = await consumeBrowserOAuthConnectionState({
+      headers: context.req.raw.headers,
+      provider: "sentry",
       state,
-    );
+    });
     if (!connectionState) {
       return context.redirect(
         settingsRedirect("/settings", "sentry", "error", "invalid_state"),
@@ -1644,7 +1731,11 @@ export const integrationRoutes = new Hono()
       );
     }
 
-    const connectionState = await consumeIntegrationConnectionState("slack", state);
+    const connectionState = await consumeBrowserOAuthConnectionState({
+      headers: context.req.raw.headers,
+      provider: "slack",
+      state,
+    });
     if (!connectionState) {
       return context.redirect(
         settingsRedirect("/settings", "slack", "error", "invalid_state"),
@@ -1728,7 +1819,11 @@ export const integrationRoutes = new Hono()
       );
     }
 
-    const connectionState = await consumeIntegrationConnectionState("github", state);
+    const connectionState = await consumeBrowserOAuthConnectionState({
+      headers: context.req.raw.headers,
+      provider: "github",
+      state,
+    });
     if (!connectionState) {
       return context.redirect(
         settingsRedirect("/settings", "github", "error", "invalid_state"),

--- a/apps/control-plane/server/integrations/urls.test.ts
+++ b/apps/control-plane/server/integrations/urls.test.ts
@@ -26,4 +26,12 @@ describe("integration URLs", () => {
       "https://branch.responder.localhost/settings?integration=slack&status=connected",
     );
   });
+
+  it("rejects backslash-based cross-origin return paths", () => {
+    vi.stubEnv("BETTER_AUTH_URL", "https://responder.example");
+
+    expect(settingsRedirect("/\\evil.example", "slack", "connected")).toBe(
+      "https://responder.example/settings?integration=slack&status=connected",
+    );
+  });
 });

--- a/apps/control-plane/server/integrations/urls.ts
+++ b/apps/control-plane/server/integrations/urls.ts
@@ -24,10 +24,14 @@ export function settingsRedirect(
   status: "connected" | "error" | "finishing",
   reason?: string,
 ): string {
+  const baseUrl = new URL(controlPlaneBaseUrl());
   const path = returnTo.startsWith("/") && !returnTo.startsWith("//")
     ? returnTo
     : "/settings";
-  const url = new URL(path, controlPlaneBaseUrl());
+  const candidate = new URL(path, baseUrl);
+  const url = candidate.origin === baseUrl.origin
+    ? candidate
+    : new URL("/settings", baseUrl);
   url.searchParams.set("integration", provider);
   url.searchParams.set("status", status);
   if (reason) url.searchParams.set("reason", reason);

--- a/apps/control-plane/server/integrations/vercel.ts
+++ b/apps/control-plane/server/integrations/vercel.ts
@@ -44,6 +44,28 @@ const vercelProjectsPageSchema = z.object({
   }).optional(),
 });
 
+const vercelConfigurationSchema = z.object({
+  deletedAt: z.number().nullish(),
+  disabledAt: z.number().nullish(),
+  id: z.string().min(1),
+  projectSelection: z.enum(["all", "selected"]),
+  projects: z.array(z.string().min(1)).optional().default([]),
+  scopes: z.array(z.string().min(1)),
+  slug: z.string().min(1),
+  status: z
+    .enum([
+      "error",
+      "onboarding",
+      "pending",
+      "ready",
+      "resumed",
+      "suspended",
+      "uninstalled",
+    ])
+    .optional(),
+  teamId: z.string().min(1).nullish(),
+});
+
 function vercelEnvironment() {
   const integrationSlug = process.env.VERCEL_INTEGRATION_SLUG;
   const clientId = process.env.VERCEL_CLIENT_ID;
@@ -226,4 +248,46 @@ export async function listVercelProjects(input: {
   }
 
   throw new Error("Vercel project pagination exceeded the safety limit");
+}
+
+export async function getVercelConfiguration(input: {
+  accessToken: string;
+  configurationId: string;
+  teamId: string | null;
+}) {
+  const { integrationSlug } = vercelEnvironment();
+  const configuration = vercelConfigurationSchema.parse(
+    await vercelGet(
+      vercelApiUrl(
+        `/v1/integrations/configuration/${encodeURIComponent(input.configurationId)}`,
+        input.teamId,
+      ),
+      input.accessToken,
+      "Unable to verify the Vercel installation",
+    ),
+  );
+  const configurationTeamId = configuration.teamId ?? null;
+  if (
+    configuration.id !== input.configurationId ||
+    configuration.slug !== integrationSlug ||
+    configurationTeamId !== input.teamId
+  ) {
+    throw new Error("The Vercel installation identity did not match");
+  }
+  if (
+    configuration.deletedAt != null ||
+    configuration.disabledAt != null ||
+    configuration.status === "error" ||
+    configuration.status === "suspended" ||
+    configuration.status === "uninstalled"
+  ) {
+    throw new Error("The Vercel installation is not active");
+  }
+  if (
+    configuration.projectSelection === "selected" &&
+    configuration.projects.length === 0
+  ) {
+    throw new Error("The Vercel installation has no selected projects");
+  }
+  return configuration;
 }

--- a/apps/control-plane/server/investigations/queue.test.ts
+++ b/apps/control-plane/server/investigations/queue.test.ts
@@ -5,13 +5,13 @@ const mocks = vi.hoisted(() => ({
   bossSend: vi.fn(),
   bossStart: vi.fn(),
   bossStop: vi.fn(),
+  claimIssuePullRequestForRemediation: vi.fn(),
   consumeInvestigation: vi.fn(),
   discardPendingInvestigation: vi.fn(),
   failInvestigation: vi.fn(),
   failIssuePullRequest: vi.fn(),
   getIssuePullRequestForRemediation: vi.fn(),
   getRuntimeAgentConfig: vi.fn(),
-  markIssuePullRequestStarted: vi.fn(),
   notifyBillingLimitReached: vi.fn(),
   prepareWorkerQueues: vi.fn(),
   setIssuePullRequestSession: vi.fn(),
@@ -33,10 +33,11 @@ vi.mock("../../../../packages/core/src/db/investigations.js", () => ({
 }));
 
 vi.mock("../../../../packages/core/src/db/pull-requests.js", () => ({
+  claimIssuePullRequestForRemediation:
+    mocks.claimIssuePullRequestForRemediation,
   failIssuePullRequest: mocks.failIssuePullRequest,
   getIssuePullRequestForRemediation:
     mocks.getIssuePullRequestForRemediation,
-  markIssuePullRequestStarted: mocks.markIssuePullRequestStarted,
   setIssuePullRequestSession: mocks.setIssuePullRequestSession,
 }));
 
@@ -177,7 +178,7 @@ describe("investigation queue", () => {
     await expect(
       queueIssueRemediation(remediationRequest.requestId),
     ).rejects.toBe(error);
-    expect(mocks.markIssuePullRequestStarted).toHaveBeenCalledWith(
+    expect(mocks.claimIssuePullRequestForRemediation).toHaveBeenCalledWith(
       remediationRequest.requestId,
     );
     expect(mocks.failIssuePullRequest).toHaveBeenCalledWith(

--- a/apps/control-plane/server/production.ts
+++ b/apps/control-plane/server/production.ts
@@ -1,7 +1,7 @@
 import { serve } from "@hono/node-server";
+import { loadResponderSecrets } from "@responder/core/secrets";
 
-const secretsFile = process.env.RESPONDER_SECRETS_FILE;
-if (secretsFile) process.loadEnvFile(secretsFile);
+loadResponderSecrets();
 
 const { flushServerMonitoring, initializeServerMonitoring } = await import(
   "./monitoring.js"

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@aws-crypto/sha256-js": "5.2.0",
     "@daytona/sdk": "0.203.0",
-    "@daytonaio/sdk": "0.162.0",
+    "@daytonaio/sdk": "npm:@daytona/sdk@0.203.0",
     "@openai/agents": "0.14.2",
     "@openai/agents-extensions": "0.14.2",
     "@opentelemetry/api": "1.9.1",
@@ -25,7 +25,7 @@
     "@upstash/cli": "1.1.1",
     "@upstash/mcp-server": "0.2.7",
     "openai": "6.49.0",
-    "tsx": "4.20.6",
+    "tsx": "4.23.12",
     "zod": "4.4.3"
   }
 }

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -4,6 +4,8 @@ import {
   linearTicketJobSchema,
   linearTicketQueue,
   prepareWorkerQueues,
+  remediationJobSchema,
+  remediationQueue as remediationQueueName,
   type LinearTicketJob,
   type RemediationJob,
   responderJobSchema,
@@ -17,10 +19,12 @@ import {
   markInvestigationStarted,
 } from "@responder/core/db/investigations";
 import {
-  failIssuePullRequest,
   failPendingInvestigationPullRequests,
 } from "@responder/core/db/pull-requests";
-import { queueIssueRemediationJob } from "@responder/core/remediation-queue";
+import {
+  queueIssueRemediationJob,
+  recoverAbandonedIssueRemediations,
+} from "@responder/core/remediation-queue";
 import {
   queueLinearTicketJob,
   queuePendingLinearTicketJobs,
@@ -42,10 +46,6 @@ import {
   runInvestigationAgent,
   safeInvestigationError,
 } from "./investigate.js";
-import {
-  remediationRunDiagnostics,
-  runRemediationAgent,
-} from "./remediate.js";
 import { runLinearTicketJob } from "./linear-ticket-job.js";
 import {
   InvestigationReplayRequestProcessingError,
@@ -56,13 +56,14 @@ import {
   initializeErrorMonitoring,
   reportWorkerException,
 } from "./monitoring.js";
+import { processRemediationJob } from "./remediation-job.js";
+import { loadResponderSecrets } from "@responder/core/secrets";
 
-const secretsFile = process.env.RESPONDER_SECRETS_FILE;
-if (secretsFile) process.loadEnvFile(secretsFile);
+loadResponderSecrets();
 initializeErrorMonitoring();
 
 const boss = createJobBoss();
-const remediationQueue = {
+const remediationJobQueue = {
   send: (
     name: string,
     data: RemediationJob,
@@ -79,6 +80,7 @@ const linearTicketJobQueue = {
 let stopping = false;
 let replayRequestDrain: Promise<void> | undefined;
 let linearTicketDrain: Promise<void> | undefined;
+let remediationRecoveryDrain: Promise<void> | undefined;
 
 const replayRequestQueue = {
   send: (
@@ -162,6 +164,39 @@ function drainLinearTicketRequests(): Promise<void> {
   return linearTicketDrain;
 }
 
+function drainAbandonedRemediationRequests(): Promise<void> {
+  if (remediationRecoveryDrain) return remediationRecoveryDrain;
+  remediationRecoveryDrain = recoverAbandonedIssueRemediations(boss)
+    .then((requestIds) => {
+      if (requestIds.length === 0) return;
+      console.error(JSON.stringify({
+        event: "abandoned_remediations_recovered",
+        requestIds,
+      }));
+    })
+    .catch(async (error: unknown) => {
+      console.error(JSON.stringify({
+        error: error instanceof Error ? error.message : String(error),
+        event: "abandoned_remediation_recovery_failed",
+      }));
+      await reportWorkerException(error, { operation: "remediation" }).catch(
+        (reportError: unknown) => {
+          console.error(JSON.stringify({
+            error:
+              reportError instanceof Error
+                ? reportError.message
+                : String(reportError),
+            event: "abandoned_remediation_recovery_reporting_failed",
+          }));
+        },
+      );
+    })
+    .finally(() => {
+      remediationRecoveryDrain = undefined;
+    });
+  return remediationRecoveryDrain;
+}
+
 async function reportIncompleteSlackDelivery(input: {
   deliveryWarnings: string[];
   investigationId: string;
@@ -239,50 +274,16 @@ await boss.work(linearTicketQueue, { localConcurrency: 2 }, async ([job]) => {
     throw error;
   }
 });
+await boss.work(remediationQueueName, { localConcurrency: 1 }, async ([job]) => {
+  const payload = remediationJobSchema.parse(job.data);
+  return processRemediationJob(job.id, payload, process.env);
+});
 await boss.work(investigationQueue, { localConcurrency: 1 }, async ([job]) => {
   const payload = responderJobSchema.parse(job.data);
   if (payload.kind === "remediation") {
-    try {
-      await runRemediationAgent(payload, process.env);
-      await failIssuePullRequest(
-        payload.remediationRequestId,
-        "Remediation finished without creating a pull request",
-      );
-      console.log(
-        JSON.stringify({
-          event: "remediation_job_complete",
-          jobId: job.id,
-          requestId: payload.remediationRequestId,
-        }),
-      );
-    } catch (error) {
-      const message = safeInvestigationError(error);
-      let diagnostics: ReturnType<typeof remediationRunDiagnostics>;
-      try {
-        diagnostics = remediationRunDiagnostics(error, process.env);
-      } catch {
-        diagnostics = undefined;
-      }
-      await reportWorkerException(error, {
-        ...(diagnostics ? { diagnostics: { ...diagnostics } } : {}),
-        investigationId: payload.investigationId,
-        jobId: job.id,
-        operation: "remediation",
-        organizationId: payload.config.organizationId,
-        requestId: payload.remediationRequestId,
-      });
-      await failIssuePullRequest(payload.remediationRequestId, message);
-      console.error(
-        JSON.stringify({
-          ...(diagnostics ? { diagnostics } : {}),
-          error: message,
-          event: "remediation_job_failed",
-          jobId: job.id,
-          requestId: payload.remediationRequestId,
-        }),
-      );
-    }
-    return { requestId: payload.remediationRequestId };
+    // Drain jobs queued by older workers while all new remediations use the
+    // versioned exclusive queue above.
+    return processRemediationJob(job.id, payload, process.env);
   }
   await markInvestigationStarted(
     payload.investigationId,
@@ -328,7 +329,7 @@ await boss.work(investigationQueue, { localConcurrency: 1 }, async ([job]) => {
         const queued = await Promise.allSettled(
           requestIds.map(async (requestId) => {
             const result = await queueIssueRemediationJob(
-              remediationQueue,
+              remediationJobQueue,
               requestId,
             );
             console.log(
@@ -447,6 +448,7 @@ await boss.work(investigationQueue, { localConcurrency: 1 }, async ([job]) => {
 
 void drainInvestigationReplayRequests();
 void drainLinearTicketRequests();
+void drainAbandonedRemediationRequests();
 const replayRequestPoller = setInterval(
   () => void drainInvestigationReplayRequests(),
   2_000,
@@ -457,6 +459,11 @@ const linearTicketPoller = setInterval(
   10_000,
 );
 linearTicketPoller.unref();
+const remediationRecoveryPoller = setInterval(
+  () => void drainAbandonedRemediationRequests(),
+  5 * 60 * 1_000,
+);
+remediationRecoveryPoller.unref();
 
 console.log(JSON.stringify({ event: "worker_ready" }));
 
@@ -465,8 +472,10 @@ async function shutdown(signal: string): Promise<void> {
   stopping = true;
   clearInterval(replayRequestPoller);
   clearInterval(linearTicketPoller);
+  clearInterval(remediationRecoveryPoller);
   await replayRequestDrain;
   await linearTicketDrain;
+  await remediationRecoveryDrain;
   console.log(JSON.stringify({ event: "worker_stopping", signal }));
   try {
     await boss.stop({ graceful: true, timeout: 25_000 });

--- a/apps/worker/src/investigate.test.ts
+++ b/apps/worker/src/investigate.test.ts
@@ -178,11 +178,12 @@ describe("sandbox agent configuration", () => {
       datadogConnected: false,
       repositories: [],
       sentryConnected: false,
-      vercelAccounts: ["Acme"],
+      vercelAccountIds: ["04040404-0404-4404-8404-040404040404"],
     });
 
     expect(instructions).toContain("connected read-only Vercel tools");
     expect(instructions).toContain("Search the Vercel API catalog");
+    expect(instructions).toContain("04040404-0404-4404-8404-040404040404");
     expect(instructions).toContain("Never attempt to retrieve environment-variable values");
     expect(instructions).not.toContain("No observability data source is connected");
   });

--- a/apps/worker/src/investigate.ts
+++ b/apps/worker/src/investigate.ts
@@ -169,19 +169,19 @@ export function investigationInstructions(input: {
     environmentVariable: string;
     allowedHosts: string[];
   }>;
-  vercelAccounts?: string[];
+  vercelAccountIds?: string[];
 }): string {
   const awsAccountNames = input.awsAccountNames ?? [];
   const customMcpNames = input.customMcpNames ?? [];
   const slackChannels = input.slackChannels ?? [];
   const workspaceSecrets = input.workspaceSecrets ?? [];
-  const vercelAccounts = input.vercelAccounts ?? [];
+  const vercelAccountIds = input.vercelAccountIds ?? [];
   const observabilityConnected =
     input.datadogConnected ||
     input.sentryConnected ||
     input.clickStackConnected ||
     input.upstashConnected ||
-    vercelAccounts.length > 0 ||
+    vercelAccountIds.length > 0 ||
     awsAccountNames.length > 0 ||
     customMcpNames.length > 0;
   return [
@@ -206,8 +206,8 @@ export function investigationInstructions(input: {
     input.linearConnected
       ? "Use the connected Linear tools to inspect relevant project and issue context. Never use a Linear connection tool to write. If the saved report creates new issues, Responder queues a separate job to create the requested Linear tickets and record their identifiers and links."
       : null,
-    vercelAccounts.length > 0
-      ? `Use the connected read-only Vercel tools to inspect relevant projects, deployments, build and runtime logs, domains, and platform configuration. Search the Vercel API catalog before calling an operation. Never attempt to retrieve environment-variable values or other secrets. Connected Vercel accounts: ${vercelAccounts.join(", ")}.`
+    vercelAccountIds.length > 0
+      ? `Use the connected read-only Vercel tools to inspect selected projects, deployments, build and runtime logs, and project domains. Search the Vercel API catalog before calling an operation. Never attempt to retrieve environment-variable values or other secrets. Connected Vercel account IDs: ${vercelAccountIds.join(", ")}.`
       : null,
     customMcpNames.length > 0
       ? `Use the connected custom MCP tools when they can provide relevant evidence. Connected MCPs: ${customMcpNames.join(", ")}.`
@@ -454,7 +454,7 @@ export async function runInvestigationAgent(
       slackChannels: slackConnection?.channels,
       upstashConnected: upstashServer !== null,
       workspaceSecrets,
-      vercelAccounts: vercelConnections.map((connection) => connection.displayName),
+      vercelAccountIds: vercelConnections.map((connection) => connection.accountId),
     });
     // Save the same string passed to the agent so the trace never reconstructs it.
     await writeTrace(investigationInstructionsTraceEvent(instructions));
@@ -485,6 +485,7 @@ export async function runInvestigationAgent(
       const event = investigationTraceEventFromStream(
         streamEvent,
         environment,
+        new Date(),
       );
       if (event) await writeTrace(event);
     }

--- a/apps/worker/src/linear-ticket-job.ts
+++ b/apps/worker/src/linear-ticket-job.ts
@@ -57,6 +57,7 @@ export async function runLinearTicketJob(
           agentConfigVersionId: job.config.id,
           investigationId: job.investigationId,
           organizationId: job.config.organizationId,
+          requestId: job.requestId,
         })],
       });
       await run(agent, "Create the required Linear ticket now.", { maxTurns: 10 });

--- a/apps/worker/src/linear-ticket.test.ts
+++ b/apps/worker/src/linear-ticket.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fulfillLinearTicketRequest } from "@responder/core/db/linear-tickets";
+import { createLinearTicketTool } from "./linear-ticket.js";
+
+vi.mock("@responder/core/db/linear-tickets", () => ({
+  fulfillLinearTicketRequest: vi.fn(),
+}));
+
+describe("Linear ticket tool", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("binds the write to the queued request instead of model output", async () => {
+    vi.mocked(fulfillLinearTicketRequest).mockResolvedValue({
+      id: "linear-issue-id",
+      identifier: "OPS-42",
+      url: "https://linear.app/example/issue/OPS-42/example",
+    });
+    const tool = createLinearTicketTool({
+      agentConfigVersionId: "10000000-0000-4000-8000-000000000001",
+      investigationId: "10000000-0000-4000-8000-000000000002",
+      organizationId: "10000000-0000-4000-8000-000000000003",
+      requestId: "10000000-0000-4000-8000-000000000004",
+    });
+
+    await expect(tool.invoke(
+      undefined as never,
+      JSON.stringify({
+        projectId: "project-id",
+        requestId: "90000000-0000-4000-8000-000000000099",
+        teamId: "team-id",
+      }),
+    )).resolves.toMatchObject({
+      created: true,
+      linearIdentifier: "OPS-42",
+    });
+    expect(fulfillLinearTicketRequest).toHaveBeenCalledWith({
+      agentConfigVersionId: "10000000-0000-4000-8000-000000000001",
+      investigationId: "10000000-0000-4000-8000-000000000002",
+      organizationId: "10000000-0000-4000-8000-000000000003",
+      requestId: "10000000-0000-4000-8000-000000000004",
+      teamId: "team-id",
+      projectId: "project-id",
+    });
+  });
+});

--- a/apps/worker/src/linear-ticket.ts
+++ b/apps/worker/src/linear-ticket.ts
@@ -6,20 +6,20 @@ export function createLinearTicketTool(input: {
   agentConfigVersionId: string;
   investigationId: string;
   organizationId: string;
+  requestId: string;
 }) {
   return tool({
     name: "create_linear_ticket",
     description:
       "Create the Linear issue for a pending request returned by submit_investigation_report. Use Linear read tools first to choose the team and project. This tool applies the saved template and records the Linear identifier and link.",
     parameters: z.object({
-      requestId: z.uuid(),
       teamId: z.string().min(1),
       projectId: z.string().min(1).optional(),
     }),
     async execute(selection) {
       const issue = await fulfillLinearTicketRequest({
-        ...input,
         ...selection,
+        ...input,
       });
       return {
         created: true,

--- a/apps/worker/src/monitoring.test.ts
+++ b/apps/worker/src/monitoring.test.ts
@@ -76,13 +76,14 @@ describe("worker error monitoring", () => {
     ).toEqual({ message: "request failed for [redacted]" });
   });
 
-  it("reports the original exception and redacts its serialized event", async () => {
+  it("preserves stack frames while removing error and event secrets", async () => {
     const monitoring = await import("./monitoring.js");
     const environment = {
       DAYTONA_API_KEY: "daytona-secret",
       NODE_ENV: "production",
       SENTRY_DSN: "https://public@example.invalid/1",
       SENTRY_RELEASE: "abc123",
+      VERCEL_CLIENT_SECRET: "vercel-client-secret",
     };
 
     const originalError = new TypeError("request failed for daytona-secret");
@@ -129,7 +130,14 @@ describe("worker error monitoring", () => {
           },
         ],
       },
-      extra: { diagnostic: "request failed for daytona-secret" },
+      environment: "production",
+      extra: {
+        accessToken: "dynamic-provider-token",
+        authorization: "Bearer dynamic-provider-token",
+        diagnostic:
+          "request failed for daytona-secret and vercel-client-secret",
+        url: "https://example.invalid/callback?access_token=dynamic-provider-token",
+      },
     });
 
     expect(serializedEvent).toEqual(
@@ -149,18 +157,125 @@ describe("worker error monitoring", () => {
             }),
           ],
         },
-        extra: { diagnostic: "request failed for [redacted]" },
+        environment: "production",
+        extra: {
+          accessToken: "[redacted]",
+          authorization: "[redacted]",
+          diagnostic: "request failed for [redacted] and [redacted]",
+          url: "https://example.invalid/callback?access_token=[redacted]",
+        },
       }),
     );
     expect(sentryMocks.scope.setContext).toHaveBeenCalledWith(
       "responder",
       expect.objectContaining({ investigationId: "investigation-1" }),
     );
-    expect(sentryMocks.captureException).toHaveBeenCalledWith(originalError);
+    const capturedError = sentryMocks.captureException.mock.calls[0]?.[0] as Error;
+    expect(capturedError).not.toBe(originalError);
+    expect(capturedError.name).toBe("TypeError");
+    expect(capturedError.message).toBe("request failed for [redacted]");
+    expect(capturedError.stack).toContain(
+      "at runInvestigation (/app/apps/worker/src/investigate.ts:10:2)",
+    );
+    expect(capturedError.stack).not.toContain("daytona-secret");
     expect(sentryMocks.flush).not.toHaveBeenCalled();
 
     await expect(monitoring.flushWorkerMonitoring()).resolves.toBe(true);
     expect(sentryMocks.flush).toHaveBeenCalledWith(2_000);
+  });
+
+  it("redacts short explicit secrets and inferred key variants", async () => {
+    const monitoring = await import("./monitoring.js");
+    monitoring.initializeErrorMonitoring({
+      AUTUMN_SECRET_KEY: "autumn-value",
+      AWS_ACCESS_KEY: "access-value",
+      INTERNAL_INGEST_TOKEN: "tiny",
+      SENTRY_DSN: "https://public@example.invalid/1",
+    });
+
+    await monitoring.reportWorkerException(
+      new Error("request failed for tiny, autumn-value, and access-value"),
+      { operation: "worker" },
+    );
+
+    const processor = sentryMocks.addEventProcessor.mock.calls[0]?.[0] as (
+      event: Record<string, unknown>,
+    ) => Record<string, unknown>;
+    const event = processor({
+      extra: {
+        accessKey: "dynamic-access-key",
+        apiKey: "dynamic-api-key",
+        diagnostic:
+          "https://example.invalid/callback?client_secret=client-value&refresh-token=refresh-value&id_token=id-value&request_id=req-1",
+      },
+    });
+    const serialized = JSON.stringify(event);
+
+    expect(event).toEqual({
+      extra: {
+        accessKey: "[redacted]",
+        apiKey: "[redacted]",
+        diagnostic:
+          "https://example.invalid/callback?client_secret=[redacted]&refresh-token=[redacted]&id_token=[redacted]&request_id=req-1",
+      },
+    });
+    expect(serialized).not.toContain("client-value");
+    expect(serialized).not.toContain("refresh-value");
+    expect(serialized).not.toContain("id-value");
+
+    const capturedError = sentryMocks.captureException.mock.calls[0]?.[0] as Error;
+    expect(capturedError.message).toBe(
+      "request failed for [redacted], [redacted], and [redacted]",
+    );
+  });
+
+  it("redacts access-key query parameters while preserving diagnostics", async () => {
+    const monitoring = await import("./monitoring.js");
+    monitoring.initializeErrorMonitoring({
+      SENTRY_DSN: "https://public@example.invalid/1",
+    });
+
+    const processor = sentryMocks.addEventProcessor.mock.calls[0]?.[0] as (
+      event: Record<string, unknown>,
+    ) => Record<string, unknown>;
+    const event = processor({
+      extra: {
+        diagnostic:
+          "https://example.invalid/callback?access_key=underscored-value&AcCeSs-KeY=hyphenated-value&request_id=req-1&status=failed",
+      },
+    });
+
+    expect(event).toEqual({
+      extra: {
+        diagnostic:
+          "https://example.invalid/callback?access_key=[redacted]&AcCeSs-KeY=[redacted]&request_id=req-1&status=failed",
+      },
+    });
+  });
+
+  it("redacts complete error fields before truncating them", async () => {
+    const monitoring = await import("./monitoring.js");
+    const secret = "boundary-crossing-value";
+    monitoring.initializeErrorMonitoring({
+      DAYTONA_API_KEY: secret,
+      SENTRY_DSN: "https://public@example.invalid/1",
+    });
+
+    const originalError = new Error(`${"m".repeat(1_990)}${secret}`);
+    originalError.stack = [
+      `Error: ${originalError.message}`,
+      `    at operation (${"s".repeat(972)}${secret})`,
+    ].join("\n");
+    await monitoring.reportWorkerException(originalError, {
+      operation: "worker",
+    });
+
+    const capturedError = sentryMocks.captureException.mock.calls[0]?.[0] as Error;
+    expect(capturedError.message).toHaveLength(2_000);
+    expect(capturedError.message).toContain("[redacted]");
+    expect(capturedError.message).not.toContain("boundary-");
+    expect(capturedError.stack).toContain("[redacted]");
+    expect(capturedError.stack).not.toContain("boundary-");
   });
 
   it("attaches safe Slack diagnostics to delivery failures", async () => {
@@ -203,7 +318,12 @@ describe("worker error monitoring", () => {
         },
       ],
     });
-    expect(sentryMocks.captureException).toHaveBeenCalledWith(error);
+    const capturedError = sentryMocks.captureException.mock.calls[0]?.[0] as Error;
+    expect(capturedError).not.toBe(error);
+    expect(capturedError).toBeInstanceOf(Error);
+    expect(capturedError.message).toBe(
+      "Slack investigation delivery incomplete",
+    );
   });
 
   it("stores structured remediation diagnostics separately from identifiers", async () => {

--- a/apps/worker/src/monitoring.ts
+++ b/apps/worker/src/monitoring.ts
@@ -34,6 +34,34 @@ const secretEnvironmentNames = [
   "CREDENTIAL_ENCRYPTION_KEY",
   "INTERNAL_INGEST_TOKEN",
 ] as const;
+const secretEnvironmentName =
+  /(?:ACCESS_KEY|API_KEY|AUTH_TOKEN|CREDENTIAL|DATABASE_URL|DSN|PASSWORD|PRIVATE_KEY|SECRET(?:_KEY)?|TOKEN)$/iu;
+const secretEventKey =
+  /(?:access[_-]?key|api[_-]?key|authorization|cookie|credential|password|private[_-]?key|secret|token)|^(?:buildEnv|env|envs|environmentVariables?)$/iu;
+
+function eventSecrets(environment: NodeJS.ProcessEnv): string[] {
+  const explicitNames = new Set<string>(secretEnvironmentNames);
+  return Object.entries(environment).flatMap(([name, value]) =>
+    value &&
+    (explicitNames.has(name) ||
+      (value.length >= 8 && secretEnvironmentName.test(name)))
+      ? [value]
+      : [],
+  );
+}
+
+function redactString(value: string, secrets: readonly string[]): string {
+  return secrets
+    .reduce(
+      (redacted, secret) => redacted.replaceAll(secret, "[redacted]"),
+      value,
+    )
+    .replace(/\b(Bearer|Basic)\s+[^\s,;]+/giu, "$1 [redacted]")
+    .replace(
+      /([?&](?:access[_-]?(?:key|token)|api[_-]?key|client[_-]?secret|id[_-]?token|password|refresh[_-]?token|secret|token)=)[^&#\s]+/giu,
+      "$1[redacted]",
+    );
+}
 
 function redactEventValue(
   value: unknown,
@@ -41,10 +69,7 @@ function redactEventValue(
   seen: WeakSet<object>,
 ): unknown {
   if (typeof value === "string") {
-    return secrets.reduce(
-      (redacted, secret) => redacted.replaceAll(secret, "[redacted]"),
-      value,
-    );
+    return redactString(value, secrets);
   }
   if (!value || typeof value !== "object" || seen.has(value)) return value;
 
@@ -58,19 +83,43 @@ function redactEventValue(
 
   const record = value as Record<string, unknown>;
   for (const [key, item] of Object.entries(record)) {
-    record[key] = redactEventValue(item, secrets, seen);
+    record[key] = secretEventKey.test(key)
+      ? "[redacted]"
+      : redactEventValue(item, secrets, seen);
   }
   return record;
+}
+
+function errorForMonitoring(
+  error: unknown,
+  secrets: readonly string[],
+): Error {
+  if (!(error instanceof Error)) {
+    return new Error("Worker operation failed with a non-Error exception");
+  }
+
+  const message = redactString(error.message, secrets).slice(0, 2_000);
+  const sanitized = new Error(message || "Worker operation failed");
+  sanitized.name = error.name;
+  if (error.stack) {
+    const frames = error.stack
+      .split("\n")
+      .slice(1)
+      .filter((line) => /^\s+at\s/u.test(line))
+      .slice(0, 100)
+      .map((line) => redactString(line, secrets).slice(0, 1_000));
+    sanitized.stack = [`${sanitized.name}: ${sanitized.message}`, ...frames].join(
+      "\n",
+    );
+  }
+  return sanitized;
 }
 
 function scrubWorkerSentryEvent(
   event: Event,
   environment: NodeJS.ProcessEnv,
 ): Event {
-  const secrets = secretEnvironmentNames.flatMap((name) => {
-    const value = environment[name];
-    return value ? [value] : [];
-  });
+  const secrets = eventSecrets(environment);
   redactEventValue(event, secrets, new WeakSet());
 
   for (const exception of event.exception?.values ?? []) {
@@ -142,7 +191,9 @@ export async function reportWorkerException(
       if (context.operation === "slack_delivery") {
         scope.setContext("slack", slackErrorLogFields(error));
       }
-      Sentry.captureException(error);
+      Sentry.captureException(
+        errorForMonitoring(error, eventSecrets(eventScrubbingEnvironment)),
+      );
     });
   } catch (reportingError) {
     console.error(

--- a/apps/worker/src/remediation-job.test.ts
+++ b/apps/worker/src/remediation-job.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { RemediationJob } from "@responder/core/jobs";
+import { processRemediationJob } from "./remediation-job.js";
+
+const payload: RemediationJob = {
+  kind: "remediation",
+  config: {
+    agentId: "13131313-1313-4313-8313-131313131313",
+    id: "08080808-0808-4808-8808-080808080808",
+    model: "instance/default",
+    organizationId: "15151515-1515-4515-8515-151515151515",
+    prMode: "manual",
+    prompt: "Fix the issue carefully.",
+  },
+  investigationId: "16161616-1616-4616-8616-161616161616",
+  issue: {
+    id: "10101010-1010-4010-8010-101010101010",
+    title: "Broken route",
+    description: "The route throws.",
+    severity: "SEV-2",
+    remediation: "Handle the missing value.",
+    evidence: [],
+  },
+  queuedAt: "2026-08-17T12:00:00.000Z",
+  remediationRequestId: "05050505-0505-4505-8505-050505050505",
+  runtimeProfileId: "19191919-1919-4919-8919-191919191919",
+};
+
+describe("remediation job terminal state", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("records the terminal failure even when monitoring is unavailable", async () => {
+    const agentError = new Error("agent failed");
+    const diagnostics = {
+      applyPatchFailures: [
+        {
+          callId: "call-1",
+          error: "Invalid Context 12",
+          operation: "update_file" as const,
+          path: "/workspace/repository/src/index.ts",
+        },
+      ],
+      completedTurns: 40,
+      maxTurns: 40,
+    };
+    const failRequest = vi.fn().mockResolvedValue(undefined);
+    const reportException = vi.fn(() => {
+      throw new Error("monitoring unavailable");
+    });
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    await expect(
+      processRemediationJob("job-id", payload, {}, {
+        failRequest,
+        reportException,
+        runDiagnostics: vi.fn(() => diagnostics),
+        runAgent: vi.fn().mockRejectedValue(agentError),
+      }),
+    ).resolves.toEqual({ requestId: payload.remediationRequestId });
+
+    expect(failRequest).toHaveBeenCalledWith(
+      payload.remediationRequestId,
+      "agent failed",
+    );
+    expect(reportException).toHaveBeenCalledWith(
+      agentError,
+      expect.objectContaining({
+        diagnostics,
+        jobId: "job-id",
+        requestId: payload.remediationRequestId,
+      }),
+    );
+    expect(consoleError).toHaveBeenCalledWith(
+      JSON.stringify({
+        diagnostics,
+        error: "agent failed",
+        event: "remediation_job_failed",
+        jobId: "job-id",
+        requestId: payload.remediationRequestId,
+      }),
+    );
+    expect(consoleError).toHaveBeenCalledWith(
+      JSON.stringify({
+        error: "monitoring unavailable",
+        event: "remediation_error_reporting_failed",
+        jobId: "job-id",
+        requestId: payload.remediationRequestId,
+      }),
+    );
+  });
+
+  it("fails the queue job when the terminal database write is unavailable", async () => {
+    const databaseError = new Error("database unavailable");
+    const reportException = vi.fn().mockResolvedValue(undefined);
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    await expect(
+      processRemediationJob("job-id", payload, {}, {
+        failRequest: vi.fn().mockRejectedValue(databaseError),
+        reportException,
+        runDiagnostics: vi.fn(() => undefined),
+        runAgent: vi.fn().mockRejectedValue(new Error("agent failed")),
+      }),
+    ).rejects.toThrow("Unable to record remediation failure");
+
+    expect(reportException).toHaveBeenCalledOnce();
+    expect(consoleError).toHaveBeenCalledWith(
+      JSON.stringify({
+        error: "database unavailable",
+        event: "remediation_failure_recording_failed",
+        jobId: "job-id",
+        requestId: payload.remediationRequestId,
+      }),
+    );
+  });
+
+  it("records a no-pull-request result without reporting an exception", async () => {
+    const failRequest = vi.fn().mockResolvedValue(undefined);
+    const reportException = vi.fn();
+    vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await expect(
+      processRemediationJob("job-id", payload, {}, {
+        failRequest,
+        reportException,
+        runDiagnostics: vi.fn(() => undefined),
+        runAgent: vi.fn().mockResolvedValue("No safe change was available"),
+      }),
+    ).resolves.toEqual({ requestId: payload.remediationRequestId });
+
+    expect(failRequest).toHaveBeenCalledWith(
+      payload.remediationRequestId,
+      "Remediation finished without creating a pull request",
+    );
+    expect(reportException).not.toHaveBeenCalled();
+  });
+
+  it("does not let unreadable diagnostics mask a remediation failure", async () => {
+    const agentError = new Error("agent failed");
+    const failRequest = vi.fn().mockResolvedValue(undefined);
+    const reportException = vi.fn().mockResolvedValue(undefined);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(
+      processRemediationJob("job-id", payload, {}, {
+        failRequest,
+        reportException,
+        runDiagnostics: vi.fn(() => {
+          throw new Error("unreadable diagnostics");
+        }),
+        runAgent: vi.fn().mockRejectedValue(agentError),
+      }),
+    ).resolves.toEqual({ requestId: payload.remediationRequestId });
+
+    expect(failRequest).toHaveBeenCalledWith(
+      payload.remediationRequestId,
+      "agent failed",
+    );
+    expect(reportException).toHaveBeenCalledOnce();
+    expect(reportException.mock.calls[0]?.[1]).not.toHaveProperty("diagnostics");
+  });
+});

--- a/apps/worker/src/remediation-job.ts
+++ b/apps/worker/src/remediation-job.ts
@@ -1,0 +1,128 @@
+import { failIssuePullRequest } from "@responder/core/db/pull-requests";
+import type { RemediationJob } from "@responder/core/jobs";
+import {
+  remediationRunDiagnostics,
+  runRemediationAgent,
+} from "./remediate.js";
+import { safeInvestigationError } from "./investigate.js";
+import { reportWorkerException } from "./monitoring.js";
+
+interface RemediationJobDependencies {
+  failRequest: typeof failIssuePullRequest;
+  reportException: typeof reportWorkerException;
+  runDiagnostics: typeof remediationRunDiagnostics;
+  runAgent: typeof runRemediationAgent;
+}
+
+const defaultDependencies: RemediationJobDependencies = {
+  failRequest: failIssuePullRequest,
+  reportException: reportWorkerException,
+  runDiagnostics: remediationRunDiagnostics,
+  runAgent: runRemediationAgent,
+};
+
+export async function processRemediationJob(
+  jobId: string,
+  payload: RemediationJob,
+  environment: NodeJS.ProcessEnv = process.env,
+  dependencies: RemediationJobDependencies = defaultDependencies,
+): Promise<{ requestId: string }> {
+  let failure: unknown;
+  let reportFailure = false;
+
+  try {
+    await dependencies.runAgent(payload, environment);
+    failure = new Error(
+      "Remediation finished without creating a pull request",
+    );
+  } catch (error) {
+    failure = error;
+    reportFailure = true;
+  }
+
+  const message = safeInvestigationError(failure, environment);
+  let diagnostics: ReturnType<typeof remediationRunDiagnostics> = undefined;
+  if (reportFailure) {
+    try {
+      diagnostics = dependencies.runDiagnostics(failure, environment);
+    } catch {
+      diagnostics = undefined;
+    }
+  }
+  if (reportFailure) {
+    console.error(
+      JSON.stringify({
+        ...(diagnostics ? { diagnostics } : {}),
+        error: message,
+        event: "remediation_job_failed",
+        jobId,
+        requestId: payload.remediationRequestId,
+      }),
+    );
+  }
+
+  const recording = Promise.resolve().then(() =>
+    dependencies.failRequest(payload.remediationRequestId, message)
+  );
+  const reporting =
+    reportFailure
+      ? Promise.resolve().then(() =>
+          dependencies.reportException(failure, {
+            ...(diagnostics ? { diagnostics: { ...diagnostics } } : {}),
+            investigationId: payload.investigationId,
+            jobId,
+            operation: "remediation",
+            organizationId: payload.config.organizationId,
+            requestId: payload.remediationRequestId,
+          })
+        )
+      : Promise.resolve();
+  const [recordingResult, reportingResult] = await Promise.allSettled([
+    recording,
+    reporting,
+  ]);
+
+  if (reportingResult.status === "rejected") {
+    console.error(
+      JSON.stringify({
+        error: safeInvestigationError(reportingResult.reason, environment),
+        event: "remediation_error_reporting_failed",
+        jobId,
+        requestId: payload.remediationRequestId,
+      }),
+    );
+  }
+
+  if (recordingResult.status === "rejected") {
+    console.error(
+      JSON.stringify({
+        error: safeInvestigationError(recordingResult.reason, environment),
+        event: "remediation_failure_recording_failed",
+        jobId,
+        requestId: payload.remediationRequestId,
+      }),
+    );
+    throw new AggregateError(
+      [
+        failure,
+        recordingResult.reason,
+        ...(reportingResult.status === "rejected"
+          ? [reportingResult.reason]
+          : []),
+      ],
+      "Unable to record remediation failure",
+    );
+  }
+
+  if (!reportFailure) {
+    console.log(
+      JSON.stringify({
+        event: "remediation_job_complete",
+        jobId,
+        requestId: payload.remediationRequestId,
+      }),
+    );
+  }
+
+  return { requestId: payload.remediationRequestId };
+}

--- a/apps/worker/src/send-health-job.ts
+++ b/apps/worker/src/send-health-job.ts
@@ -3,9 +3,9 @@ import {
   prepareWorkerQueues,
   workerHealthQueue,
 } from "@responder/core/jobs";
+import { loadResponderSecrets } from "@responder/core/secrets";
 
-const secretsFile = process.env.RESPONDER_SECRETS_FILE;
-if (secretsFile) process.loadEnvFile(secretsFile);
+loadResponderSecrets();
 
 const marker = process.env.WORKER_HEALTH_MARKER;
 if (!marker) throw new Error("WORKER_HEALTH_MARKER is required");

--- a/apps/worker/src/trace.test.ts
+++ b/apps/worker/src/trace.test.ts
@@ -148,6 +148,37 @@ describe("investigation trace events", () => {
     expect(JSON.stringify(event)).toContain("[secret placeholder redacted]");
   });
 
+  it("retains sanitized provider output for later debugging", () => {
+    const event = investigationTraceEventFromStream(
+      {
+        type: "run_item_stream_event",
+        name: "tool_output",
+        item: {
+          callId: "call_provider",
+          output: {
+            authorization: "Bearer hidden",
+            log: "database request timed out after 30 seconds",
+          },
+          rawItem: { status: "completed" },
+        },
+      } as never,
+      {},
+      at,
+    );
+
+    expect(event?.data).toEqual({
+      result: {
+        callId: "call_provider",
+        kind: "tool-result",
+        output: {
+          authorization: "[redacted]",
+          log: "database request timed out after 30 seconds",
+        },
+      },
+      status: "completed",
+    });
+  });
+
   it("ignores token-by-token model events", () => {
     expect(
       investigationTraceEventFromStream(

--- a/apps/worker/src/trace.ts
+++ b/apps/worker/src/trace.ts
@@ -159,6 +159,7 @@ export function investigationTraceEventFromStream(
 
   if (event.name === "tool_called") {
     const callId = text(item.callId) ?? text(raw.callId) ?? text(raw.id);
+    const name = toolName(item, raw);
     return traceEvent(
       "actions.requested",
       {
@@ -167,7 +168,7 @@ export function investigationTraceEventFromStream(
             callId,
             input: safeTraceValue(toolInput(raw), environment),
             kind: "tool-call",
-            toolName: toolName(item, raw),
+            toolName: name,
           },
         ],
       },

--- a/apps/worker/src/upstash-fetch-guard.mjs
+++ b/apps/worker/src/upstash-fetch-guard.mjs
@@ -1,0 +1,163 @@
+/* global AbortSignal, Request, Response */
+
+import process from "node:process";
+import { ReadableStream } from "node:stream/web";
+import { URL } from "node:url";
+
+const DEFAULT_MAXIMUM_RESPONSE_BYTES = 1_048_576;
+const REQUEST_TIMEOUT_MS = 30_000;
+const RESPONSE_LIMIT_ERROR =
+  "Upstash response exceeded the 1 MiB investigation limit; narrow the query";
+const TIMEOUT_ERROR = "Upstash request exceeded the investigation timeout";
+const READONLY_PROBE_URL =
+  "https://api.upstash.com/v2/redis/database/readonly-check-nonexistent";
+
+function requestUrl(input) {
+  if (input instanceof Request) return new URL(input.url);
+  if (input instanceof URL) return input;
+  return new URL(input);
+}
+
+function requestMethod(input, init) {
+  return (init?.method ?? (input instanceof Request ? input.method : "GET"))
+    .toUpperCase();
+}
+
+function validateUpstashRequest(url, method) {
+  if (
+    url.protocol !== "https:" ||
+    url.username ||
+    url.password ||
+    url.hash ||
+    (url.port && url.port !== "443")
+  ) {
+    throw new Error("The Upstash child attempted an invalid request URL");
+  }
+  if (url.hostname === "api.upstash.com") {
+    if (method !== "GET") {
+      throw new Error("The Upstash child attempted a management API mutation");
+    }
+    return;
+  }
+  if (!url.hostname.endsWith(".upstash.io")) {
+    throw new Error("The Upstash child attempted an unexpected request origin");
+  }
+  if (method !== "GET" && method !== "POST") {
+    throw new Error("The Upstash child attempted an unsupported request method");
+  }
+}
+
+async function boundedResponse(
+  response,
+  maximumResponseBytes,
+  timeoutSignal,
+  existingSignal,
+) {
+  if (!response.body) return response;
+
+  const declaredLength = Number(response.headers.get("content-length"));
+  if (
+    Number.isFinite(declaredLength) &&
+    declaredLength > maximumResponseBytes
+  ) {
+    await response.body.cancel();
+    throw new Error(RESPONSE_LIMIT_ERROR);
+  }
+
+  const reader = response.body.getReader();
+  let receivedBytes = 0;
+  const body = new ReadableStream({
+    async pull(controller) {
+      try {
+        const chunk = await reader.read();
+        if (chunk.done) {
+          controller.close();
+          return;
+        }
+        receivedBytes += chunk.value.byteLength;
+        if (receivedBytes > maximumResponseBytes) {
+          await reader.cancel();
+          controller.error(new Error(RESPONSE_LIMIT_ERROR));
+          return;
+        }
+        controller.enqueue(chunk.value);
+      } catch (error) {
+        controller.error(
+          timeoutSignal.aborted && !existingSignal?.aborted
+            ? new Error(TIMEOUT_ERROR)
+            : error,
+        );
+      }
+    },
+    cancel(reason) {
+      return reader.cancel(reason);
+    },
+  });
+
+  return new Response(body, {
+    headers: response.headers,
+    status: response.status,
+    statusText: response.statusText,
+  });
+}
+
+export function createBoundedUpstashFetch(
+  fetchImplementation = globalThis.fetch,
+  maximumResponseBytes = DEFAULT_MAXIMUM_RESPONSE_BYTES,
+  requestTimeoutMs = REQUEST_TIMEOUT_MS,
+) {
+  if (
+    !Number.isSafeInteger(maximumResponseBytes) ||
+    maximumResponseBytes < 1
+  ) {
+    throw new Error("The Upstash response limit is invalid");
+  }
+  if (!Number.isSafeInteger(requestTimeoutMs) || requestTimeoutMs < 1) {
+    throw new Error("The Upstash request timeout is invalid");
+  }
+
+  return async function guardedUpstashFetch(input, init) {
+    const url = requestUrl(input);
+    const method = requestMethod(input, init);
+
+    // The upstream server probes write access with DELETE and only selects the
+    // provider's read-only Redis/QStash tokens after receiving this response.
+    // Answer locally so startup never performs a mutation-shaped request.
+    if (url.href === READONLY_PROBE_URL && method === "DELETE") {
+      return new Response("Readonly API key", {
+        status: 403,
+        statusText: "Forbidden",
+      });
+    }
+
+    validateUpstashRequest(url, method);
+    const existingSignal =
+      init?.signal ?? (input instanceof Request ? input.signal : undefined);
+    const timeoutSignal = AbortSignal.timeout(requestTimeoutMs);
+    let response;
+    try {
+      response = await fetchImplementation(input, {
+        ...init,
+        redirect: "error",
+        signal: existingSignal
+          ? AbortSignal.any([existingSignal, timeoutSignal])
+          : timeoutSignal,
+      });
+    } catch (error) {
+      if (timeoutSignal.aborted && !existingSignal?.aborted) {
+        throw new Error(TIMEOUT_ERROR);
+      }
+      throw error;
+    }
+    return boundedResponse(
+      response,
+      maximumResponseBytes,
+      timeoutSignal,
+      existingSignal,
+    );
+  };
+}
+
+if (process.env.RESPONDER_UPSTASH_FETCH_GUARD === "1") {
+  globalThis.fetch = createBoundedUpstashFetch();
+}

--- a/apps/worker/src/upstash.test.ts
+++ b/apps/worker/src/upstash.test.ts
@@ -36,6 +36,7 @@ function upstreamServer() {
         name: "workflow_logs_list",
         inputSchema: {
           properties: {
+            count: { type: "number" },
             local_mode_port: { type: "number" },
             qstash_creds: { type: "object" },
             region: { enum: ["eu", "us", "local"] },
@@ -73,6 +74,7 @@ describe("Upstash investigation context", () => {
         name: "workflow_logs_list",
         inputSchema: expect.objectContaining({
           properties: {
+            count: expect.objectContaining({ default: 10, maximum: 10 }),
             region: expect.objectContaining({ enum: ["eu", "us"] }),
           },
         }),
@@ -80,10 +82,10 @@ describe("Upstash investigation context", () => {
       expect.objectContaining({
         name: "redis_database_run_redis_commands",
         inputSchema: expect.objectContaining({
-          properties: {
+          properties: expect.objectContaining({
             commands: { type: "array" },
-            database_id: { type: "string" },
-          },
+            database_id: expect.objectContaining({ type: "string" }),
+          }),
         }),
       }),
     ]);
@@ -114,6 +116,15 @@ describe("Upstash investigation context", () => {
     await expect(
       scoped.callTool("workflow_dlq_list", { count: 101, region: "eu" }),
     ).rejects.toThrow("limited to 100 items");
+    await expect(
+      scoped.callTool("workflow_logs_list", { count: 11, region: "eu" }),
+    ).rejects.toThrow("limited to 10 items");
+    await expect(
+      scoped.callTool("qstash_logs_list", { cursor: "x".repeat(4_097) }),
+    ).rejects.toThrow("cursor is invalid");
+    await expect(
+      scoped.callTool("workflow_logs_list", { workflowUrl: "file:///tmp/log" }),
+    ).rejects.toThrow("workflowUrl is invalid");
     expect(callTool).not.toHaveBeenCalled();
   });
 
@@ -127,9 +138,140 @@ describe("Upstash investigation context", () => {
     expect(() =>
       validateUpstashRedisCommands({
         database_id: "db-1",
+        commands: [["SCAN", "0"]],
+      }),
+    ).toThrow("requires a bounded COUNT");
+    expect(() =>
+      validateUpstashRedisCommands({
+        database_id: "db-1",
         commands: [["SET", "status", "ok"]],
       }),
     ).toThrow("Redis command SET is not allowed");
+    expect(() =>
+      validateUpstashRedisCommands({
+        database_id: "db-1",
+        commands: [["PFCOUNT", "visitors"]],
+      }),
+    ).toThrow("Redis command PFCOUNT is not allowed");
+    expect(() =>
+      validateUpstashRedisCommands({
+        database_id: "db-1",
+        commands: [["LRANGE", "events", "0", "100"]],
+      }),
+    ).toThrow("range is limited to 100 items");
+    expect(() =>
+      validateUpstashRedisCommands({
+        database_id: "db-1",
+        commands: [["LRANGE", "events", "-100", "-1"]],
+      }),
+    ).not.toThrow();
+    expect(() =>
+      validateUpstashRedisCommands({
+        database_id: "db-1",
+        commands: [["LRANGE", "events", "0", "-1"]],
+      }),
+    ).toThrow("range is limited to 100 items");
+    expect(() =>
+      validateUpstashRedisCommands({
+        database_id: "db-1",
+        commands: [["XRANGE", "events", "-", "+"]],
+      }),
+    ).toThrow("requires a bounded COUNT");
+    expect(() =>
+      validateUpstashRedisCommands({
+        database_id: "db-1",
+        commands: [["XRANGE", "events", "-", "+", "COUNT", "100"]],
+      }),
+    ).not.toThrow();
+    expect(() =>
+      validateUpstashRedisCommands({
+        database_id: "db-1",
+        commands: [["XRANGE", "COUNT", "1", "100"]],
+      }),
+    ).toThrow("requires a bounded COUNT");
+    expect(() =>
+      validateUpstashRedisCommands({
+        database_id: "db-1",
+        commands: [["ZRANGEBYSCORE", "LIMIT", "0", "100"]],
+      }),
+    ).toThrow("requires a bounded LIMIT");
+    expect(() =>
+      validateUpstashRedisCommands({
+        database_id: "db-1",
+        commands: [["GEOSEARCH", "places", "FROMMEMBER", "here", "BYRADIUS", "5", "km", "COUNT", "100", "ANY"]],
+      }),
+    ).not.toThrow();
+    expect(() =>
+      validateUpstashRedisCommands({
+        database_id: "db-1",
+        commands: [["GEOSEARCH", "places", "FROMMEMBER", "here", "BYRADIUS", "5", "km", "COUNT", "100"]],
+      }),
+    ).toThrow("requires COUNT with ANY");
+    expect(() =>
+      validateUpstashRedisCommands({
+        database_id: "db-1",
+        commands: [["GETRANGE", "payload", "0", "65535"]],
+      }),
+    ).not.toThrow();
+    expect(() =>
+      validateUpstashRedisCommands({
+        database_id: "db-1",
+        commands: [["GETRANGE", "payload", "0", "65536"]],
+      }),
+    ).toThrow("limited to 64 KiB");
+    expect(() =>
+      validateUpstashRedisCommands({
+        database_id: "db-1",
+        commands: [["GETRANGE", "payload", "-65536", "-1"]],
+      }),
+    ).not.toThrow();
+    expect(() =>
+      validateUpstashRedisCommands({
+        database_id: "db-1",
+        commands: [["XINFO", "STREAM", "events"]],
+      }),
+    ).not.toThrow();
+    expect(() =>
+      validateUpstashRedisCommands({
+        database_id: "db-1",
+        commands: [["XINFO", "GROUPS", "events"]],
+      }),
+    ).toThrow("Only bounded XINFO STREAM");
+    expect(() =>
+      validateUpstashRedisCommands({
+        database_id: "db-1",
+        commands: [["MEMORY", "USAGE", "cache", "SAMPLES", "100"]],
+      }),
+    ).not.toThrow();
+    expect(() =>
+      validateUpstashRedisCommands({
+        database_id: "db-1",
+        commands: [["MEMORY", "USAGE", "cache", "SAMPLES", "0"]],
+      }),
+    ).toThrow("samples are limited to 100");
+    for (const command of [
+      "HGETALL",
+      "HKEYS",
+      "HVALS",
+      "JSON.OBJKEYS",
+      "SMEMBERS",
+    ]) {
+      expect(() =>
+        validateUpstashRedisCommands({
+          database_id: "db-1",
+          commands: [[command, "collection"]],
+        }),
+      ).toThrow(`Redis command ${command} is not allowed`);
+    }
+    expect(() =>
+      validateUpstashRedisCommands({
+        database_id: "db-1",
+        commands: Array.from({ length: 20 }, () => [
+          "MGET",
+          ...Array.from({ length: 20 }, () => "界".repeat(1_000)),
+        ]),
+      }),
+    ).toThrow("exceed the 64 KiB request limit");
     expect(() =>
       validateUpstashRedisCommands({
         database_rest_token: "direct-token",
@@ -142,10 +284,92 @@ describe("Upstash investigation context", () => {
     const scoped = new ScopedUpstashMcpServer(server, connection);
     await expect(
       scoped.callTool("redis_database_get_statistics", {
-        database_id: "../../qstash/user",
+        id: "../../qstash/user",
+        period: "1h",
       }),
-    ).rejects.toThrow("database_id is invalid");
+    ).rejects.toThrow("id is invalid");
     expect(callTool).not.toHaveBeenCalled();
+
+    await scoped.callTool("redis_database_get_statistics", {
+      id: "db-1",
+      period: "1h",
+    });
+    expect(callTool).toHaveBeenCalledWith(
+      "redis_database_get_statistics",
+      { id: "db-1", period: "1h" },
+      undefined,
+      undefined,
+    );
+  });
+
+  it("bounds utility and QStash filter inputs without rejecting opaque cursors", async () => {
+    const { callTool, server } = upstreamServer();
+    const scoped = new ScopedUpstashMcpServer(server, connection);
+
+    await expect(
+      scoped.callTool("util_dates_to_timestamps", {
+        dates: Array.from({ length: 101 }, () => "2026-08-17"),
+      }),
+    ).rejects.toThrow("limited to 100 values");
+    await expect(
+      scoped.callTool("util_timestamps_to_date", {
+        timestamps: Array.from({ length: 101 }, (_, index) => index),
+      }),
+    ).rejects.toThrow("limited to 100 values");
+    await scoped.callTool("qstash_logs_list", {
+      cursor: "opaque/+/cursor==",
+      url: "http://service.example/jobs?id=123",
+    });
+    expect(callTool).toHaveBeenCalledWith(
+      "qstash_logs_list",
+      {
+        count: 25,
+        cursor: "opaque/+/cursor==",
+        url: "http://service.example/jobs?id=123",
+      },
+      undefined,
+      undefined,
+    );
+
+    await scoped.callTool("workflow_logs_list", {});
+    expect(callTool).toHaveBeenLastCalledWith(
+      "workflow_logs_list",
+      { count: 10 },
+      undefined,
+      undefined,
+    );
+  });
+
+  it("limits aggregate Upstash child operations to two", async () => {
+    const { callTool, server } = upstreamServer();
+    let active = 0;
+    let maximumActive = 0;
+    const releases: Array<() => void> = [];
+    callTool.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          active += 1;
+          maximumActive = Math.max(maximumActive, active);
+          releases.push(() => {
+            active -= 1;
+            resolve([]);
+          });
+        }),
+    );
+    const scoped = new ScopedUpstashMcpServer(server, connection);
+    const calls = Array.from({ length: 4 }, () =>
+      scoped.callTool("workflow_logs_list", {}),
+    );
+
+    await vi.waitFor(() => expect(callTool).toHaveBeenCalledTimes(2));
+    releases.shift()?.();
+    await vi.waitFor(() => expect(callTool).toHaveBeenCalledTimes(3));
+    releases.shift()?.();
+    await vi.waitFor(() => expect(callTool).toHaveBeenCalledTimes(4));
+    while (releases.length > 0) releases.shift()?.();
+    await Promise.all(calls);
+
+    expect(maximumActive).toBe(2);
   });
 
   it("redacts provider credentials from nested CLI and MCP output", async () => {
@@ -154,7 +378,12 @@ describe("Upstash investigation context", () => {
         api_key: "developer-api-key",
         nested: {
           headers: { authorization: "Bearer destination-secret" },
+          jwt: "signed-token",
+          privateKey: "private-key",
           read_only_rest_token: "db-secret",
+          session_id: "session-secret",
+          signing_key: "signing-key",
+          webhookSignature: "webhook-signature",
           value: "safe",
         },
       }, ["developer-api-key"]),
@@ -162,10 +391,63 @@ describe("Upstash investigation context", () => {
       api_key: "[redacted]",
       nested: {
         headers: "[redacted]",
+        jwt: "[redacted]",
+        privateKey: "[redacted]",
         read_only_rest_token: "[redacted]",
+        session_id: "[redacted]",
+        signing_key: "[redacted]",
+        webhookSignature: "[redacted]",
         value: "safe",
       },
     });
+
+    const sanitizedUrls = sanitizeUpstashOutput({
+      callback:
+        "https://user:password@example.com/hook?signature=secret-signature&event=failed#token-fragment",
+      databaseDsn: "redis://default:redis-password@example.upstash.io:6379/0",
+      destination: "https://example.com/jobs?key=secret-key&job=123",
+    }) as Record<string, string>;
+    expect(sanitizedUrls.callback).not.toContain("user:password");
+    expect(sanitizedUrls.callback).not.toContain("secret-signature");
+    expect(sanitizedUrls.callback).not.toContain("token-fragment");
+    expect(new URL(sanitizedUrls.callback).searchParams.get("event")).toBe(
+      "failed",
+    );
+    expect(sanitizedUrls.databaseDsn).toBe("[redacted]");
+    expect(sanitizedUrls.destination).not.toContain("secret-key");
+    expect(new URL(sanitizedUrls.destination).searchParams.get("job")).toBe(
+      "123",
+    );
+
+    const compoundParameters = new URL(
+      sanitizeUpstashOutput(
+        "https://example.com/callback?client_secret=s&refresh_token=t&x-api-key=k&request_id=req-1",
+      ) as string,
+    );
+    expect(compoundParameters.searchParams.get("client_secret")).toContain(
+      "redacted",
+    );
+    expect(compoundParameters.searchParams.get("refresh_token")).toContain(
+      "redacted",
+    );
+    expect(compoundParameters.searchParams.get("x-api-key")).toContain(
+      "redacted",
+    );
+    expect(compoundParameters.searchParams.get("request_id")).toBe("req-1");
+
+    const unstructured = sanitizeUpstashOutput(
+      "inspection failed: dsn=dsn-value jwt:jwt-value " +
+        "privateKey=private-value session_id=session-value " +
+        "signing-key=signing-value webhookSignature=signature-value " +
+        "diagnostic=preserved",
+    ) as string;
+    expect(unstructured).not.toContain("dsn-value");
+    expect(unstructured).not.toContain("jwt-value");
+    expect(unstructured).not.toContain("private-value");
+    expect(unstructured).not.toContain("session-value");
+    expect(unstructured).not.toContain("signing-value");
+    expect(unstructured).not.toContain("signature-value");
+    expect(unstructured).toContain("diagnostic=preserved");
 
     const { server } = upstreamServer();
     const result = await new ScopedUpstashMcpServer(
@@ -205,6 +487,14 @@ describe("Upstash investigation context", () => {
       upstashInspectionArgs({
         period: "1h",
         resourceId: "../../qstash/user",
+        resourceType: "redis",
+        view: "details",
+      }),
+    ).toThrow("resource ID is invalid");
+    expect(() =>
+      upstashInspectionArgs({
+        period: "1h",
+        resourceId: "--output=/tmp/result",
         resourceType: "redis",
         view: "details",
       }),

--- a/apps/worker/src/upstash.ts
+++ b/apps/worker/src/upstash.ts
@@ -1,4 +1,5 @@
 import { execFile } from "node:child_process";
+import { Buffer } from "node:buffer";
 import { createRequire } from "node:module";
 import { dirname, join } from "node:path";
 import {
@@ -20,6 +21,10 @@ const MCP_SCRIPT = join(
   dirname(require.resolve("@upstash/mcp-server/package.json")),
   "dist/index.js",
 );
+const UPSTASH_FETCH_GUARD = new URL(
+  "./upstash-fetch-guard.mjs",
+  import.meta.url,
+).href;
 
 export const UPSTASH_CONTEXT_MCP_TOOLS = [
   "util_timestamps_to_date",
@@ -54,17 +59,13 @@ const READ_ONLY_REDIS_COMMANDS = new Set([
   "GETRANGE",
   "HEXISTS",
   "HGET",
-  "HGETALL",
-  "HKEYS",
   "HLEN",
   "HMGET",
   "HSCAN",
   "HSTRLEN",
-  "HVALS",
   "INFO",
   "JSON.ARRLEN",
   "JSON.GET",
-  "JSON.OBJKEYS",
   "JSON.OBJLEN",
   "JSON.TYPE",
   "LINDEX",
@@ -73,12 +74,10 @@ const READ_ONLY_REDIS_COMMANDS = new Set([
   "MEMORY",
   "MGET",
   "OBJECT",
-  "PFCOUNT",
   "PTTL",
   "SCAN",
   "SCARD",
   "SISMEMBER",
-  "SMEMBERS",
   "SSCAN",
   "STRLEN",
   "TTL",
@@ -110,10 +109,147 @@ const READ_ONLY_OBJECT_SUBCOMMANDS = new Set([
   "REFCOUNT",
 ]);
 const SENSITIVE_KEY =
-  /api.?key|authorization|credential|header|password|secret|token/i;
+  /api.?key|authorization|credential|dsn|header|password|secret|token/i;
+const URI_PATTERN = /\b[a-z][a-z0-9+.-]*:\/\/[^\s"'<>]+/giu;
 const REDACTED = "[redacted]";
 const MAX_OUTPUT_LENGTH = 100_000;
-const SAFE_RESOURCE_ID = /^[A-Za-z0-9_-]{1,500}$/;
+const MAX_REDIS_PIPELINE_BYTES = 65_536;
+const MAX_UPSTASH_CONCURRENCY = 2;
+const SAFE_RESOURCE_ID = /^[A-Za-z0-9][A-Za-z0-9_-]{0,499}$/;
+const UPSTASH_LIST_LIMITS: Partial<
+  Record<string, { defaultCount: number; maximumCount: number }>
+> = {
+  qstash_dlq_list: { defaultCount: 25, maximumCount: 100 },
+  qstash_logs_list: { defaultCount: 25, maximumCount: 100 },
+  workflow_dlq_list: { defaultCount: 25, maximumCount: 100 },
+  workflow_logs_list: { defaultCount: 10, maximumCount: 10 },
+};
+const UPSTASH_STRING_LIMITS = {
+  callerIP: 500,
+  callerIp: 500,
+  cursor: 4_096,
+  failureCallbackState: 500,
+  messageId: 500,
+  queueName: 500,
+  scheduleId: 500,
+  topicName: 500,
+  url: 8_192,
+  workflowRunId: 500,
+  workflowUrl: 8_192,
+} as const;
+
+function containsControlCharacter(value: string): boolean {
+  return Array.from(value).some((character) => {
+    const codePoint = character.codePointAt(0);
+    return codePoint !== undefined && (codePoint <= 0x1f || codePoint === 0x7f);
+  });
+}
+
+function isBoundedRedisRange(
+  start: number,
+  stop: number,
+  maximumSpan: number,
+): boolean {
+  const sameDirection =
+    (start >= 0 && stop >= 0) || (start < 0 && stop < 0);
+  return (
+    Number.isSafeInteger(start) &&
+    Number.isSafeInteger(stop) &&
+    sameDirection &&
+    stop >= start &&
+    stop - start < maximumSpan
+  );
+}
+
+let activeUpstashOperations = 0;
+const pendingUpstashOperations: Array<() => void> = [];
+
+async function withUpstashConcurrencyLimit<T>(
+  operation: () => Promise<T>,
+): Promise<T> {
+  if (activeUpstashOperations >= MAX_UPSTASH_CONCURRENCY) {
+    await new Promise<void>((resolve) => pendingUpstashOperations.push(resolve));
+  } else {
+    activeUpstashOperations += 1;
+  }
+  try {
+    return await operation();
+  } finally {
+    const nextOperation = pendingUpstashOperations.shift();
+    if (nextOperation) nextOperation();
+    else activeUpstashOperations -= 1;
+  }
+}
+
+function isSensitiveUrlParameter(parameter: string): boolean {
+  const normalized = parameter.toLowerCase().replaceAll(/[^a-z0-9]+/g, "_");
+  if (
+    [
+      "access_token",
+      "api_key",
+      "authorization",
+      "code",
+      "credential",
+      "jwt",
+      "key",
+      "password",
+      "secret",
+      "session",
+      "session_id",
+      "sig",
+      "signature",
+      "token",
+    ].includes(normalized)
+  ) {
+    return true;
+  }
+  return (
+    /(?:^|_)(?:credential|password|secret|sig|signature|token)$/.test(
+      normalized,
+    ) ||
+    /(?:^|_)(?:api|private|signing|x_api)_?key$/.test(normalized)
+  );
+}
+
+function isSensitiveObjectKey(key: string): boolean {
+  if (SENSITIVE_KEY.test(key)) return true;
+  const normalized = key.toLowerCase().replaceAll(/[^a-z0-9]+/g, "_");
+  return (
+    normalized === "jwt" ||
+    /(?:private|signing)_?key$/.test(normalized) ||
+    /session_?(?:id|token)?$/.test(normalized) ||
+    /signature$/.test(normalized)
+  );
+}
+
+function sanitizedUri(value: string): string {
+  try {
+    const url = new URL(value);
+    if (url.username || url.password) url.username = REDACTED;
+    url.password = "";
+    if (url.hash) url.hash = REDACTED;
+    for (const key of new Set(url.searchParams.keys())) {
+      if (isSensitiveUrlParameter(key)) {
+        url.searchParams.set(key, REDACTED);
+      }
+    }
+    return url.toString();
+  } catch {
+    return value;
+  }
+}
+
+function sanitizedUris(value: string): string {
+  return value
+    .replace(URI_PATTERN, sanitizedUri)
+    .replace(
+      /([?&])([^=&#\s]+)=([^&#\s]*)/gu,
+      (match, separator: string, parameter: string) =>
+        isSensitiveUrlParameter(parameter)
+          ? `${separator}${parameter}=${REDACTED}`
+          : match,
+    );
+}
 
 function sanitizedString(value: string, secrets: readonly string[]): string {
   let sanitized = value;
@@ -130,8 +266,8 @@ function sanitizedString(value: string, secrets: readonly string[]): string {
       ? `${encoded.slice(0, MAX_OUTPUT_LENGTH)}\n[output truncated]`
       : encoded;
   } catch {
-    sanitized = sanitized.replace(
-      /((?:api.?key|authorization|credential|header|password|secret|token)["']?\s*[:=]\s*)(?:"[^"]*"|'[^']*'|[^\s,}]+)/gi,
+    sanitized = sanitizedUris(sanitized).replace(
+      /((?:api.?key|authorization|credential|dsn|header|jwt|password|private[_-]?key|secret|session(?:[_-]?(?:id|token))?|signature|signing[_-]?key|token)["']?\s*[:=]\s*)(?:"[^"]*"|'[^']*'|[^\s,}&]+)/gi,
       `$1${REDACTED}`,
     );
     return sanitized.length > MAX_OUTPUT_LENGTH
@@ -152,7 +288,7 @@ export function sanitizeUpstashOutput(
     return Object.fromEntries(
       Object.entries(value).map(([key, item]) => [
         key,
-        SENSITIVE_KEY.test(key)
+        isSensitiveObjectKey(key)
           ? REDACTED
           : sanitizeUpstashOutput(item, secrets),
       ]),
@@ -164,7 +300,11 @@ export function sanitizeUpstashOutput(
 export function validateUpstashRedisCommands(
   args: Record<string, unknown> | null,
 ): void {
-  if (!args || typeof args.database_id !== "string" || !args.database_id) {
+  if (
+    !args ||
+    typeof args.database_id !== "string" ||
+    !SAFE_RESOURCE_ID.test(args.database_id)
+  ) {
     throw new Error("A database_id is required for Redis inspection");
   }
   if ("database_rest_url" in args || "database_rest_token" in args) {
@@ -173,6 +313,15 @@ export function validateUpstashRedisCommands(
   const commands = args.commands;
   if (!Array.isArray(commands) || commands.length < 1 || commands.length > 20) {
     throw new Error("Redis inspection requires between 1 and 20 commands");
+  }
+  let encodedCommands: string;
+  try {
+    encodedCommands = JSON.stringify(commands);
+  } catch {
+    throw new Error("Redis commands have an invalid shape or size");
+  }
+  if (Buffer.byteLength(encodedCommands, "utf8") > MAX_REDIS_PIPELINE_BYTES) {
+    throw new Error("Redis inspection commands exceed the 64 KiB request limit");
   }
   for (const command of commands) {
     if (
@@ -196,12 +345,159 @@ export function validateUpstashRedisCommands(
     ) {
       throw new Error("Only read-only MEMORY subcommands are allowed");
     }
+    if (name === "MEMORY") {
+      if (subcommand === "USAGE") {
+        const samples = Number(command[4]);
+        if (
+          (command.length !== 3 && command.length !== 5) ||
+          (command.length === 5 &&
+            (command[3]?.toUpperCase() !== "SAMPLES" ||
+              !Number.isSafeInteger(samples) ||
+              samples < 1 ||
+              samples > 100))
+        ) {
+          throw new Error("MEMORY USAGE samples are limited to 100");
+        }
+      } else if (command.length !== 2) {
+        throw new Error(`MEMORY ${subcommand} does not accept arguments`);
+      }
+    }
     if (
       name === "OBJECT" &&
       (!subcommand || !READ_ONLY_OBJECT_SUBCOMMANDS.has(subcommand))
     ) {
       throw new Error("Only read-only OBJECT subcommands are allowed");
     }
+    if (name === "OBJECT" && command.length !== 3) {
+      throw new Error(`OBJECT ${subcommand} requires exactly one key`);
+    }
+    const upper = command.map((part) => part.toUpperCase());
+    const optionSearchStart =
+      name === "SCAN"
+        ? 2
+        : ["HSCAN", "SSCAN", "ZSCAN"].includes(name)
+          ? 3
+          : [
+                "LRANGE",
+                "XRANGE",
+                "XREVRANGE",
+                "ZRANGE",
+                "ZRANGEBYSCORE",
+                "ZREVRANGE",
+                "ZREVRANGEBYSCORE",
+              ].includes(name)
+            ? 4
+            : 2;
+    const boundedCount = (option: "COUNT" | "LIMIT") => {
+      const optionIndex = upper.indexOf(option, optionSearchStart);
+      if (optionIndex < 0) {
+        throw new Error(`Redis command ${name} requires a bounded ${option}`);
+      }
+      if (optionIndex !== upper.lastIndexOf(option)) {
+        throw new Error(`Redis command ${name} accepts only one ${option}`);
+      }
+      const countIndex = optionIndex + (option === "LIMIT" ? 2 : 1);
+      const count = Number(command[countIndex]);
+      if (!Number.isSafeInteger(count) || count < 1 || count > 100) {
+        throw new Error(`Redis command ${name} ${option} must be between 1 and 100`);
+      }
+      if (option === "LIMIT") {
+        const offset = Number(command[optionIndex + 1]);
+        if (!Number.isSafeInteger(offset) || offset < 0 || offset > 10_000) {
+          throw new Error(`Redis command ${name} LIMIT offset is invalid`);
+        }
+      }
+      return optionIndex;
+    };
+    if (["SCAN", "HSCAN", "SSCAN", "ZSCAN"].includes(name)) {
+      boundedCount("COUNT");
+    }
+    let countOptionIndex: number | undefined;
+    if (["GEOSEARCH", "XRANGE", "XREVRANGE"].includes(name)) {
+      countOptionIndex = boundedCount("COUNT");
+    }
+    if (["ZRANGEBYSCORE", "ZREVRANGEBYSCORE"].includes(name)) {
+      boundedCount("LIMIT");
+    }
+    if (["LRANGE", "ZRANGE", "ZREVRANGE"].includes(name)) {
+      const usesScoreOrLexRange =
+        name !== "LRANGE" &&
+        (upper.slice(4).includes("BYSCORE") ||
+          upper.slice(4).includes("BYLEX"));
+      if (usesScoreOrLexRange) {
+        boundedCount("LIMIT");
+      } else {
+        const start = Number(command[2]);
+        const stop = Number(command[3]);
+        if (!isBoundedRedisRange(start, stop, 100)) {
+          throw new Error(`Redis command ${name} range is limited to 100 items`);
+        }
+      }
+    }
+    if (
+      name === "GEOSEARCH" &&
+      (countOptionIndex === undefined ||
+        upper[countOptionIndex + 2] !== "ANY")
+    ) {
+      throw new Error("Redis command GEOSEARCH requires COUNT with ANY");
+    }
+    if (
+      name === "XINFO" &&
+      (subcommand !== "STREAM" || command.length !== 3)
+    ) {
+      throw new Error("Only bounded XINFO STREAM inspection is allowed");
+    }
+    if (name === "GETRANGE") {
+      const start = Number(command[2]);
+      const stop = Number(command[3]);
+      if (
+        command.length !== 4 ||
+        !isBoundedRedisRange(start, stop, 65_536)
+      ) {
+        throw new Error("Redis command GETRANGE is limited to 64 KiB");
+      }
+    }
+    if (name === "BITCOUNT") {
+      const start = Number(command[2]);
+      const stop = Number(command[3]);
+      const unit = (command[4] ?? "BYTE").toUpperCase();
+      const maximumSpan = unit === "BIT" ? 65_536 * 8 : 65_536;
+      if (
+        (command.length !== 4 && command.length !== 5) ||
+        (unit !== "BYTE" && unit !== "BIT") ||
+        !isBoundedRedisRange(start, stop, maximumSpan)
+      ) {
+        throw new Error("Redis command BITCOUNT is limited to 64 KiB");
+      }
+    }
+    const maximumCollectionArguments =
+      name === "EXISTS" || name === "MGET"
+        ? 21
+        : ["GEOHASH", "GEOPOS", "HMGET", "JSON.GET", "ZMSCORE"].includes(
+              name,
+            )
+          ? 22
+          : undefined;
+    if (
+      maximumCollectionArguments !== undefined &&
+      command.length > maximumCollectionArguments
+    ) {
+      throw new Error(`Redis command ${name} is limited to 20 values`);
+    }
+  }
+}
+
+function validateUpstashFilterUrl(parameter: string, value: string): void {
+  // These are exact-match filters sent to Upstash's HTTPS API, not network
+  // destinations fetched by the worker. HTTP callback URLs are valid log data.
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    throw new Error(`The Upstash ${parameter} is invalid`);
+  }
+  if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+    throw new Error(`The Upstash ${parameter} is invalid`);
   }
 }
 
@@ -209,13 +505,16 @@ function validateUpstashMcpArgs(
   toolName: string,
   args: Record<string, unknown> | null,
 ): void {
-  if (
-    toolName.startsWith("redis_database_") &&
-    args?.database_id !== undefined &&
-    (typeof args.database_id !== "string" ||
-      !SAFE_RESOURCE_ID.test(args.database_id))
-  ) {
-    throw new Error("The Upstash database_id is invalid");
+  if (toolName.startsWith("redis_database_")) {
+    for (const parameter of ["database_id", "id"] as const) {
+      const value = args?.[parameter];
+      if (
+        value !== undefined &&
+        (typeof value !== "string" || !SAFE_RESOURCE_ID.test(value))
+      ) {
+        throw new Error(`The Upstash ${parameter} is invalid`);
+      }
+    }
   }
   if (
     (toolName === "qstash_dlq_get" || toolName === "workflow_dlq_get") &&
@@ -227,6 +526,33 @@ function validateUpstashMcpArgs(
     validateUpstashRedisCommands(args);
   }
   if (!toolName.startsWith("qstash_") && !toolName.startsWith("workflow_")) {
+    if (toolName === "util_timestamps_to_date") {
+      const timestamps = args?.timestamps;
+      if (
+        !Array.isArray(timestamps) ||
+        timestamps.length > 100 ||
+        timestamps.some(
+          (value) => typeof value !== "number" || !Number.isFinite(value),
+        )
+      ) {
+        throw new Error("Upstash timestamp conversion is limited to 100 values");
+      }
+    }
+    if (toolName === "util_dates_to_timestamps") {
+      const dates = args?.dates;
+      if (
+        !Array.isArray(dates) ||
+        dates.length > 100 ||
+        dates.some(
+          (value) =>
+            typeof value !== "string" ||
+            value.length > 100 ||
+            containsControlCharacter(value),
+        )
+      ) {
+        throw new Error("Upstash date conversion is limited to 100 values");
+      }
+    }
     return;
   }
   if (args && ("qstash_creds" in args || "local_mode_port" in args)) {
@@ -248,6 +574,46 @@ function validateUpstashMcpArgs(
   ) {
     throw new Error("QStash and Workflow list requests are limited to 100 items");
   }
+  for (const [parameter, maximum] of Object.entries(UPSTASH_STRING_LIMITS)) {
+    const value = args?.[parameter];
+    if (
+      value !== undefined &&
+      (typeof value !== "string" ||
+        value.length < 1 ||
+        value.length > maximum ||
+        containsControlCharacter(value))
+    ) {
+      throw new Error(`The Upstash ${parameter} is invalid`);
+    }
+    if (
+      typeof value === "string" &&
+      (parameter === "url" || parameter === "workflowUrl")
+    ) {
+      validateUpstashFilterUrl(parameter, value);
+    }
+  }
+}
+
+function normalizedUpstashMcpArgs(
+  toolName: string,
+  args: Record<string, unknown> | null,
+): Record<string, unknown> | null {
+  const limits = UPSTASH_LIST_LIMITS[toolName];
+  if (!limits) return args;
+  const normalized = { ...(args ?? {}) };
+  const count = normalized.count ?? limits.defaultCount;
+  if (
+    typeof count !== "number" ||
+    !Number.isInteger(count) ||
+    count < 1 ||
+    count > limits.maximumCount
+  ) {
+    throw new Error(
+      `Upstash ${toolName} requests are limited to ${limits.maximumCount} items`,
+    );
+  }
+  normalized.count = count;
+  return normalized;
 }
 
 function scopeUpstashMcpTool(
@@ -279,6 +645,58 @@ function scopeUpstashMcpTool(
         enum: ["eu", "us"],
       };
     }
+    if (properties.count && typeof properties.count === "object") {
+      const limits = UPSTASH_LIST_LIMITS[item.name];
+      properties.count = {
+        ...(properties.count as Record<string, unknown>),
+        ...(limits
+          ? {
+              default: limits.defaultCount,
+              maximum: limits.maximumCount,
+            }
+          : {}),
+        minimum: 1,
+      };
+    }
+    for (const [parameter, maximum] of Object.entries(UPSTASH_STRING_LIMITS)) {
+      if (properties[parameter] && typeof properties[parameter] === "object") {
+        properties[parameter] = {
+          ...(properties[parameter] as Record<string, unknown>),
+          maxLength: maximum,
+          minLength: 1,
+          ...(parameter === "url" || parameter === "workflowUrl"
+            ? { pattern: "^https?://" }
+            : {}),
+        };
+      }
+    }
+  }
+  for (const parameter of ["database_id", "id", "dlqId"] as const) {
+    if (properties[parameter] && typeof properties[parameter] === "object") {
+      properties[parameter] = {
+        ...(properties[parameter] as Record<string, unknown>),
+        maxLength: 500,
+        minLength: 1,
+        pattern: SAFE_RESOURCE_ID.source,
+      };
+    }
+  }
+  if (item.name === "util_timestamps_to_date" && properties.timestamps) {
+    properties.timestamps = {
+      ...(properties.timestamps as Record<string, unknown>),
+      maxItems: 100,
+    };
+  }
+  if (item.name === "util_dates_to_timestamps" && properties.dates) {
+    const dates = properties.dates as Record<string, unknown>;
+    properties.dates = {
+      ...dates,
+      items: {
+        ...((dates.items as Record<string, unknown> | undefined) ?? {}),
+        maxLength: 100,
+      },
+      maxItems: 100,
+    };
   }
   const required = Array.isArray(schema.required)
     ? schema.required.filter(
@@ -364,9 +782,12 @@ export class ScopedUpstashMcpServer implements MCPServer {
     if (!UPSTASH_CONTEXT_MCP_TOOL_SET.has(toolName)) {
       throw new Error(`Upstash tool ${toolName} is not available during investigations`);
     }
-    validateUpstashMcpArgs(toolName, args);
+    const normalizedArgs = normalizedUpstashMcpArgs(toolName, args);
+    validateUpstashMcpArgs(toolName, normalizedArgs);
     try {
-      const result = await this.server.callTool(toolName, args, meta, options);
+      const result = await withUpstashConcurrencyLimit(() =>
+        this.server.callTool(toolName, normalizedArgs, meta, options),
+      );
       return sanitizeMcpResult(result, [this.connection.apiKey]);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
@@ -393,6 +814,8 @@ export function createUpstashMcpServer(
       // mode. Keep the isolated child quiet so inspected Redis values never
       // reach worker logs.
       NODE_ENV: "test",
+      NODE_OPTIONS: `--max-old-space-size=128 --import=${UPSTASH_FETCH_GUARD}`,
+      RESPONDER_UPSTASH_FETCH_GUARD: "1",
       UPSTASH_API_KEY: connection.apiKey,
       UPSTASH_EMAIL: connection.email,
     },
@@ -411,37 +834,40 @@ export type UpstashCliRunner = (
   connection: RuntimeUpstashConnection,
 ) => Promise<unknown>;
 
-export const runUpstashCli: UpstashCliRunner = async (args, connection) => {
-  const output = await new Promise<string>((resolve, reject) => {
-    execFile(
-      process.execPath,
-      [CLI_SCRIPT, ...args],
-      {
-        cwd: dirname(CLI_SCRIPT),
-        encoding: "utf8",
-        env: {
-          NODE_ENV: "production",
-          NO_COLOR: "1",
-          UPSTASH_API_KEY: connection.apiKey,
-          UPSTASH_EMAIL: connection.email,
+export const runUpstashCli: UpstashCliRunner = (args, connection) =>
+  withUpstashConcurrencyLimit(async () => {
+    const output = await new Promise<string>((resolve, reject) => {
+      execFile(
+        process.execPath,
+        [CLI_SCRIPT, ...args],
+        {
+          cwd: dirname(CLI_SCRIPT),
+          encoding: "utf8",
+          env: {
+            NODE_ENV: "production",
+            NODE_OPTIONS: `--max-old-space-size=128 --import=${UPSTASH_FETCH_GUARD}`,
+            NO_COLOR: "1",
+            RESPONDER_UPSTASH_FETCH_GUARD: "1",
+            UPSTASH_API_KEY: connection.apiKey,
+            UPSTASH_EMAIL: connection.email,
+          },
+          maxBuffer: 1_000_000,
+          timeout: 30_000,
         },
-        maxBuffer: 1_000_000,
-        timeout: 30_000,
-      },
-      (error, stdout) => {
-        if (error) reject(new Error("Upstash CLI request failed"));
-        else resolve(stdout);
-      },
-    );
+        (error, stdout) => {
+          if (error) reject(new Error("Upstash CLI request failed"));
+          else resolve(stdout);
+        },
+      );
+    });
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(output);
+    } catch {
+      parsed = output;
+    }
+    return sanitizeUpstashOutput(parsed, [connection.apiKey]);
   });
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(output);
-  } catch {
-    parsed = output;
-  }
-  return sanitizeUpstashOutput(parsed, [connection.apiKey]);
-};
 
 const resourceTypeSchema = z.enum([
   "redis",

--- a/apps/worker/src/vercel.ts
+++ b/apps/worker/src/vercel.ts
@@ -436,12 +436,12 @@ const parameterValueSchema = z.union([
 export function createVercelTools(connections: RuntimeVercelConnection[]) {
   if (connections.length === 0) return [];
   const accountDescription = connections
-    .map((connection) => `${connection.accountId}: ${connection.displayName}`)
+    .map((connection) => connection.accountId)
     .join(", ");
   const searchVercelApi = tool({
     name: "search_vercel_api",
     description:
-      "Search the read-only Vercel REST API catalog before making a Vercel API call. Secret, token, and environment-value operations are excluded.",
+      "Search the read-only Vercel REST API catalog before making an API call. Secret, token, and environment-value operations are excluded.",
     parameters: z.object({
       query: z.string().trim().max(500).default(""),
       limit: z.number().int().min(1).max(20).default(8),

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -142,6 +142,8 @@ Responder encrypts each installation token, synchronizes only the projects
 visible to that installation, and keeps the token in the worker process. The
 investigation sandbox receives two host-side tools: one searches a generated
 catalog of safe Vercel GET operations, and one executes a selected operation.
+The callback verifies the installation identity, team, and selected-project
+set without narrowing the integration's configured read permissions.
 Regenerate the catalog from Vercel's published OpenAPI document after API
 updates with `pnpm vercel:generate-api`.
 

--- a/drizzle/0024_security_hardening.sql
+++ b/drizzle/0024_security_hardening.sql
@@ -1,0 +1,78 @@
+LOCK TABLE "issue_pull_requests" IN SHARE ROW EXCLUSIVE MODE;--> statement-breakpoint
+WITH "ranked_active_requests" AS (
+	SELECT
+		"id",
+		row_number() OVER (
+			PARTITION BY "issue_id"
+			ORDER BY
+				CASE "status"
+					WHEN 'created' THEN 1
+					WHEN 'creating' THEN 2
+					WHEN 'queued' THEN 3
+					ELSE 4
+				END,
+				("pull_request_url" IS NOT NULL) DESC,
+				("eve_session_id" IS NOT NULL) DESC,
+				"updated_at" DESC,
+				"created_at",
+				"id"
+		) AS "active_rank"
+	FROM "issue_pull_requests"
+	WHERE "status" in ('queued', 'creating', 'created')
+)
+UPDATE "issue_pull_requests" AS "request"
+SET
+	"status" = 'failed',
+	"failure_reason" = COALESCE(
+		"request"."failure_reason",
+		'Superseded by another active pull request during database migration'
+	),
+	"completed_at" = COALESCE("request"."completed_at", now()),
+	"updated_at" = now()
+FROM "ranked_active_requests" AS "ranked"
+WHERE "request"."id" = "ranked"."id"
+	AND "ranked"."active_rank" > 1;--> statement-breakpoint
+CREATE UNIQUE INDEX "issue_pull_requests_active_issue_idx" ON "issue_pull_requests" USING btree ("issue_id") WHERE "status" in ('queued', 'creating', 'created');--> statement-breakpoint
+LOCK TABLE "integration_connection_states" IN SHARE ROW EXCLUSIVE MODE;--> statement-breakpoint
+DELETE FROM "integration_connection_states"
+WHERE "expires_at" <= now();--> statement-breakpoint
+WITH "ranked_connection_states" AS (
+	SELECT
+		"state_hash",
+		row_number() OVER (
+			PARTITION BY "organization_id", "user_id", "provider"
+			ORDER BY "expires_at" DESC, "created_at" DESC, "state_hash" DESC
+		) AS "state_rank"
+	FROM "integration_connection_states"
+)
+DELETE FROM "integration_connection_states" AS "connection_state"
+USING "ranked_connection_states" AS "ranked"
+WHERE "connection_state"."state_hash" = "ranked"."state_hash"
+	AND "ranked"."state_rank" > 1;--> statement-breakpoint
+CREATE UNIQUE INDEX "integration_connection_states_owner_provider_idx" ON "integration_connection_states" USING btree ("organization_id", "user_id", "provider");
+--> statement-breakpoint
+LOCK TABLE "integration_accounts" IN SHARE ROW EXCLUSIVE MODE;--> statement-breakpoint
+UPDATE "integration_accounts" AS "legacy"
+SET
+	"external_account_id" = btrim("legacy"."metadata" ->> 'workspaceId'),
+	"updated_at" = now()
+WHERE "legacy"."provider" = 'linear'
+	AND "legacy"."external_account_id" = 'https://mcp.linear.app/mcp'
+	AND NULLIF(btrim("legacy"."metadata" ->> 'workspaceId'), '') IS NOT NULL
+	AND NOT EXISTS (
+		SELECT 1
+		FROM "integration_accounts" AS "current"
+		WHERE "current"."organization_id" = "legacy"."organization_id"
+			AND "current"."provider" = 'linear'
+			AND "current"."external_account_id" = btrim("legacy"."metadata" ->> 'workspaceId')
+			AND "current"."id" <> "legacy"."id"
+	);--> statement-breakpoint
+UPDATE "integration_accounts"
+SET
+	"status" = 'error',
+	"encrypted_credentials" = NULL,
+	"credential_key_version" = NULL,
+	"metadata" = "metadata" || '{"legacyAccountRetired":true}'::jsonb,
+	"updated_at" = now()
+WHERE "provider" = 'linear'
+	AND "external_account_id" = 'https://mcp.linear.app/mcp';

--- a/drizzle/meta/0024_snapshot.json
+++ b/drizzle/meta/0024_snapshot.json
@@ -1,0 +1,3533 @@
+{
+  "id": "c3d98162-6040-40df-a3d4-3e64816a037f",
+  "prevId": "80af88d2-7d29-4955-ac09-7717309e332d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "invitation_organizationId_idx": {
+          "name": "invitation_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_email_idx": {
+          "name": "invitation_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "member_organizationId_idx": {
+          "name": "member_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_userId_idx": {
+          "name": "member_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'user'"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_organization_id": {
+          "name": "last_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_config_versions": {
+      "name": "agent_config_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "trigger_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_config": {
+          "name": "trigger_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "report_config": {
+          "name": "report_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context_account_ids": {
+          "name": "context_account_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "context_resource_ids": {
+          "name": "context_resource_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "pr_mode": {
+          "name": "pr_mode",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pr_mode_policy": {
+          "name": "pr_mode_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'disabled'"
+        },
+        "create_linear_tickets": {
+          "name": "create_linear_tickets",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "linear_issue_template": {
+          "name": "linear_issue_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'## Responder issue\n[{{issue_id}}]({{issue_url}})\n\n## Description\n{{description}}\n\n## Evidence\n{{evidence}}\n\n## Recommended remediation\n{{remediation}}'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_config_versions_agent_version_idx": {
+          "name": "agent_config_versions_agent_version_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_config_versions_agent_idx": {
+          "name": "agent_config_versions_agent_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_config_versions_agent_id_agents_id_fk": {
+          "name": "agent_config_versions_agent_id_agents_id_fk",
+          "tableFrom": "agent_config_versions",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_config_versions_created_by_user_id_fk": {
+          "name": "agent_config_versions_created_by_user_id_fk",
+          "tableFrom": "agent_config_versions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_version_repositories": {
+      "name": "agent_version_repositories",
+      "schema": "",
+      "columns": {
+        "agent_config_version_id": {
+          "name": "agent_config_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_version_repositories_agent_config_version_id_agent_config_versions_id_fk": {
+          "name": "agent_version_repositories_agent_config_version_id_agent_config_versions_id_fk",
+          "tableFrom": "agent_version_repositories",
+          "tableTo": "agent_config_versions",
+          "columnsFrom": [
+            "agent_config_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_version_repositories_repository_id_repositories_id_fk": {
+          "name": "agent_version_repositories_repository_id_repositories_id_fk",
+          "tableFrom": "agent_version_repositories",
+          "tableTo": "repositories",
+          "columnsFrom": [
+            "repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_version_repositories_agent_config_version_id_repository_id_pk": {
+          "name": "agent_version_repositories_agent_config_version_id_repository_id_pk",
+          "columns": [
+            "agent_config_version_id",
+            "repository_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_version_secrets": {
+      "name": "agent_version_secrets",
+      "schema": "",
+      "columns": {
+        "agent_config_version_id": {
+          "name": "agent_config_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_secret_id": {
+          "name": "workspace_secret_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_version_secrets_agent_config_version_id_agent_config_versions_id_fk": {
+          "name": "agent_version_secrets_agent_config_version_id_agent_config_versions_id_fk",
+          "tableFrom": "agent_version_secrets",
+          "tableTo": "agent_config_versions",
+          "columnsFrom": [
+            "agent_config_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_version_secrets_workspace_secret_id_workspace_secrets_id_fk": {
+          "name": "agent_version_secrets_workspace_secret_id_workspace_secrets_id_fk",
+          "tableFrom": "agent_version_secrets",
+          "tableTo": "workspace_secrets",
+          "columnsFrom": [
+            "workspace_secret_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_version_secrets_agent_config_version_id_workspace_secret_id_pk": {
+          "name": "agent_version_secrets_agent_config_version_id_workspace_secret_id_pk",
+          "columns": [
+            "agent_config_version_id",
+            "workspace_secret_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "active_version_id": {
+          "name": "active_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agents_organization_idx": {
+          "name": "agents_organization_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agents_organization_id_organization_id_fk": {
+          "name": "agents_organization_id_organization_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.billing_notification_deliveries": {
+      "name": "billing_notification_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integration_account_id": {
+          "name": "integration_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_key": {
+          "name": "period_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination": {
+          "name": "destination",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "billing_notification_delivery_target_idx": {
+          "name": "billing_notification_delivery_target_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "integration_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "destination",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "billing_notification_delivery_status_idx": {
+          "name": "billing_notification_delivery_status_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "billing_notification_deliveries_organization_id_organization_id_fk": {
+          "name": "billing_notification_deliveries_organization_id_organization_id_fk",
+          "tableFrom": "billing_notification_deliveries",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "billing_notification_deliveries_integration_account_id_integration_accounts_id_fk": {
+          "name": "billing_notification_deliveries_integration_account_id_integration_accounts_id_fk",
+          "tableFrom": "billing_notification_deliveries",
+          "tableTo": "integration_accounts",
+          "columnsFrom": [
+            "integration_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.delivery_attempts": {
+      "name": "delivery_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "investigation_id": {
+          "name": "investigation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination": {
+          "name": "destination",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "delivery_attempts_idempotency_idx": {
+          "name": "delivery_attempts_idempotency_idx",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_attempts_investigation_idx": {
+          "name": "delivery_attempts_investigation_idx",
+          "columns": [
+            {
+              "expression": "investigation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "delivery_attempts_investigation_id_investigations_id_fk": {
+          "name": "delivery_attempts_investigation_id_investigations_id_fk",
+          "tableFrom": "delivery_attempts",
+          "tableTo": "investigations",
+          "columnsFrom": [
+            "investigation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instance_configuration": {
+      "name": "instance_configuration",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "active_runtime_profile_id": {
+          "name": "active_runtime_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "instance_configuration_active_runtime_profile_id_runtime_profiles_id_fk": {
+          "name": "instance_configuration_active_runtime_profile_id_runtime_profiles_id_fk",
+          "tableFrom": "instance_configuration",
+          "tableTo": "runtime_profiles",
+          "columnsFrom": [
+            "active_runtime_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_accounts": {
+      "name": "integration_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "integration_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_account_id": {
+          "name": "external_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'connected'"
+        },
+        "encrypted_credentials": {
+          "name": "encrypted_credentials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_key_version": {
+          "name": "credential_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "integration_accounts_organization_provider_external_idx": {
+          "name": "integration_accounts_organization_provider_external_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_accounts_organization_idx": {
+          "name": "integration_accounts_organization_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_accounts_organization_id_organization_id_fk": {
+          "name": "integration_accounts_organization_id_organization_id_fk",
+          "tableFrom": "integration_accounts",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_connection_states": {
+      "name": "integration_connection_states",
+      "schema": "",
+      "columns": {
+        "state_hash": {
+          "name": "state_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "integration_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_verifier": {
+          "name": "code_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "return_to": {
+          "name": "return_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'/settings'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "integration_connection_states_expires_idx": {
+          "name": "integration_connection_states_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_connection_states_organization_idx": {
+          "name": "integration_connection_states_organization_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_connection_states_owner_provider_idx": {
+          "name": "integration_connection_states_owner_provider_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_connection_states_organization_id_organization_id_fk": {
+          "name": "integration_connection_states_organization_id_organization_id_fk",
+          "tableFrom": "integration_connection_states",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "integration_connection_states_user_id_user_id_fk": {
+          "name": "integration_connection_states_user_id_user_id_fk",
+          "tableFrom": "integration_connection_states",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_resources": {
+      "name": "integration_resources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "integration_account_id": {
+          "name": "integration_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "integration_resource_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "available": {
+          "name": "available",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "integration_resources_account_kind_external_idx": {
+          "name": "integration_resources_account_kind_external_idx",
+          "columns": [
+            {
+              "expression": "integration_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_resources_account_idx": {
+          "name": "integration_resources_account_idx",
+          "columns": [
+            {
+              "expression": "integration_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_resources_integration_account_id_integration_accounts_id_fk": {
+          "name": "integration_resources_integration_account_id_integration_accounts_id_fk",
+          "tableFrom": "integration_resources",
+          "tableTo": "integration_accounts",
+          "columnsFrom": [
+            "integration_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.investigation_issues": {
+      "name": "investigation_issues",
+      "schema": "",
+      "columns": {
+        "investigation_id": {
+          "name": "investigation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relationship": {
+          "name": "relationship",
+          "type": "issue_relationship",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "investigation_issues_issue_idx": {
+          "name": "investigation_issues_issue_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "investigation_issues_investigation_id_investigations_id_fk": {
+          "name": "investigation_issues_investigation_id_investigations_id_fk",
+          "tableFrom": "investigation_issues",
+          "tableTo": "investigations",
+          "columnsFrom": [
+            "investigation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "investigation_issues_issue_id_issues_id_fk": {
+          "name": "investigation_issues_issue_id_issues_id_fk",
+          "tableFrom": "investigation_issues",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "investigation_issues_investigation_id_issue_id_pk": {
+          "name": "investigation_issues_investigation_id_issue_id_pk",
+          "columns": [
+            "investigation_id",
+            "issue_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.investigation_replay_requests": {
+      "name": "investigation_replay_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source_investigation_id": {
+          "name": "source_investigation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "replay_investigation_id": {
+          "name": "replay_investigation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_by": {
+          "name": "requested_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "investigation_replay_request_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "processing_started_at": {
+          "name": "processing_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "queued_at": {
+          "name": "queued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "investigation_replay_requests_replay_idx": {
+          "name": "investigation_replay_requests_replay_idx",
+          "columns": [
+            {
+              "expression": "replay_investigation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "investigation_replay_requests_claim_idx": {
+          "name": "investigation_replay_requests_claim_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "investigation_replay_requests_source_idx": {
+          "name": "investigation_replay_requests_source_idx",
+          "columns": [
+            {
+              "expression": "source_investigation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "investigation_replay_requests_source_investigation_id_investigations_id_fk": {
+          "name": "investigation_replay_requests_source_investigation_id_investigations_id_fk",
+          "tableFrom": "investigation_replay_requests",
+          "tableTo": "investigations",
+          "columnsFrom": [
+            "source_investigation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.investigation_trace_events": {
+      "name": "investigation_trace_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "investigation_id": {
+          "name": "investigation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event": {
+          "name": "event",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "investigation_trace_events_investigation_id_idx": {
+          "name": "investigation_trace_events_investigation_id_idx",
+          "columns": [
+            {
+              "expression": "investigation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "investigation_trace_events_investigation_id_investigations_id_fk": {
+          "name": "investigation_trace_events_investigation_id_investigations_id_fk",
+          "tableFrom": "investigation_trace_events",
+          "tableTo": "investigations",
+          "columnsFrom": [
+            "investigation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.investigations": {
+      "name": "investigations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_config_version_id": {
+          "name": "agent_config_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime_profile_id": {
+          "name": "runtime_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "investigation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finding": {
+          "name": "finding",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "structured_report": {
+          "name": "structured_report",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replay_report": {
+          "name": "replay_report",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "report_markdown": {
+          "name": "report_markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_replay": {
+          "name": "is_replay",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "replay_of_investigation_id": {
+          "name": "replay_of_investigation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eve_session_id": {
+          "name": "eve_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_message_timestamp": {
+          "name": "slack_message_timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_trace_items": {
+          "name": "slack_trace_items",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "investigations_organization_created_idx": {
+          "name": "investigations_organization_created_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "investigations_agent_created_idx": {
+          "name": "investigations_agent_created_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "investigations_replay_source_idx": {
+          "name": "investigations_replay_source_idx",
+          "columns": [
+            {
+              "expression": "replay_of_investigation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "investigations_organization_id_organization_id_fk": {
+          "name": "investigations_organization_id_organization_id_fk",
+          "tableFrom": "investigations",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "investigations_agent_id_agents_id_fk": {
+          "name": "investigations_agent_id_agents_id_fk",
+          "tableFrom": "investigations",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "investigations_agent_config_version_id_agent_config_versions_id_fk": {
+          "name": "investigations_agent_config_version_id_agent_config_versions_id_fk",
+          "tableFrom": "investigations",
+          "tableTo": "agent_config_versions",
+          "columnsFrom": [
+            "agent_config_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "investigations_runtime_profile_id_runtime_profiles_id_fk": {
+          "name": "investigations_runtime_profile_id_runtime_profiles_id_fk",
+          "tableFrom": "investigations",
+          "tableTo": "runtime_profiles",
+          "columnsFrom": [
+            "runtime_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "investigations_replay_source_fk": {
+          "name": "investigations_replay_source_fk",
+          "tableFrom": "investigations",
+          "tableTo": "investigations",
+          "columnsFrom": [
+            "replay_of_investigation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_linear_tickets": {
+      "name": "issue_linear_tickets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "investigation_id": {
+          "name": "investigation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_config_version_id": {
+          "name": "agent_config_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integration_account_id": {
+          "name": "integration_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linear_issue_id": {
+          "name": "linear_issue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linear_identifier": {
+          "name": "linear_identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linear_issue_url": {
+          "name": "linear_issue_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "issue_linear_tickets_issue_idx": {
+          "name": "issue_linear_tickets_issue_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_linear_tickets_investigation_idx": {
+          "name": "issue_linear_tickets_investigation_idx",
+          "columns": [
+            {
+              "expression": "investigation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_linear_tickets_status_created_idx": {
+          "name": "issue_linear_tickets_status_created_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_linear_tickets_issue_id_issues_id_fk": {
+          "name": "issue_linear_tickets_issue_id_issues_id_fk",
+          "tableFrom": "issue_linear_tickets",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_linear_tickets_investigation_id_investigations_id_fk": {
+          "name": "issue_linear_tickets_investigation_id_investigations_id_fk",
+          "tableFrom": "issue_linear_tickets",
+          "tableTo": "investigations",
+          "columnsFrom": [
+            "investigation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_linear_tickets_agent_config_version_id_agent_config_versions_id_fk": {
+          "name": "issue_linear_tickets_agent_config_version_id_agent_config_versions_id_fk",
+          "tableFrom": "issue_linear_tickets",
+          "tableTo": "agent_config_versions",
+          "columnsFrom": [
+            "agent_config_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "issue_linear_tickets_integration_account_id_integration_accounts_id_fk": {
+          "name": "issue_linear_tickets_integration_account_id_integration_accounts_id_fk",
+          "tableFrom": "issue_linear_tickets",
+          "tableTo": "integration_accounts",
+          "columnsFrom": [
+            "integration_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_pull_requests": {
+      "name": "issue_pull_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "investigation_id": {
+          "name": "investigation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_config_version_id": {
+          "name": "agent_config_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_full_name": {
+          "name": "repository_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pull_request_number": {
+          "name": "pull_request_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pull_request_url": {
+          "name": "pull_request_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eve_session_id": {
+          "name": "eve_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "issue_pull_requests_active_issue_idx": {
+          "name": "issue_pull_requests_active_issue_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"status\" in ('queued', 'creating', 'created')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_pull_requests_issue_created_idx": {
+          "name": "issue_pull_requests_issue_created_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_pull_requests_investigation_idx": {
+          "name": "issue_pull_requests_investigation_idx",
+          "columns": [
+            {
+              "expression": "investigation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_pull_requests_issue_id_issues_id_fk": {
+          "name": "issue_pull_requests_issue_id_issues_id_fk",
+          "tableFrom": "issue_pull_requests",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_pull_requests_investigation_id_investigations_id_fk": {
+          "name": "issue_pull_requests_investigation_id_investigations_id_fk",
+          "tableFrom": "issue_pull_requests",
+          "tableTo": "investigations",
+          "columnsFrom": [
+            "investigation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_pull_requests_agent_config_version_id_agent_config_versions_id_fk": {
+          "name": "issue_pull_requests_agent_config_version_id_agent_config_versions_id_fk",
+          "tableFrom": "issue_pull_requests",
+          "tableTo": "agent_config_versions",
+          "columnsFrom": [
+            "agent_config_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issues": {
+      "name": "issues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "severity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "remediation": {
+          "name": "remediation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_model": {
+          "name": "embedding_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issues_organization_created_idx": {
+          "name": "issues_organization_created_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issues_organization_id_organization_id_fk": {
+          "name": "issues_organization_id_organization_id_fk",
+          "tableFrom": "issues",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.repositories": {
+      "name": "repositories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "integration_account_id": {
+          "name": "integration_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'main'"
+        },
+        "private": {
+          "name": "private",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "available": {
+          "name": "available",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "repositories_installation_external_idx": {
+          "name": "repositories_installation_external_idx",
+          "columns": [
+            {
+              "expression": "integration_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "repositories_integration_account_id_integration_accounts_id_fk": {
+          "name": "repositories_integration_account_id_integration_accounts_id_fk",
+          "tableFrom": "repositories",
+          "tableTo": "integration_accounts",
+          "columnsFrom": [
+            "integration_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runtime_profiles": {
+      "name": "runtime_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "version": {
+          "name": "version",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_options": {
+          "name": "model_options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "runtime_profiles_version_idx": {
+          "name": "runtime_profiles_version_idx",
+          "columns": [
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_receipts": {
+      "name": "webhook_receipts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_event_id": {
+          "name": "external_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "investigation_id": {
+          "name": "investigation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_hash": {
+          "name": "payload_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_receipts_provider_event_idx": {
+          "name": "webhook_receipts_provider_event_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_receipts_organization_id_organization_id_fk": {
+          "name": "webhook_receipts_organization_id_organization_id_fk",
+          "tableFrom": "webhook_receipts",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_secrets": {
+      "name": "workspace_secrets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "daytona_secret_id": {
+          "name": "daytona_secret_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "daytona_secret_name": {
+          "name": "daytona_secret_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allowed_hosts": {
+          "name": "allowed_hosts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workspace_secrets_organization_name_idx": {
+          "name": "workspace_secrets_organization_name_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_secrets_daytona_id_idx": {
+          "name": "workspace_secrets_daytona_id_idx",
+          "columns": [
+            {
+              "expression": "daytona_secret_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_secrets_daytona_name_idx": {
+          "name": "workspace_secrets_daytona_name_idx",
+          "columns": [
+            {
+              "expression": "daytona_secret_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_secrets_organization_id_organization_id_fk": {
+          "name": "workspace_secrets_organization_id_organization_id_fk",
+          "tableFrom": "workspace_secrets",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "workspace_secrets_created_by_user_id_fk": {
+          "name": "workspace_secrets_created_by_user_id_fk",
+          "tableFrom": "workspace_secrets",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.integration_provider": {
+      "name": "integration_provider",
+      "schema": "public",
+      "values": [
+        "aws",
+        "github",
+        "slack",
+        "sentry",
+        "datadog",
+        "clickstack",
+        "upstash",
+        "vercel",
+        "custom_mcp",
+        "linear"
+      ]
+    },
+    "public.integration_resource_kind": {
+      "name": "integration_resource_kind",
+      "schema": "public",
+      "values": [
+        "slack_channel",
+        "sentry_project",
+        "datadog_monitor",
+        "vercel_project"
+      ]
+    },
+    "public.investigation_replay_request_status": {
+      "name": "investigation_replay_request_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "queued",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.investigation_status": {
+      "name": "investigation_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "investigating",
+        "resolved",
+        "failed"
+      ]
+    },
+    "public.issue_relationship": {
+      "name": "issue_relationship",
+      "schema": "public",
+      "values": [
+        "new",
+        "recurrence"
+      ]
+    },
+    "public.severity": {
+      "name": "severity",
+      "schema": "public",
+      "values": [
+        "SEV-1",
+        "SEV-2",
+        "SEV-3"
+      ]
+    },
+    "public.trigger_kind": {
+      "name": "trigger_kind",
+      "schema": "public",
+      "values": [
+        "sentry_issue",
+        "datadog_monitor",
+        "slack_channel",
+        "slack_mention"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -169,6 +169,13 @@
       "when": 1786970691972,
       "tag": "0023_black_loners",
       "breakpoints": true
+    },
+    {
+      "idx": 24,
+      "version": "7",
+      "when": 1786974440481,
+      "tag": "0024_security_hardening",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "eslint-plugin-react-hooks": "7.1.1",
     "eslint-plugin-react-refresh": "0.5.3",
     "portless": "0.15.1",
-    "tsx": "4.20.6",
+    "tsx": "4.23.12",
     "typescript": "6.0.3",
     "typescript-eslint": "8.65.0",
     "vite": "8.2.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,15 +8,17 @@
     "./*": "./src/*.ts"
   },
   "dependencies": {
-    "@aws-sdk/client-s3": "3.1106.0",
+    "@aws-sdk/client-s3": "3.1111.0",
     "@aws-sdk/client-sts": "3.1111.0",
-    "@aws-sdk/s3-request-presigner": "3.1106.0",
+    "@aws-sdk/s3-request-presigner": "3.1111.0",
     "@modelcontextprotocol/sdk": "1.30.0",
     "autumn-js": "1.2.45",
     "drizzle-orm": "0.45.2",
+    "ipaddr.js": "2.5.0",
     "pg": "8.22.0",
     "pg-boss": "12.26.3",
     "posthog-node": "^5.47.0",
+    "undici": "8.10.0",
     "zod": "4.4.3"
   }
 }

--- a/packages/core/src/daytona-config.test.ts
+++ b/packages/core/src/daytona-config.test.ts
@@ -19,6 +19,50 @@ describe("Daytona client configuration", () => {
     });
   });
 
+  it("accepts an absolute HTTPS API URL", () => {
+    expect(
+      requireDaytonaClientConfig({
+        DAYTONA_API_KEY: "api-key",
+        DAYTONA_API_URL: " https://daytona.example.test:8443/api ",
+      }).daytonaApiUrl,
+    ).toBe("https://daytona.example.test:8443/api");
+  });
+
+  it.each([
+    "http://daytona.example.test",
+    "daytona.example.test",
+    "/api",
+  ])("rejects a non-HTTPS or relative API URL: %s", (daytonaApiUrl) => {
+    expect(() =>
+      requireDaytonaClientConfig({
+        DAYTONA_API_KEY: "api-key",
+        DAYTONA_API_URL: daytonaApiUrl,
+      }),
+    ).toThrow("DAYTONA_API_URL must be an absolute HTTPS URL");
+  });
+
+  it("rejects credentials, fragments, and query parameters in the API URL", () => {
+    expect(() =>
+      requireDaytonaClientConfig({
+        DAYTONA_API_KEY: "api-key",
+        DAYTONA_API_URL: "https://user:password@daytona.example.test/api",
+      }),
+    ).toThrow("DAYTONA_API_URL cannot contain credentials");
+    expect(() =>
+      requireDaytonaClientConfig({
+        DAYTONA_API_KEY: "api-key",
+        DAYTONA_API_URL: "https://daytona.example.test/api#ignored",
+      }),
+    ).toThrow("DAYTONA_API_URL cannot contain a fragment");
+    expect(() =>
+      requireDaytonaClientConfig({
+        DAYTONA_API_KEY: "api-key",
+        DAYTONA_API_URL:
+          "https://daytona.example.test/api?access_token=secret",
+      }),
+    ).toThrow("DAYTONA_API_URL cannot contain query parameters");
+  });
+
   it("recognizes not-found errors across package boundaries", () => {
     const namedError = new Error("missing");
     namedError.name = "DaytonaNotFoundError";

--- a/packages/core/src/daytona-config.ts
+++ b/packages/core/src/daytona-config.ts
@@ -4,6 +4,31 @@ export interface DaytonaClientConfig {
   daytonaTarget?: string;
 }
 
+function optionalDaytonaApiUrl(value: string | undefined): string | undefined {
+  const configured = value?.trim();
+  if (!configured) return undefined;
+
+  let url: URL;
+  try {
+    url = new URL(configured);
+  } catch {
+    throw new Error("DAYTONA_API_URL must be an absolute HTTPS URL");
+  }
+  if (url.protocol !== "https:") {
+    throw new Error("DAYTONA_API_URL must be an absolute HTTPS URL");
+  }
+  if (url.username || url.password) {
+    throw new Error("DAYTONA_API_URL cannot contain credentials");
+  }
+  if (url.hash) {
+    throw new Error("DAYTONA_API_URL cannot contain a fragment");
+  }
+  if (url.search) {
+    throw new Error("DAYTONA_API_URL cannot contain query parameters");
+  }
+  return url.toString();
+}
+
 export function requireDaytonaClientConfig(
   environment: NodeJS.ProcessEnv = process.env,
 ): DaytonaClientConfig {
@@ -11,7 +36,7 @@ export function requireDaytonaClientConfig(
   if (!daytonaApiKey) throw new Error("DAYTONA_API_KEY is required");
   return {
     daytonaApiKey,
-    daytonaApiUrl: environment.DAYTONA_API_URL?.trim() || undefined,
+    daytonaApiUrl: optionalDaytonaApiUrl(environment.DAYTONA_API_URL),
     daytonaTarget: environment.DAYTONA_TARGET?.trim() || undefined,
   };
 }

--- a/packages/core/src/db/integrations.test.ts
+++ b/packages/core/src/db/integrations.test.ts
@@ -1,8 +1,17 @@
-import { getTableConfig } from "drizzle-orm/pg-core";
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { getTableConfig, PgDialect } from "drizzle-orm/pg-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { getDatabase } from "./client.js";
-import { upsertIntegrationAccount } from "./integrations.js";
-import { integrationAccounts } from "./schema.js";
+import {
+  createIntegrationConnectionState,
+  consumeIntegrationConnectionState,
+  upsertIntegrationAccount,
+} from "./integrations.js";
+import {
+  integrationAccounts,
+  integrationConnectionStates,
+} from "./schema.js";
 
 vi.mock("./client.js", () => ({
   getDatabase: vi.fn(),
@@ -85,5 +94,100 @@ describe("integration account tenancy", () => {
       upsertIntegrationAccount({ ...account, provider: "github" }),
     ).resolves.toBe("account-3");
     expect(database.select).not.toHaveBeenCalled();
+  });
+
+  it("atomically binds OAuth state consumption to its user and organization", async () => {
+    const returning = vi.fn().mockResolvedValue([]);
+    const where = vi.fn((condition: unknown) => {
+      void condition;
+      return { returning };
+    });
+    vi.mocked(getDatabase).mockReturnValue({
+      delete: vi.fn(() => ({ where })),
+    } as never);
+
+    await consumeIntegrationConnectionState("linear", "oauth-state", {
+      organizationId: account.organizationId,
+      userId: "20000000-0000-4000-8000-000000000000",
+    });
+
+    const query = new PgDialect().sqlToQuery(where.mock.calls[0]![0] as never);
+    expect(query.params).toEqual([
+      createHash("sha256").update("oauth-state").digest("hex"),
+      "linear",
+      account.organizationId,
+      "20000000-0000-4000-8000-000000000000",
+      expect.stringMatching(/^\d{4}-\d{2}-\d{2}T/),
+    ]);
+  });
+
+  it("bounds OAuth connection state to one live flow per owner and provider", async () => {
+    const deleteWhere = vi.fn().mockResolvedValue(undefined);
+    const onConflictDoUpdate = vi.fn().mockResolvedValue(undefined);
+    const values = vi.fn(() => ({ onConflictDoUpdate }));
+    vi.mocked(getDatabase).mockReturnValue({
+      delete: vi.fn(() => ({ where: deleteWhere })),
+      insert: vi.fn(() => ({ values })),
+    } as never);
+
+    const state = await createIntegrationConnectionState({
+      organizationId: account.organizationId,
+      provider: "linear",
+      userId: "20000000-0000-4000-8000-000000000000",
+    });
+
+    expect(state).toMatch(/^[A-Za-z0-9_-]{43}$/);
+    expect(deleteWhere).toHaveBeenCalledOnce();
+    const pruneQuery = new PgDialect().sqlToQuery(
+      deleteWhere.mock.calls[0]![0] as never,
+    );
+    expect(pruneQuery.sql).toContain('"expires_at" <= $1');
+    expect(pruneQuery.params).toEqual([
+      expect.stringMatching(/^\d{4}-\d{2}-\d{2}T/),
+    ]);
+    expect(onConflictDoUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        target: [
+          integrationConnectionStates.organizationId,
+          integrationConnectionStates.userId,
+          integrationConnectionStates.provider,
+        ],
+      }),
+    );
+  });
+
+  it("enforces the OAuth connection-state owner/provider bound in the schema", () => {
+    const indexes = getTableConfig(integrationConnectionStates).indexes;
+    const ownerProviderIndex = indexes.find(
+      (index) =>
+        index.config.name ===
+        "integration_connection_states_owner_provider_idx",
+    );
+
+    expect(ownerProviderIndex?.config.unique).toBe(true);
+    expect(
+      ownerProviderIndex?.config.columns.map((column) =>
+        "name" in column ? column.name : undefined,
+      ),
+    ).toEqual(["organization_id", "user_id", "provider"]);
+  });
+
+  it("re-keys legacy Linear accounts without leaving stale credentials connected", () => {
+    const migration = readFileSync(
+      new URL(
+        "../../../../drizzle/0024_security_hardening.sql",
+        import.meta.url,
+      ),
+      "utf8",
+    );
+
+    expect(migration).toContain(
+      '"external_account_id" = btrim("legacy"."metadata" ->> \'workspaceId\')',
+    );
+    expect(migration).toContain(
+      '"external_account_id" = \'https://mcp.linear.app/mcp\'',
+    );
+    expect(migration).toContain('"encrypted_credentials" = NULL');
+    expect(migration).toContain('"status" = \'error\'');
   });
 });

--- a/packages/core/src/db/integrations.ts
+++ b/packages/core/src/db/integrations.ts
@@ -1,5 +1,5 @@
 import { createHash, randomBytes } from "node:crypto";
-import { and, count, eq, gt, inArray, isNotNull } from "drizzle-orm";
+import { and, count, eq, gt, inArray, isNotNull, lte } from "drizzle-orm";
 import { getDatabase } from "./client.js";
 import {
   integrationAccounts,
@@ -33,7 +33,16 @@ export async function createIntegrationConnectionState(input: {
     ? `responder-v1.${Buffer.from(input.routingUrl).toString("base64url")}.${nonce}`
     : nonce;
 
-  await getDatabase()
+  const database = getDatabase();
+  const expiresAt = new Date(Date.now() + CONNECTION_STATE_TTL_MS);
+
+  // Bound abandoned OAuth attempts. The unique owner/provider index keeps one
+  // live flow even when the same user starts requests concurrently, while the
+  // indexed prune prevents expired rows from accumulating across tenants.
+  await database
+    .delete(integrationConnectionStates)
+    .where(lte(integrationConnectionStates.expiresAt, new Date()));
+  await database
     .insert(integrationConnectionStates)
     .values({
       stateHash: hashConnectionState(state),
@@ -43,7 +52,22 @@ export async function createIntegrationConnectionState(input: {
       codeVerifier: input.codeVerifier,
       metadata: input.metadata ?? {},
       returnTo: input.returnTo ?? "/settings",
-      expiresAt: new Date(Date.now() + CONNECTION_STATE_TTL_MS),
+      expiresAt,
+    })
+    .onConflictDoUpdate({
+      target: [
+        integrationConnectionStates.organizationId,
+        integrationConnectionStates.userId,
+        integrationConnectionStates.provider,
+      ],
+      set: {
+        stateHash: hashConnectionState(state),
+        codeVerifier: input.codeVerifier ?? null,
+        metadata: input.metadata ?? {},
+        returnTo: input.returnTo ?? "/settings",
+        expiresAt,
+        createdAt: new Date(),
+      },
     });
 
   return state;
@@ -52,6 +76,7 @@ export async function createIntegrationConnectionState(input: {
 export async function consumeIntegrationConnectionState(
   provider: IntegrationProvider,
   state: string,
+  tenant: { organizationId: string; userId: string },
 ): Promise<{
   organizationId: string;
   userId: string;
@@ -65,6 +90,8 @@ export async function consumeIntegrationConnectionState(
       and(
         eq(integrationConnectionStates.stateHash, hashConnectionState(state)),
         eq(integrationConnectionStates.provider, provider),
+        eq(integrationConnectionStates.organizationId, tenant.organizationId),
+        eq(integrationConnectionStates.userId, tenant.userId),
         gt(integrationConnectionStates.expiresAt, new Date()),
       ),
     )

--- a/packages/core/src/db/issues.test.ts
+++ b/packages/core/src/db/issues.test.ts
@@ -1,0 +1,156 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getDatabase } from "./client.js";
+import { submitInvestigationReport } from "./issues.js";
+import { queueAutomaticIssuePullRequests } from "./pull-requests.js";
+import { investigations } from "./schema.js";
+
+vi.mock("./client.js", () => ({
+  getDatabase: vi.fn(),
+}));
+
+vi.mock("./pull-requests.js", () => ({
+  getIssuePullRequestState: vi.fn(),
+  queueAutomaticIssuePullRequests: vi.fn(),
+}));
+
+const investigationId = "16161616-1616-4616-8616-161616161616";
+const organizationId = "15151515-1515-4515-8515-151515151515";
+const agentConfigVersionId = "08080808-0808-4808-8808-080808080808";
+const firstIssueId = "10101010-1010-4010-8010-101010101010";
+const secondIssueId = "20202020-2020-4020-8020-202020202020";
+
+function databaseDouble(status = "investigating") {
+  const forUpdate = vi.fn().mockResolvedValue([{
+    id: investigationId,
+    status,
+    agentConfigVersionId,
+    prMode: "always",
+  }]);
+  const investigationSelect = {
+    innerJoin: vi.fn(),
+    where: vi.fn(() => ({
+      limit: vi.fn(() => ({ for: forUpdate })),
+    })),
+  };
+  investigationSelect.innerJoin.mockReturnValue(investigationSelect);
+
+  const existingIssueWhere = vi.fn().mockResolvedValue([
+    {
+      id: firstIssueId,
+      title: "First issue",
+      description: "First issue description",
+      severity: "SEV-2",
+      remediation: "Fix the first issue",
+    },
+    {
+      id: secondIssueId,
+      title: "Second issue",
+      description: "Second issue description",
+      severity: "SEV-3",
+      remediation: "Fix the second issue",
+    },
+  ]);
+  const select = vi
+    .fn()
+    .mockReturnValueOnce({ from: vi.fn(() => investigationSelect) })
+    .mockReturnValueOnce({
+      from: vi.fn(() => ({ where: existingIssueWhere })),
+    });
+  const investigationIssueValues = vi.fn().mockResolvedValue([]);
+  const updateWhere = vi.fn().mockResolvedValue([]);
+  const tx = {
+    insert: vi.fn(() => ({ values: investigationIssueValues })),
+    select,
+    update: vi.fn(() => ({
+      set: vi.fn(() => ({ where: updateWhere })),
+    })),
+  };
+  const transaction = vi.fn(async (callback) => callback(tx));
+  vi.mocked(getDatabase).mockReturnValue({ transaction } as never);
+  return { forUpdate, tx };
+}
+
+describe("automatic pull requests from investigation reports", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns issue and request IDs only for inserts that won a conflict", async () => {
+    const { forUpdate, tx } = databaseDouble();
+    const requestId = "05050505-0505-4505-8505-050505050505";
+    vi.mocked(queueAutomaticIssuePullRequests).mockResolvedValue([{
+      id: requestId,
+      issueId: secondIssueId,
+    }]);
+    const evidence = [{
+      source: "other" as const,
+      title: "Observed failure",
+      detail: "The failure recurred during this investigation.",
+    }];
+
+    const result = await submitInvestigationReport({
+      investigationId,
+      organizationId,
+      submission: {
+        newIssueEmbeddings: [],
+        report: {
+          schemaVersion: 1,
+          headline: "Two issues recurred",
+          summary: "Only one automatic request won its concurrent insert.",
+          issues: [
+            {
+              evidence,
+              issueId: firstIssueId,
+              resolution: "existing",
+            },
+            {
+              evidence,
+              issueId: secondIssueId,
+              resolution: "existing",
+            },
+          ],
+        },
+      },
+    });
+
+    expect(queueAutomaticIssuePullRequests).toHaveBeenCalledWith(tx, {
+      agentConfigVersionId,
+      investigationId,
+      issueIds: [firstIssueId, secondIssueId],
+    });
+    expect(result.automaticPullRequestIssueIds).toEqual([secondIssueId]);
+    expect(result.automaticPullRequestRequestIds).toEqual([requestId]);
+    expect(forUpdate).toHaveBeenCalledWith("update", { of: investigations });
+  });
+
+  it("rejects a second report after the locked investigation is resolved", async () => {
+    const { tx } = databaseDouble("resolved");
+    const evidence = [{
+      source: "other" as const,
+      title: "Observed failure",
+      detail: "The failure recurred during this investigation.",
+    }];
+
+    await expect(
+      submitInvestigationReport({
+        investigationId,
+        organizationId,
+        submission: {
+          newIssueEmbeddings: [],
+          report: {
+            schemaVersion: 1,
+            headline: "Duplicate report",
+            summary: "This second submission must not write.",
+            issues: [{
+              evidence,
+              issueId: firstIssueId,
+              resolution: "existing",
+            }],
+          },
+        },
+      }),
+    ).rejects.toThrow("Investigation report has already been submitted");
+    expect(tx.insert).not.toHaveBeenCalled();
+    expect(queueAutomaticIssuePullRequests).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/db/issues.ts
+++ b/packages/core/src/db/issues.ts
@@ -22,12 +22,14 @@ import {
   investigationIssues,
   investigations,
   issueLinearTickets,
-  issuePullRequests,
   issues,
   type AgentPrMode,
   type InvestigationSlackTraceItem,
 } from "./schema.js";
-import { getIssuePullRequestState } from "./pull-requests.js";
+import {
+  getIssuePullRequestState,
+  queueAutomaticIssuePullRequests,
+} from "./pull-requests.js";
 
 export interface IssueEmbedding {
   model: string;
@@ -140,7 +142,8 @@ export async function submitInvestigationReport(input: {
           eq(investigations.organizationId, input.organizationId),
         ),
       )
-      .limit(1);
+      .limit(1)
+      .for("update", { of: investigations });
     const investigation = investigationRows[0];
     if (!investigation) throw new Error("Investigation not found");
     if (
@@ -256,46 +259,14 @@ export async function submitInvestigationReport(input: {
     const candidatePullRequestIssueIds = references.map(
       (reference) => reference.issueId,
     );
-    const existingPullRequestIssueIds =
-      investigation.prMode === "always" &&
-      candidatePullRequestIssueIds.length > 0
-        ? new Set(
-            (
-              await tx
-                .select({ issueId: issuePullRequests.issueId })
-                .from(issuePullRequests)
-                .where(
-                  and(
-                    inArray(
-                      issuePullRequests.issueId,
-                      candidatePullRequestIssueIds,
-                    ),
-                    inArray(issuePullRequests.status, [
-                      "queued",
-                      "creating",
-                      "created",
-                    ]),
-                  ),
-                )
-            ).map((request) => request.issueId),
-          )
-        : new Set<string>();
-    const automaticPullRequestIssueIds = candidatePullRequestIssueIds.filter(
-      (issueId) => !existingPullRequestIssueIds.has(issueId),
-    );
     const automaticPullRequestRequests =
       investigation.prMode === "always" &&
-      automaticPullRequestIssueIds.length > 0
-        ? await tx
-            .insert(issuePullRequests)
-            .values(
-              automaticPullRequestIssueIds.map((issueId) => ({
-                issueId,
-                investigationId: input.investigationId,
-                agentConfigVersionId: investigation.agentConfigVersionId,
-              })),
-            )
-            .returning({ id: issuePullRequests.id })
+      candidatePullRequestIssueIds.length > 0
+        ? await queueAutomaticIssuePullRequests(tx, {
+            agentConfigVersionId: investigation.agentConfigVersionId,
+            investigationId: input.investigationId,
+            issueIds: candidatePullRequestIssueIds,
+          })
         : [];
     const newIssueIds = references.flatMap((reference) =>
       reference.relationship === "new" ? [reference.issueId] : [],
@@ -326,7 +297,13 @@ export async function submitInvestigationReport(input: {
         completedAt: new Date(),
         updatedAt: new Date(),
       })
-      .where(eq(investigations.id, input.investigationId));
+      .where(
+        and(
+          eq(investigations.id, input.investigationId),
+          eq(investigations.organizationId, input.organizationId),
+          inArray(investigations.status, ["pending", "investigating"]),
+        ),
+      );
 
     return {
       report,
@@ -367,7 +344,7 @@ export async function submitInvestigationReport(input: {
       markdown,
       automaticPullRequestIssueIds:
         investigation.prMode === "always"
-          ? automaticPullRequestIssueIds
+          ? automaticPullRequestRequests.map((request) => request.issueId)
           : [],
       automaticPullRequestRequestIds: automaticPullRequestRequests.map(
         (request) => request.id,

--- a/packages/core/src/db/linear-tickets.test.ts
+++ b/packages/core/src/db/linear-tickets.test.ts
@@ -1,4 +1,4 @@
-import { getTableConfig } from "drizzle-orm/pg-core";
+import { getTableConfig, PgDialect } from "drizzle-orm/pg-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   createLinearIssue,
@@ -9,6 +9,7 @@ import { getDatabase } from "./client.js";
 import { getRuntimeLinearConnection } from "./investigations.js";
 import {
   fulfillLinearTicketRequest,
+  listPendingLinearTicketRequests,
   LinearTicketError,
 } from "./linear-tickets.js";
 import { issueLinearTickets } from "./schema.js";
@@ -47,7 +48,10 @@ const request = {
   linearIssueUrl: null,
 };
 
-function databaseDouble(rows: unknown[]) {
+function databaseDouble(
+  rows: unknown[],
+  claimedRows: Array<{ id: string }> = [{ id: scope.requestId }],
+) {
   const limit = vi.fn().mockResolvedValue(rows);
   const innerJoin = vi.fn();
   const query = {
@@ -56,11 +60,15 @@ function databaseDouble(rows: unknown[]) {
   };
   innerJoin.mockReturnValue(query);
   const finalWhere = vi.fn().mockResolvedValue(undefined);
-  const returning = vi.fn().mockResolvedValue([{ id: scope.requestId }]);
+  const returning = vi.fn().mockResolvedValue(claimedRows);
+  const claimWhere = vi.fn((condition: unknown) => {
+    void condition;
+    return { returning };
+  });
   const update = vi.fn()
     .mockReturnValueOnce({
       set: vi.fn(() => ({
-        where: vi.fn(() => ({ returning })),
+        where: claimWhere,
       })),
     })
     .mockReturnValue({
@@ -72,6 +80,11 @@ function databaseDouble(rows: unknown[]) {
     })),
     update,
   } as never);
+  return { claimWhere };
+}
+
+function compiledSql(statement: unknown) {
+  return new PgDialect().sqlToQuery(statement as never);
 }
 
 describe("Linear ticket requests", () => {
@@ -98,7 +111,7 @@ describe("Linear ticket requests", () => {
 
   it("recovers a retry by looking up the stable request ID", async () => {
     vi.stubEnv("RESPONDER_PUBLIC_URL", "https://responder.example");
-    databaseDouble([request]);
+    const { claimWhere } = databaseDouble([request]);
     vi.mocked(getRuntimeLinearConnection).mockResolvedValue({
       accessToken: "linear-token",
       accountId: request.integrationAccountId,
@@ -133,5 +146,56 @@ describe("Linear ticket requests", () => {
       scope.agentConfigVersionId,
       request.integrationAccountId,
     );
+    const claim = compiledSql(claimWhere.mock.calls[0]![0]);
+    expect(claim.params).toEqual([
+      request.id,
+      "pending",
+      "failed",
+      6,
+    ]);
+    expect(claim.params).not.toContain("creating");
+  });
+
+  it("does not let a concurrent worker reclaim an active request", async () => {
+    databaseDouble([request], []);
+
+    await expect(fulfillLinearTicketRequest(scope)).rejects.toEqual(
+      new LinearTicketError(
+        "Linear ticket request is no longer active",
+        "request_not_active",
+      ),
+    );
+    expect(getRuntimeLinearConnection).not.toHaveBeenCalled();
+    expect(createLinearIssue).not.toHaveBeenCalled();
+  });
+
+  it("does not expose active requests to duplicate jobs", async () => {
+    const orderBy = vi.fn().mockResolvedValue([]);
+    const where = vi.fn((condition: unknown) => {
+      void condition;
+      return { orderBy };
+    });
+    const joined = { innerJoin: vi.fn(), where };
+    joined.innerJoin.mockReturnValue(joined);
+    vi.mocked(getDatabase).mockReturnValue({
+      select: vi.fn(() => ({
+        from: vi.fn(() => joined),
+      })),
+    } as never);
+
+    await expect(listPendingLinearTicketRequests({
+      investigationId: scope.investigationId,
+      organizationId: scope.organizationId,
+    })).resolves.toEqual([]);
+
+    const pending = compiledSql(where.mock.calls[0]![0]);
+    expect(pending.params).toEqual([
+      scope.investigationId,
+      scope.organizationId,
+      "pending",
+      "failed",
+      6,
+    ]);
+    expect(pending.params).not.toContain("creating");
   });
 });

--- a/packages/core/src/db/linear-tickets.ts
+++ b/packages/core/src/db/linear-tickets.ts
@@ -13,6 +13,16 @@ import {
   issues,
 } from "./schema.js";
 
+const retryableLinearTicketStatuses = ["pending", "failed"] as const;
+const linearTicketAttemptLimit = 6;
+
+function retryableLinearTicketRequestPredicate() {
+  return and(
+    inArray(issueLinearTickets.status, retryableLinearTicketStatuses),
+    lt(issueLinearTickets.attemptCount, linearTicketAttemptLimit),
+  );
+}
+
 export class LinearTicketError extends Error {
   constructor(
     message: string,
@@ -49,7 +59,7 @@ export async function listPendingLinearTicketRequests(input: {
       and(
         eq(issueLinearTickets.investigationId, input.investigationId),
         eq(investigations.organizationId, input.organizationId),
-        inArray(issueLinearTickets.status, ["pending", "creating", "failed"]),
+        retryableLinearTicketRequestPredicate(),
       ),
     )
     .orderBy(issueLinearTickets.createdAt);
@@ -65,7 +75,7 @@ export async function listLinearTicketRequestsForQueue(limit = 100) {
       and(
         eq(issueLinearTickets.status, "creating"),
         lt(issueLinearTickets.updatedAt, staleBefore),
-        lt(issueLinearTickets.attemptCount, 6),
+        lt(issueLinearTickets.attemptCount, linearTicketAttemptLimit),
       ),
     );
   return db
@@ -77,7 +87,7 @@ export async function listLinearTicketRequestsForQueue(limit = 100) {
     .from(issueLinearTickets)
     .where(
       and(
-        lt(issueLinearTickets.attemptCount, 6),
+        lt(issueLinearTickets.attemptCount, linearTicketAttemptLimit),
         eq(issueLinearTickets.status, "pending"),
       ),
     )
@@ -196,7 +206,7 @@ export async function fulfillLinearTicketRequest(input: {
     .where(
       and(
         eq(issueLinearTickets.id, request.id),
-        inArray(issueLinearTickets.status, ["pending", "creating", "failed"]),
+        retryableLinearTicketRequestPredicate(),
       ),
     )
     .returning({ id: issueLinearTickets.id });

--- a/packages/core/src/db/pull-requests.test.ts
+++ b/packages/core/src/db/pull-requests.test.ts
@@ -1,0 +1,414 @@
+import { getTableConfig, PgDialect } from "drizzle-orm/pg-core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getDatabase } from "./client.js";
+import {
+  claimIssuePullRequestForRemediation,
+  listStaleCreatingIssuePullRequests,
+  markIssuePullRequestStarted,
+  queueAutomaticIssuePullRequests,
+  queueManualIssuePullRequest,
+  recoverAbandonedIssuePullRequest,
+} from "./pull-requests.js";
+import {
+  activeIssuePullRequestIndexPredicate,
+  issuePullRequests,
+} from "./schema.js";
+
+vi.mock("./client.js", () => ({
+  getDatabase: vi.fn(),
+}));
+
+const issueId = "10101010-1010-4010-8010-101010101010";
+const organizationId = "15151515-1515-4515-8515-151515151515";
+const investigationId = "16161616-1616-4616-8616-161616161616";
+const agentConfigVersionId = "08080808-0808-4808-8808-080808080808";
+
+function simpleSelect(
+  rows: unknown[],
+  limit = vi.fn().mockResolvedValue(rows),
+) {
+  return {
+    from: vi.fn(() => ({
+      where: vi.fn(() => ({ limit })),
+    })),
+  };
+}
+
+function joinedSelect(rows: unknown[]) {
+  const limit = vi.fn().mockResolvedValue(rows);
+  const joined = {
+    innerJoin: vi.fn(),
+    where: vi.fn(() => ({
+      orderBy: vi.fn(() => ({ limit })),
+    })),
+  };
+  joined.innerJoin.mockReturnValue(joined);
+  return { from: vi.fn(() => joined) };
+}
+
+function databaseDouble(
+  inserted: Array<{ id: string }>,
+  options: {
+    activeIndexAvailable?: boolean;
+    existing?: Array<{ id: string }>;
+  } = {},
+) {
+  const activeIndexAvailable = options.activeIndexAvailable ?? true;
+  const existingLimit = vi.fn().mockResolvedValue(options.existing ?? []);
+  const returning = vi.fn().mockResolvedValue(inserted);
+  const onConflictDoNothing = vi.fn(() => ({ returning }));
+  const values = vi.fn(() => ({ onConflictDoNothing, returning }));
+  const execute = vi
+    .fn()
+    .mockResolvedValueOnce({ rows: [{ available: activeIndexAvailable }] })
+    .mockResolvedValue({ rows: [] });
+  const transaction = vi.fn(async (callback) => {
+    const select = vi
+      .fn()
+      .mockReturnValueOnce(simpleSelect([{ id: issueId }]))
+      .mockReturnValueOnce(simpleSelect(options.existing ?? [], existingLimit))
+      .mockReturnValueOnce(
+        joinedSelect([{ investigationId, agentConfigVersionId }]),
+      );
+    return callback({
+      execute,
+      insert: vi.fn(() => ({ values })),
+      select,
+    });
+  });
+  vi.mocked(getDatabase).mockReturnValue({ transaction } as never);
+  return { execute, existingLimit, onConflictDoNothing, returning };
+}
+
+function compiledSql(statement: unknown) {
+  return new PgDialect().sqlToQuery(statement as never);
+}
+
+describe("manual pull request uniqueness", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("enforces one active pull request request for each issue", () => {
+    const index = getTableConfig(issuePullRequests).indexes.find(
+      (candidate) =>
+        candidate.config.name === "issue_pull_requests_active_issue_idx",
+    );
+
+    expect(index?.config.unique).toBe(true);
+    expect(
+      index?.config.columns.map((column) =>
+        "name" in column ? column.name : undefined,
+      ),
+    ).toEqual(["issue_id"]);
+    expect(index?.config.where).toBe(activeIssuePullRequestIndexPredicate);
+    expect(
+      new PgDialect().sqlToQuery(activeIssuePullRequestIndexPredicate).sql,
+    ).toBe(`"status" in ('queued', 'creating', 'created')`);
+  });
+
+  it("returns the request that wins the atomic insert", async () => {
+    const requestId = "05050505-0505-4505-8505-050505050505";
+    const { execute, onConflictDoNothing } = databaseDouble([{ id: requestId }]);
+
+    await expect(
+      queueManualIssuePullRequest({ issueId, organizationId }),
+    ).resolves.toEqual({ id: requestId });
+    expect(execute).toHaveBeenCalledOnce();
+    expect(compiledSql(execute.mock.calls[0]![0])).toMatchObject({
+      params: ["public.issue_pull_requests_active_issue_idx"],
+    });
+    expect(compiledSql(execute.mock.calls[0]![0]).sql).toContain(
+      "and indisunique",
+    );
+    expect(onConflictDoNothing).toHaveBeenCalledWith({
+      target: issuePullRequests.issueId,
+      where: activeIssuePullRequestIndexPredicate,
+    });
+  });
+
+  it("rejects a concurrent request that loses the atomic insert", async () => {
+    databaseDouble([]);
+
+    await expect(
+      queueManualIssuePullRequest({ issueId, organizationId }),
+    ).rejects.toMatchObject({
+      code: "already_requested",
+      message: "A pull request has already been requested for this issue",
+    });
+  });
+
+  it("serializes and inserts without ON CONFLICT before the index exists", async () => {
+    const requestId = "05050505-0505-4505-8505-050505050505";
+    const {
+      execute,
+      existingLimit,
+      onConflictDoNothing,
+      returning,
+    } = databaseDouble([{ id: requestId }], { activeIndexAvailable: false });
+
+    await expect(
+      queueManualIssuePullRequest({ issueId, organizationId }),
+    ).resolves.toEqual({ id: requestId });
+
+    expect(execute).toHaveBeenCalledTimes(2);
+    expect(compiledSql(execute.mock.calls[1]![0]).sql).toBe(
+      'lock table "issue_pull_requests" in access exclusive mode',
+    );
+    expect(execute.mock.invocationCallOrder[1]).toBeLessThan(
+      existingLimit.mock.invocationCallOrder[0]!,
+    );
+    expect(onConflictDoNothing).not.toHaveBeenCalled();
+    expect(returning).toHaveBeenCalledOnce();
+  });
+
+  it("rechecks for an active request after acquiring the compatibility lock", async () => {
+    const existingRequestId = "06060606-0606-4606-8606-060606060606";
+    const { execute, onConflictDoNothing, returning } = databaseDouble([], {
+      activeIndexAvailable: false,
+      existing: [{ id: existingRequestId }],
+    });
+
+    await expect(
+      queueManualIssuePullRequest({ issueId, organizationId }),
+    ).rejects.toMatchObject({
+      code: "already_requested",
+      message: "A pull request has already been requested for this issue",
+    });
+
+    expect(execute).toHaveBeenCalledTimes(2);
+    expect(onConflictDoNothing).not.toHaveBeenCalled();
+    expect(returning).not.toHaveBeenCalled();
+  });
+});
+
+describe("remediation request state transitions", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function updateDouble(rows: Array<{ id: string }>) {
+    const returning = vi.fn().mockResolvedValue(rows);
+    const where = vi.fn((condition: unknown) => {
+      void condition;
+      return { returning };
+    });
+    vi.mocked(getDatabase).mockReturnValue({
+      update: vi.fn(() => ({
+        set: vi.fn(() => ({ where })),
+      })),
+    } as never);
+    return { where };
+  }
+
+  it("claims only a queued request before placing it on the exclusive queue", async () => {
+    const requestId = "05050505-0505-4505-8505-050505050505";
+    const { where } = updateDouble([{ id: requestId }]);
+
+    await claimIssuePullRequestForRemediation(requestId);
+
+    expect(compiledSql(where.mock.calls[0]![0]).params).toEqual([
+      requestId,
+      "queued",
+    ]);
+  });
+
+  it("lets the assigned worker continue an already-creating request", async () => {
+    const requestId = "05050505-0505-4505-8505-050505050505";
+    const { where } = updateDouble([{ id: requestId }]);
+
+    await markIssuePullRequestStarted(requestId);
+
+    expect(compiledSql(where.mock.calls[0]![0]).params).toEqual([
+      requestId,
+      "queued",
+      "creating",
+    ]);
+  });
+
+  it("rejects a losing enqueue claim", async () => {
+    updateDouble([]);
+
+    await expect(
+      claimIssuePullRequestForRemediation(
+        "05050505-0505-4505-8505-050505050505",
+      ),
+    ).rejects.toMatchObject({ code: "request_not_found" });
+  });
+
+  it("rejects an assigned worker starting an inactive request", async () => {
+    updateDouble([]);
+
+    await expect(
+      markIssuePullRequestStarted(
+        "05050505-0505-4505-8505-050505050505",
+      ),
+    ).rejects.toMatchObject({ code: "request_not_found" });
+  });
+
+  it("lists only creating requests older than the recovery cutoff", async () => {
+    const staleBefore = new Date("2026-08-17T12:00:00.000Z");
+    const limit = vi.fn().mockResolvedValue([]);
+    const where = vi.fn((condition: unknown) => {
+      void condition;
+      return { limit };
+    });
+    vi.mocked(getDatabase).mockReturnValue({
+      select: vi.fn(() => ({
+        from: vi.fn(() => ({ where })),
+      })),
+    } as never);
+
+    await listStaleCreatingIssuePullRequests(staleBefore);
+
+    expect(compiledSql(where.mock.calls[0]![0]).params).toEqual([
+      "creating",
+      staleBefore.toISOString(),
+    ]);
+    expect(limit).toHaveBeenCalledWith(100);
+  });
+
+  it("atomically fails an abandoned request only while it remains stale", async () => {
+    const requestId = "05050505-0505-4505-8505-050505050505";
+    const staleBefore = new Date("2026-08-17T12:00:00.000Z");
+    const returning = vi.fn().mockResolvedValue([{ id: requestId }]);
+    const where = vi.fn((condition: unknown) => {
+      void condition;
+      return { returning };
+    });
+    const set = vi.fn(() => ({ where }));
+    vi.mocked(getDatabase).mockReturnValue({
+      update: vi.fn(() => ({ set })),
+    } as never);
+
+    await expect(
+      recoverAbandonedIssuePullRequest(requestId, staleBefore),
+    ).resolves.toBe(true);
+
+    expect(set).toHaveBeenCalledWith(expect.objectContaining({
+      failureReason: "Remediation worker stopped before recording a result",
+      status: "failed",
+    }));
+    expect(compiledSql(where.mock.calls[0]![0]).params).toEqual([
+      requestId,
+      "creating",
+      staleBefore.toISOString(),
+    ]);
+  });
+});
+
+function automaticTransactionDouble(options: {
+  activeIndexAvailable: boolean;
+  existing?: Array<{ issueId: string }>;
+  inserted: Array<{ id: string; issueId: string }>;
+}) {
+  const returning = vi.fn().mockResolvedValue(options.inserted);
+  const onConflictDoNothing = vi.fn(() => ({ returning }));
+  const values = vi.fn(() => ({ onConflictDoNothing, returning }));
+  const existingWhere = vi.fn().mockResolvedValue(options.existing ?? []);
+  const execute = vi
+    .fn()
+    .mockResolvedValueOnce({
+      rows: [{ available: options.activeIndexAvailable }],
+    })
+    .mockResolvedValue({ rows: [] });
+  const tx = {
+    execute,
+    insert: vi.fn(() => ({ values })),
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({ where: existingWhere })),
+    })),
+  };
+  return {
+    execute,
+    existingWhere,
+    onConflictDoNothing,
+    returning,
+    tx,
+    values,
+  };
+}
+
+describe("automatic pull request uniqueness", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns only contenders inserted through the active partial index", async () => {
+    const secondIssueId = "20202020-2020-4020-8020-202020202020";
+    const winningRequest = {
+      id: "05050505-0505-4505-8505-050505050505",
+      issueId,
+    };
+    const { existingWhere, onConflictDoNothing, tx, values } =
+      automaticTransactionDouble({
+        activeIndexAvailable: true,
+        inserted: [winningRequest],
+      });
+
+    await expect(
+      queueAutomaticIssuePullRequests(tx as never, {
+        agentConfigVersionId,
+        investigationId,
+        issueIds: [issueId, secondIssueId],
+      }),
+    ).resolves.toEqual([winningRequest]);
+
+    expect(values).toHaveBeenCalledWith([
+      { agentConfigVersionId, investigationId, issueId },
+      { agentConfigVersionId, investigationId, issueId: secondIssueId },
+    ]);
+    expect(onConflictDoNothing).toHaveBeenCalledWith({
+      target: issuePullRequests.issueId,
+      where: activeIssuePullRequestIndexPredicate,
+    });
+    const activeRequestQuery = compiledSql(existingWhere.mock.calls[0]![0]);
+    expect(activeRequestQuery.params).toEqual([
+      issueId,
+      secondIssueId,
+      "queued",
+      "creating",
+      "created",
+    ]);
+    expect(activeRequestQuery.params).not.toContain("merged");
+  });
+
+  it("serializes before checking and inserts only missing requests pre-migration", async () => {
+    const secondIssueId = "20202020-2020-4020-8020-202020202020";
+    const inserted = [{
+      id: "05050505-0505-4505-8505-050505050505",
+      issueId: secondIssueId,
+    }];
+    const {
+      execute,
+      existingWhere,
+      onConflictDoNothing,
+      tx,
+      values,
+    } = automaticTransactionDouble({
+      activeIndexAvailable: false,
+      existing: [{ issueId }],
+      inserted,
+    });
+
+    await expect(
+      queueAutomaticIssuePullRequests(tx as never, {
+        agentConfigVersionId,
+        investigationId,
+        issueIds: [issueId, secondIssueId],
+      }),
+    ).resolves.toEqual(inserted);
+
+    expect(execute).toHaveBeenCalledTimes(2);
+    expect(compiledSql(execute.mock.calls[1]![0]).sql).toBe(
+      'lock table "issue_pull_requests" in access exclusive mode',
+    );
+    expect(execute.mock.invocationCallOrder[1]).toBeLessThan(
+      existingWhere.mock.invocationCallOrder[0]!,
+    );
+    expect(values).toHaveBeenCalledWith([
+      { agentConfigVersionId, investigationId, issueId: secondIssueId },
+    ]);
+    expect(onConflictDoNothing).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/db/pull-requests.ts
+++ b/packages/core/src/db/pull-requests.ts
@@ -1,6 +1,7 @@
-import { and, desc, eq, inArray } from "drizzle-orm";
+import { and, desc, eq, inArray, lt, sql } from "drizzle-orm";
 import { getDatabase } from "./client.js";
 import {
+  activeIssuePullRequestIndexPredicate,
   agentConfigVersions,
   agents,
   instanceConfiguration,
@@ -10,6 +11,16 @@ import {
   issues,
   runtimeProfiles,
 } from "./schema.js";
+
+type IssuePullRequestTransaction = Parameters<
+  Parameters<ReturnType<typeof getDatabase>["transaction"]>[0]
+>[0];
+
+const activeIssuePullRequestStatuses = [
+  "queued",
+  "creating",
+  "created",
+] as const;
 
 export class IssuePullRequestError extends Error {
   constructor(
@@ -23,6 +34,82 @@ export class IssuePullRequestError extends Error {
     super(message);
     this.name = "IssuePullRequestError";
   }
+}
+
+async function prepareIssuePullRequestWrite(
+  tx: IssuePullRequestTransaction,
+): Promise<boolean> {
+  const activeIndexResult = await tx.execute<{ available: boolean }>(sql`
+    select exists (
+      select 1
+      from pg_catalog.pg_index
+      where indexrelid = to_regclass(
+        ${"public.issue_pull_requests_active_issue_idx"}
+      )
+        and indisvalid
+        and indisunique
+    ) as available
+  `);
+  const activeIndexAvailable = activeIndexResult.rows[0]?.available === true;
+
+  // During a rolling/schema-first upgrade, a caller can briefly run before the
+  // partial unique index exists. Serialize that compatibility path, then check
+  // for an active request while holding the lock. The lock also makes this safe
+  // when it races with the migration that creates the index.
+  if (!activeIndexAvailable) {
+    await tx.execute(
+      sql`lock table ${issuePullRequests} in access exclusive mode`,
+    );
+  }
+
+  return activeIndexAvailable;
+}
+
+export async function queueAutomaticIssuePullRequests(
+  tx: IssuePullRequestTransaction,
+  input: {
+    agentConfigVersionId: string;
+    investigationId: string;
+    issueIds: string[];
+  },
+) {
+  const uniqueIssueIds = [...new Set(input.issueIds)];
+  if (uniqueIssueIds.length === 0) return [];
+
+  const activeIndexAvailable = await prepareIssuePullRequestWrite(tx);
+  const existing = await tx
+    .select({ issueId: issuePullRequests.issueId })
+    .from(issuePullRequests)
+    .where(
+      and(
+        inArray(issuePullRequests.issueId, uniqueIssueIds),
+        inArray(issuePullRequests.status, activeIssuePullRequestStatuses),
+      ),
+    );
+  const existingIssueIds = new Set(existing.map((request) => request.issueId));
+  const requestedIssueIds = uniqueIssueIds.filter(
+    (issueId) => !existingIssueIds.has(issueId),
+  );
+  if (requestedIssueIds.length === 0) return [];
+
+  const insert = tx.insert(issuePullRequests).values(
+    requestedIssueIds.map((issueId) => ({
+      issueId,
+      investigationId: input.investigationId,
+      agentConfigVersionId: input.agentConfigVersionId,
+    })),
+  );
+  return activeIndexAvailable
+    ? insert
+      .onConflictDoNothing({
+        target: issuePullRequests.issueId,
+        where: activeIssuePullRequestIndexPredicate,
+      })
+      .returning({ id: issuePullRequests.id, issueId: issuePullRequests.issueId })
+    : insert.returning({
+      id: issuePullRequests.id,
+      issueId: issuePullRequests.issueId,
+    });
 }
 
 export async function getIssuePullRequestState(
@@ -108,6 +195,8 @@ export async function queueManualIssuePullRequest(input: {
       throw new IssuePullRequestError("Issue not found", "issue_not_found");
     }
 
+    const activeIndexAvailable = await prepareIssuePullRequestWrite(tx);
+
     const existing = await tx
       .select({ id: issuePullRequests.id })
       .from(issuePullRequests)
@@ -166,15 +255,29 @@ export async function queueManualIssuePullRequest(input: {
       );
     }
 
-    const inserted = await tx
+    const insert = tx
       .insert(issuePullRequests)
       .values({
         issueId: input.issueId,
         investigationId: target.investigationId,
         agentConfigVersionId: target.agentConfigVersionId,
-      })
-      .returning({ id: issuePullRequests.id });
-    return inserted[0]!;
+      });
+    const inserted = activeIndexAvailable
+      ? await insert
+        .onConflictDoNothing({
+          target: issuePullRequests.issueId,
+          where: activeIssuePullRequestIndexPredicate,
+        })
+        .returning({ id: issuePullRequests.id })
+      : await insert.returning({ id: issuePullRequests.id });
+    const request = inserted[0];
+    if (!request) {
+      throw new IssuePullRequestError(
+        "A pull request has already been requested for this issue",
+        "already_requested",
+      );
+    }
+    return request;
   });
 }
 
@@ -235,8 +338,9 @@ export async function getIssuePullRequestForRemediation(requestId: string) {
   return { ...request, runtimeProfileId };
 }
 
-export async function markIssuePullRequestStarted(
+async function transitionIssuePullRequestToCreating(
   requestId: string,
+  acceptedStatuses: Array<"queued" | "creating">,
 ) {
   const rows = await getDatabase()
     .update(issuePullRequests)
@@ -248,7 +352,7 @@ export async function markIssuePullRequestStarted(
     .where(
       and(
         eq(issuePullRequests.id, requestId),
-        inArray(issuePullRequests.status, ["queued", "creating"]),
+        inArray(issuePullRequests.status, acceptedStatuses),
       ),
     )
     .returning({ id: issuePullRequests.id });
@@ -258,6 +362,21 @@ export async function markIssuePullRequestStarted(
       "request_not_found",
     );
   }
+}
+
+export async function claimIssuePullRequestForRemediation(
+  requestId: string,
+) {
+  return transitionIssuePullRequestToCreating(requestId, ["queued"]);
+}
+
+export async function markIssuePullRequestStarted(
+  requestId: string,
+) {
+  return transitionIssuePullRequestToCreating(requestId, [
+    "queued",
+    "creating",
+  ]);
 }
 
 export async function setIssuePullRequestSession(
@@ -406,6 +525,42 @@ export async function failIssuePullRequest(
         inArray(issuePullRequests.status, ["queued", "creating"]),
       ),
     );
+}
+
+export async function listStaleCreatingIssuePullRequests(staleBefore: Date) {
+  return getDatabase()
+    .select({ requestId: issuePullRequests.id })
+    .from(issuePullRequests)
+    .where(
+      and(
+        eq(issuePullRequests.status, "creating"),
+        lt(issuePullRequests.updatedAt, staleBefore),
+      ),
+    )
+    .limit(100);
+}
+
+export async function recoverAbandonedIssuePullRequest(
+  requestId: string,
+  staleBefore: Date,
+): Promise<boolean> {
+  const recovered = await getDatabase()
+    .update(issuePullRequests)
+    .set({
+      status: "failed",
+      failureReason: "Remediation worker stopped before recording a result",
+      completedAt: new Date(),
+      updatedAt: new Date(),
+    })
+    .where(
+      and(
+        eq(issuePullRequests.id, requestId),
+        eq(issuePullRequests.status, "creating"),
+        lt(issuePullRequests.updatedAt, staleBefore),
+      ),
+    )
+    .returning({ id: issuePullRequests.id });
+  return recovered.length > 0;
 }
 
 export async function failPendingInvestigationPullRequests(

--- a/packages/core/src/db/schema.ts
+++ b/packages/core/src/db/schema.ts
@@ -1,3 +1,4 @@
+import { sql } from "drizzle-orm";
 import {
   boolean,
   foreignKey,
@@ -229,6 +230,11 @@ export const integrationConnectionStates = pgTable(
   (table) => [
     index("integration_connection_states_expires_idx").on(table.expiresAt),
     index("integration_connection_states_organization_idx").on(table.organizationId),
+    uniqueIndex("integration_connection_states_owner_provider_idx").on(
+      table.organizationId,
+      table.userId,
+      table.provider,
+    ),
   ],
 );
 
@@ -510,6 +516,10 @@ export const issues = pgTable(
   ],
 );
 
+export const activeIssuePullRequestIndexPredicate = sql.raw(
+  `"status" in ('queued', 'creating', 'created')`,
+);
+
 export const issuePullRequests = pgTable(
   "issue_pull_requests",
   {
@@ -538,6 +548,9 @@ export const issuePullRequests = pgTable(
     completedAt: timestamp("completed_at", { withTimezone: true }),
   },
   (table) => [
+    uniqueIndex("issue_pull_requests_active_issue_idx")
+      .on(table.issueId)
+      .where(activeIssuePullRequestIndexPredicate),
     index("issue_pull_requests_issue_created_idx").on(
       table.issueId,
       table.createdAt,

--- a/packages/core/src/db/superusers.ts
+++ b/packages/core/src/db/superusers.ts
@@ -7,6 +7,7 @@ export type PlatformRole = "superuser" | "user";
 export interface AuthUserSupportIdentity {
   banned: boolean | null;
   email: string;
+  emailVerified: boolean;
   role: string | null;
 }
 
@@ -14,7 +15,12 @@ export async function getAuthUserSupportIdentity(
   userId: string,
 ): Promise<AuthUserSupportIdentity | null> {
   const [record] = await getDatabase()
-    .select({ banned: user.banned, email: user.email, role: user.role })
+    .select({
+      banned: user.banned,
+      email: user.email,
+      emailVerified: user.emailVerified,
+      role: user.role,
+    })
     .from(user)
     .where(eq(user.id, userId))
     .limit(1);

--- a/packages/core/src/integrations/custom-mcp-fetch.test.ts
+++ b/packages/core/src/integrations/custom-mcp-fetch.test.ts
@@ -1,0 +1,180 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const networkMocks = vi.hoisted(() => ({
+  agentOptions: [] as Array<Record<string, unknown>>,
+  close: vi.fn(async () => undefined),
+  destroy: vi.fn(async () => undefined),
+  fetch: vi.fn(),
+  lookup: vi.fn(),
+}));
+
+vi.mock("node:dns/promises", () => ({ lookup: networkMocks.lookup }));
+vi.mock("undici", () => ({
+  Agent: class MockAgent {
+    readonly options: Record<string, unknown>;
+
+    constructor(options: Record<string, unknown>) {
+      this.options = options;
+      networkMocks.agentOptions.push(options);
+    }
+
+    close = networkMocks.close;
+    destroy = networkMocks.destroy;
+  },
+  fetch: networkMocks.fetch,
+}));
+
+import {
+  safeCustomMcpFetch,
+  validateCustomMcpUrl,
+} from "./custom-mcp.js";
+
+interface MockAgentOptions {
+  connect: {
+    lookup: (
+      hostname: string,
+      options: Record<string, unknown>,
+      callback: (
+        error: Error | null,
+        address: string | Array<{ address: string; family: number }>,
+        family?: number,
+      ) => void,
+    ) => void;
+    servername?: string;
+  };
+  maxResponseSize: number;
+}
+
+function latestAgentOptions(): MockAgentOptions {
+  return networkMocks.agentOptions.at(-1) as unknown as MockAgentOptions;
+}
+
+describe("safe custom MCP fetch", () => {
+  beforeEach(() => {
+    networkMocks.agentOptions.length = 0;
+    networkMocks.close.mockClear();
+    networkMocks.destroy.mockClear();
+    networkMocks.fetch.mockReset();
+    networkMocks.lookup.mockReset();
+    networkMocks.lookup.mockResolvedValue([
+      { address: "93.184.216.34", family: 4 },
+    ]);
+  });
+
+  it("pins the approved DNS answer while retaining hostname TLS verification", async () => {
+    networkMocks.fetch.mockImplementation(async () => {
+      const options = latestAgentOptions();
+      let pinned: { address: string; family: number } | undefined;
+      options.connect.lookup(
+        "mcp.example.test",
+        { family: 4 },
+        (error, address, family) => {
+          expect(error).toBeNull();
+          expect(typeof address).toBe("string");
+          pinned = { address: address as string, family: family as number };
+        },
+      );
+      expect(pinned).toEqual({ address: "93.184.216.34", family: 4 });
+      return new Response("ok");
+    });
+
+    const response = await safeCustomMcpFetch("https://mcp.example.test/mcp");
+
+    expect(await response.text()).toBe("ok");
+    expect(networkMocks.lookup).toHaveBeenCalledTimes(1);
+    expect(latestAgentOptions()).toMatchObject({
+      connect: { servername: "mcp.example.test" },
+      maxResponseSize: 8 * 1024 * 1024,
+    });
+  });
+
+  it("offers only approved addresses and prefers IPv4 for dual-stack hosts", async () => {
+    networkMocks.lookup.mockResolvedValue([
+      { address: "2606:2800:220:1:248:1893:25c8:1946", family: 6 },
+      { address: "93.184.216.34", family: 4 },
+    ]);
+    networkMocks.fetch.mockImplementation(async () => {
+      let pinned: unknown;
+      latestAgentOptions().connect.lookup(
+        "mcp.example.test",
+        { all: true },
+        (error, addresses) => {
+          expect(error).toBeNull();
+          pinned = addresses;
+        },
+      );
+      expect(pinned).toEqual([
+        { address: "93.184.216.34", family: 4 },
+        { address: "2606:2800:220:1:248:1893:25c8:1946", family: 6 },
+      ]);
+      return new Response("ok");
+    });
+
+    await safeCustomMcpFetch("https://mcp.example.test/mcp");
+  });
+
+  it("fails closed when DNS returns any private address", async () => {
+    networkMocks.lookup.mockResolvedValue([
+      { address: "93.184.216.34", family: 4 },
+      { address: "10.42.0.9", family: 4 },
+    ]);
+
+    await expect(
+      safeCustomMcpFetch("https://mcp.example.test/mcp"),
+    ).rejects.toThrow("MCP URLs must resolve only to public addresses");
+    expect(networkMocks.fetch).not.toHaveBeenCalled();
+  });
+
+  it("bounds DNS lookup time before opening a connection", async () => {
+    networkMocks.lookup.mockReturnValue(new Promise(() => {}));
+    const controller = new AbortController();
+    const pending = validateCustomMcpUrl("https://mcp.example.test/mcp", {
+      signal: controller.signal,
+    });
+
+    controller.abort(new Error("DNS lookup deadline exceeded"));
+
+    await expect(pending).rejects.toThrow("DNS lookup deadline exceeded");
+    expect(networkMocks.fetch).not.toHaveBeenCalled();
+  });
+
+  it("re-resolves and rejects a same-origin redirect that becomes private", async () => {
+    networkMocks.lookup
+      .mockResolvedValueOnce([{ address: "93.184.216.34", family: 4 }])
+      .mockResolvedValueOnce([{ address: "10.42.0.9", family: 4 }]);
+    networkMocks.fetch.mockResolvedValueOnce(
+      new Response("redirect", {
+        headers: { location: "/next" },
+        status: 307,
+      }),
+    );
+
+    await expect(
+      safeCustomMcpFetch("https://mcp.example.test/mcp", {
+        body: "request body",
+        method: "POST",
+      }),
+    ).rejects.toThrow("MCP URLs must resolve only to public addresses");
+    expect(networkMocks.lookup).toHaveBeenCalledTimes(2);
+    expect(networkMocks.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not forward credentials or request bodies across origins", async () => {
+    networkMocks.fetch.mockResolvedValueOnce(
+      new Response("redirect", {
+        headers: { location: "https://other.example.test/mcp" },
+        status: 307,
+      }),
+    );
+
+    await expect(
+      safeCustomMcpFetch("https://mcp.example.test/mcp", {
+        body: "sensitive request body",
+        headers: { authorization: "Bearer secret" },
+        method: "POST",
+      }),
+    ).rejects.toThrow("MCP requests cannot redirect to another origin");
+    expect(networkMocks.fetch).toHaveBeenCalledTimes(1);
+    expect(networkMocks.lookup).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/core/src/integrations/custom-mcp-stream.test.ts
+++ b/packages/core/src/integrations/custom-mcp-stream.test.ts
@@ -1,0 +1,99 @@
+import { createServer, type Server } from "node:http";
+import { gzipSync } from "node:zlib";
+import { describe, expect, it } from "vitest";
+import { safeCustomMcpFetch } from "./custom-mcp.js";
+
+async function listen(server: Server): Promise<number> {
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("Missing test port");
+  return address.port;
+}
+
+async function close(server: Server): Promise<void> {
+  const closing = new Promise<void>((resolve, reject) =>
+    server.close((error) => (error ? reject(error) : resolve())),
+  );
+  server.closeAllConnections();
+  await closing;
+}
+
+describe("custom MCP response streaming", () => {
+  it("keeps a pinned connection alive until a streaming body finishes", async () => {
+    const server = createServer((_request, response) => {
+      response.writeHead(200, { "content-type": "text/event-stream" });
+      response.write("data: first\n\n");
+      setTimeout(() => response.end("data: last\n\n"), 25);
+    });
+    const port = await listen(server);
+    try {
+      const response = await safeCustomMcpFetch(`http://localhost:${port}/mcp`);
+      await expect(response.text()).resolves.toBe(
+        "data: first\n\ndata: last\n\n",
+      );
+    } finally {
+      await close(server);
+    }
+  });
+
+  it("releases a pinned connection when the consumer cancels", async () => {
+    let responseClosed!: () => void;
+    const closed = new Promise<void>((resolve) => {
+      responseClosed = resolve;
+    });
+    const server = createServer((_request, response) => {
+      response.on("close", responseClosed);
+      response.writeHead(200, { "content-type": "text/event-stream" });
+      response.write("data: first\n\n");
+      const timer = setInterval(() => response.write("data: next\n\n"), 10);
+      response.on("close", () => clearInterval(timer));
+    });
+    const port = await listen(server);
+    try {
+      const response = await safeCustomMcpFetch(`http://localhost:${port}/mcp`);
+      const reader = response.body?.getReader();
+      await reader?.read();
+      await reader?.cancel();
+      await expect(
+        Promise.race([
+          closed.then(() => "closed"),
+          new Promise<string>((resolve) =>
+            setTimeout(() => resolve("timed out"), 1_000),
+          ),
+        ]),
+      ).resolves.toBe("closed");
+    } finally {
+      await close(server);
+    }
+  });
+
+  it("rejects a compressed response whose decoded body exceeds the limit", async () => {
+    const compressed = gzipSync(Buffer.alloc(9 * 1024 * 1024, "a"));
+    let requestedEncoding: string | undefined;
+    const server = createServer((request, response) => {
+      requestedEncoding = request.headers["accept-encoding"];
+      // Ignore the client's identity preference to exercise the decoded-byte
+      // limit against an untrusted server.
+      response.writeHead(200, {
+        "content-encoding": "gzip",
+        "content-length": compressed.byteLength,
+        "content-type": "application/json",
+      });
+      response.end(compressed);
+    });
+    const port = await listen(server);
+    try {
+      const response = await safeCustomMcpFetch(
+        `http://localhost:${port}/mcp`,
+        { headers: { "accept-encoding": "gzip" } },
+      );
+
+      await expect(response.arrayBuffer()).rejects.toThrow(
+        "MCP response exceeds 8388608 decoded bytes",
+      );
+      expect(requestedEncoding).toBe("identity");
+    } finally {
+      await close(server);
+    }
+  });
+});

--- a/packages/core/src/integrations/custom-mcp.test.ts
+++ b/packages/core/src/integrations/custom-mcp.test.ts
@@ -13,8 +13,20 @@ describe("custom MCP security", () => {
     "https://127.0.0.1/mcp",
     "https://10.0.0.4/mcp",
     "https://[::1]/mcp",
+    "https://[ff02::1]/mcp",
+    "https://[fec0::1]/mcp",
+    "https://[64:ff9b::a9fe:a9fe]/mcp",
+    "https://[::7f00:1]/mcp",
+    "https://[::ffff:127.0.0.1]/mcp",
+    "https://[4000::1]/mcp",
   ])("rejects private endpoint %s", async (url) => {
     await expect(validateCustomMcpUrl(url)).rejects.toThrow(/public|HTTPS/);
+  });
+
+  it("allows ordinary global-unicast IPv6 literals", async () => {
+    await expect(
+      validateCustomMcpUrl("https://[2607:f8b0:4005:805::200e]/mcp"),
+    ).resolves.toMatchObject({ protocol: "https:" });
   });
 
   it("allows local HTTP endpoints only when explicitly enabled", async () => {

--- a/packages/core/src/integrations/custom-mcp.ts
+++ b/packages/core/src/integrations/custom-mcp.ts
@@ -1,5 +1,6 @@
+import type { LookupAddress } from "node:dns";
 import { lookup } from "node:dns/promises";
-import { isIP } from "node:net";
+import { Readable } from "node:stream";
 import {
   auth,
   type OAuthClientProvider,
@@ -12,10 +13,15 @@ import type {
   OAuthClientMetadata,
   OAuthTokens,
 } from "@modelcontextprotocol/sdk/shared/auth.js";
+import ipaddr from "ipaddr.js";
+import { Agent, fetch as undiciFetch } from "undici";
 import { z } from "zod";
 
 const MAX_REDIRECTS = 5;
+const MAX_RESPONSE_BYTES = 8 * 1024 * 1024;
 const REQUEST_TIMEOUT_MS = 30_000;
+const IPV4_COMPATIBLE_IPV6_RANGE = ipaddr.parseCIDR("::/96");
+const GLOBAL_UNICAST_IPV6_RANGE = ipaddr.parseCIDR("2000::/3");
 
 export interface StoredCustomMcpOAuthState {
   clientInformation?: OAuthClientInformationMixed;
@@ -153,46 +159,17 @@ export class CustomMcpOAuthProvider implements OAuthClientProvider {
   }
 }
 
-function ipv4IsPublic(address: string): boolean {
-  const octets = address.split(".").map(Number);
-  if (octets.length !== 4 || octets.some((octet) => !Number.isInteger(octet))) {
+function addressIsPublic(address: string): boolean {
+  if (!ipaddr.isValid(address)) return false;
+  const parsed = ipaddr.parse(address);
+  if (
+    parsed.kind() === "ipv6" &&
+    (parsed.match(IPV4_COMPATIBLE_IPV6_RANGE) ||
+      !parsed.match(GLOBAL_UNICAST_IPV6_RANGE))
+  ) {
     return false;
   }
-  const [a, b, c] = octets as [number, number, number, number];
-  return !(
-    a === 0 ||
-    a === 10 ||
-    a === 127 ||
-    (a === 100 && b >= 64 && b <= 127) ||
-    (a === 169 && b === 254) ||
-    (a === 172 && b >= 16 && b <= 31) ||
-    (a === 192 && b === 0) ||
-    (a === 192 && b === 168) ||
-    (a === 198 && (b === 18 || b === 19)) ||
-    (a === 192 && b === 0 && c === 2) ||
-    (a === 198 && b === 51 && c === 100) ||
-    (a === 203 && b === 0 && c === 113) ||
-    a >= 224
-  );
-}
-
-function addressIsPublic(address: string): boolean {
-  const family = isIP(address);
-  if (family === 4) return ipv4IsPublic(address);
-  if (family !== 6) return false;
-
-  const normalized = address.toLowerCase();
-  if (normalized.startsWith("::ffff:")) {
-    return ipv4IsPublic(normalized.slice("::ffff:".length));
-  }
-  return !(
-    normalized === "::" ||
-    normalized === "::1" ||
-    normalized.startsWith("fc") ||
-    normalized.startsWith("fd") ||
-    /^fe[89ab]/.test(normalized) ||
-    normalized.startsWith("2001:db8:")
-  );
+  return parsed.range() === "unicast";
 }
 
 function localHostname(hostname: string): boolean {
@@ -208,9 +185,21 @@ function localHostname(hostname: string): boolean {
 
 export async function validateCustomMcpUrl(
   input: string | URL,
-  options: { allowLocal?: boolean } = {},
+  options: { allowLocal?: boolean; signal?: AbortSignal } = {},
 ): Promise<URL> {
-  const url = input instanceof URL ? new URL(input) : new URL(input);
+  return (await resolveCustomMcpUrl(input, options)).url;
+}
+
+interface ResolvedCustomMcpUrl {
+  addresses: LookupAddress[];
+  url: URL;
+}
+
+async function resolveCustomMcpUrl(
+  input: string | URL,
+  options: { allowLocal?: boolean; signal?: AbortSignal } = {},
+): Promise<ResolvedCustomMcpUrl> {
+  const url = new URL(input);
   const hostname = url.hostname.replace(/^\[|\]$/g, "");
   if (url.username || url.password) {
     throw new Error("MCP URLs cannot contain credentials");
@@ -221,24 +210,161 @@ export async function validateCustomMcpUrl(
     throw new Error("MCP URLs must use HTTPS");
   }
 
-  if (localAllowed) return url;
   if (localHostname(hostname)) {
-    throw new Error("MCP URLs must use a public host");
+    if (!localAllowed) throw new Error("MCP URLs must use a public host");
   }
 
-  const literalFamily = isIP(hostname);
-  if (literalFamily) {
-    if (!addressIsPublic(hostname)) {
+  if (ipaddr.isValid(hostname)) {
+    if (!localAllowed && !addressIsPublic(hostname)) {
       throw new Error("MCP URLs must use a public host");
     }
-    return url;
+    return {
+      addresses: [
+        {
+          address: hostname,
+          family: ipaddr.parse(hostname).kind() === "ipv4" ? 4 : 6,
+        },
+      ],
+      url,
+    };
   }
 
-  const addresses = await lookup(hostname, { all: true, verbatim: true });
-  if (addresses.length === 0 || addresses.some(({ address }) => !addressIsPublic(address))) {
+  const lookupSignal = options.signal ?? AbortSignal.timeout(REQUEST_TIMEOUT_MS);
+  const addresses = await new Promise<LookupAddress[]>((resolve, reject) => {
+    const aborted = () => {
+      reject(lookupSignal.reason ?? new Error("MCP DNS lookup was aborted"));
+    };
+    if (lookupSignal.aborted) {
+      aborted();
+      return;
+    }
+    lookupSignal.addEventListener("abort", aborted, { once: true });
+    void lookup(hostname, { all: true, verbatim: true }).then(
+      (result) => {
+        lookupSignal.removeEventListener("abort", aborted);
+        resolve(result);
+      },
+      (error: unknown) => {
+        lookupSignal.removeEventListener("abort", aborted);
+        reject(error);
+      },
+    );
+  });
+  if (
+    addresses.length === 0 ||
+    (!localAllowed &&
+      addresses.some(({ address }) => !addressIsPublic(address)))
+  ) {
     throw new Error("MCP URLs must resolve only to public addresses");
   }
-  return url;
+  return {
+    addresses: addresses.map(({ address }) => ({
+      address,
+      family: ipaddr.parse(address).kind() === "ipv4" ? 4 : 6,
+    })),
+    url,
+  };
+}
+
+function pinnedAddressAgent(target: ResolvedCustomMcpUrl): Agent {
+  const expectedHostname = target.url.hostname.replace(/^\[|\]$/g, "");
+  const approvedAddresses = [...target.addresses].sort(
+    (left, right) => left.family - right.family,
+  );
+  if (approvedAddresses.length === 0) {
+    throw new Error("MCP URLs must resolve only to public addresses");
+  }
+
+  return new Agent({
+    connect: {
+      lookup(hostname, options, callback) {
+        const actualHostname = hostname.toLowerCase().replace(/\.$/, "");
+        if (actualHostname !== expectedHostname.toLowerCase().replace(/\.$/, "")) {
+          const error = new Error("MCP request hostname changed after validation");
+          Object.assign(error, { code: "EAI_FAIL" });
+          callback(error, "", 0);
+          return;
+        }
+        if (options.all) {
+          callback(null, approvedAddresses);
+          return;
+        }
+        const requestedFamily = Number(options.family) || 0;
+        const selectedAddress = requestedFamily
+          ? approvedAddresses.find(({ family }) => family === requestedFamily)
+          : approvedAddresses[0];
+        if (!selectedAddress) {
+          const error = new Error("No approved MCP address matches the requested family");
+          Object.assign(error, { code: "EAI_ADDRFAMILY" });
+          callback(error, "", 0);
+          return;
+        }
+        callback(null, selectedAddress.address, selectedAddress.family);
+      },
+      // The socket connects to the pinned address, but TLS must authenticate the
+      // hostname from the requested URL and send that hostname through SNI.
+      ...(ipaddr.isValid(expectedHostname)
+        ? {}
+        : { servername: expectedHostname }),
+    },
+    maxResponseSize: MAX_RESPONSE_BYTES,
+  });
+}
+
+async function fetchPinnedRequest(
+  request: Request,
+  dispatcher: Agent,
+): Promise<Response> {
+  const body = request.body
+    ? Readable.fromWeb(request.body as import("node:stream/web").ReadableStream)
+    : undefined;
+  const headers = new Headers(request.headers);
+  // Undici transparently decompresses response bodies. Ask the peer not to
+  // compress, then still count decoded bytes below because an untrusted server
+  // can ignore this request header.
+  headers.set("accept-encoding", "identity");
+  try {
+    const response = await undiciFetch(request.url, {
+      ...(body ? { body, duplex: "half" as const } : {}),
+      dispatcher,
+      headers,
+      method: request.method,
+      redirect: "manual",
+      signal: request.signal,
+    });
+    let decodedBytes = 0;
+    const responseBody = response.body as unknown as ReadableStream<Uint8Array> | null;
+    const limitedBody = responseBody
+      ? responseBody.pipeThrough(
+          new TransformStream<Uint8Array, Uint8Array>({
+            transform(chunk, controller) {
+              decodedBytes += chunk.byteLength;
+              if (decodedBytes > MAX_RESPONSE_BYTES) {
+                const error = new Error(
+                  `MCP response exceeds ${MAX_RESPONSE_BYTES} decoded bytes`,
+                );
+                void dispatcher.destroy(error).catch(() => undefined);
+                controller.error(error);
+                return;
+              }
+              controller.enqueue(chunk);
+            },
+          }),
+        )
+      : null;
+    // Keep the public fetch contract (including `instanceof Response`) for the
+    // MCP SDK while the underlying body remains attached to the pinned agent.
+    // The agent-level limit bounds compressed wire bytes; this stream bounds
+    // decoded bytes before JSON parsing or other buffering can amplify them.
+    return new Response(limitedBody as ReadableStream | null, {
+      headers: new Headers(response.headers as unknown as HeadersInit),
+      status: response.status,
+      statusText: response.statusText,
+    });
+  } catch (error) {
+    await dispatcher.destroy(error instanceof Error ? error : null);
+    throw error;
+  }
 }
 
 export async function safeCustomMcpFetch(
@@ -254,20 +380,33 @@ export async function safeCustomMcpFetch(
   });
   let redirects = 0;
   while (true) {
-    await validateCustomMcpUrl(request.url, {
+    const target = await resolveCustomMcpUrl(request.url, {
       allowLocal: process.env.NODE_ENV !== "production",
+      signal: request.signal,
     });
     const redirectRequest = request.clone();
-    const response = await fetch(request, { redirect: "manual" });
-    if (![301, 302, 303, 307, 308].includes(response.status)) return response;
+    const dispatcher = pinnedAddressAgent(target);
+    const response = await fetchPinnedRequest(request, dispatcher);
+    if (![301, 302, 303, 307, 308].includes(response.status)) {
+      void dispatcher.close().catch(() => undefined);
+      return response;
+    }
 
     const location = response.headers.get("location");
-    if (!location) return response;
+    if (!location) {
+      void dispatcher.close().catch(() => undefined);
+      return response;
+    }
+    await response.body?.cancel();
+    await dispatcher.close();
     if (redirects >= MAX_REDIRECTS) {
       throw new Error("MCP request redirected too many times");
     }
     redirects += 1;
     const nextUrl = new URL(location, request.url);
+    if (nextUrl.origin !== new URL(request.url).origin) {
+      throw new Error("MCP requests cannot redirect to another origin");
+    }
     const switchToGet =
       response.status === 303 ||
       ((response.status === 301 || response.status === 302) && request.method === "POST");
@@ -278,11 +417,6 @@ export async function safeCustomMcpFetch(
           signal: redirectRequest.signal,
         })
       : new Request(nextUrl, redirectRequest);
-    if (nextUrl.origin !== new URL(request.url).origin) {
-      redirectedRequest.headers.delete("authorization");
-      redirectedRequest.headers.delete("cookie");
-      redirectedRequest.headers.delete("proxy-authorization");
-    }
     request = redirectedRequest;
   }
 }

--- a/packages/core/src/integrations/linear.test.ts
+++ b/packages/core/src/integrations/linear.test.ts
@@ -108,6 +108,7 @@ describe("Linear OAuth", () => {
       "old-refresh-token",
     );
   });
+
 });
 
 describe("Linear ticket templates", () => {
@@ -212,5 +213,23 @@ describe("Linear issue API", () => {
       fetchImpl,
       issueId: "81e37ee3-e8cf-4806-82f1-ad81fcd24dbd",
     })).resolves.toMatchObject({ identifier: "OPS-42" });
+  });
+
+  it("rejects an executable issue URL before it can be persisted", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      data: {
+        issue: {
+          id: "81e37ee3-e8cf-4806-82f1-ad81fcd24dbd",
+          identifier: "OPS-42",
+          url: "javascript:alert(document.domain)",
+        },
+      },
+    }), { status: 200 }));
+
+    await expect(findLinearIssueById({
+      accessToken: "linear-token",
+      fetchImpl,
+      issueId: "81e37ee3-e8cf-4806-82f1-ad81fcd24dbd",
+    })).rejects.toThrow("Linear issue URLs must use HTTPS");
   });
 });

--- a/packages/core/src/integrations/linear.ts
+++ b/packages/core/src/integrations/linear.ts
@@ -213,7 +213,13 @@ export function linearTicketFollowupInstruction(input: {
 const linearIssueSchema = z.object({
   id: z.string().min(1),
   identifier: z.string().min(1),
-  url: z.url(),
+  // This URL is persisted and later rendered as a clickable link. `z.url()`
+  // also accepts executable schemes such as `javascript:`, so constrain the
+  // upstream value before it reaches the UI.
+  url: z.url().refine(
+    (value) => new URL(value).protocol === "https:",
+    "Linear issue URLs must use HTTPS",
+  ),
 });
 
 const linearGraphqlResponseSchema = z.object({

--- a/packages/core/src/investigations/input.test.ts
+++ b/packages/core/src/investigations/input.test.ts
@@ -30,4 +30,17 @@ describe("investigation input", () => {
       }),
     ).toThrow();
   });
+
+  it("rejects executable source links before they can be rendered", () => {
+    expect(() =>
+      investigationRequestSchema.parse({
+        agentId: "06060606-0606-4606-8606-060606060606",
+        body: "An alert was triggered.",
+        externalEventId: "event-1",
+        provider: "sentry",
+        sourceUrl: "javascript:alert(document.domain)",
+        title: "Production alert",
+      }),
+    ).toThrow("Investigation source URLs must use HTTP or HTTPS");
+  });
 });

--- a/packages/core/src/investigations/input.ts
+++ b/packages/core/src/investigations/input.ts
@@ -7,7 +7,10 @@ export const investigationRequestSchema = z.object({
   externalEventId: z.string().min(1).max(512),
   title: z.string().min(1).max(500),
   body: z.string().min(1).max(100_000),
-  sourceUrl: z.url().optional(),
+  sourceUrl: z.url().refine(
+    (value) => ["http:", "https:"].includes(new URL(value).protocol),
+    "Investigation source URLs must use HTTP or HTTPS",
+  ).optional(),
   attributes: z
     .record(z.string(), z.union([z.string(), z.number(), z.boolean(), z.null()]))
     .optional(),

--- a/packages/core/src/jobs.test.ts
+++ b/packages/core/src/jobs.test.ts
@@ -1,8 +1,11 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   createJobBoss,
   investigationJobSchema,
   investigationQueue,
+  linearTicketQueue,
+  prepareWorkerQueues,
+  remediationQueue,
   remediationJobSchema,
   workerHealthJobSchema,
   workerHealthQueue,
@@ -12,6 +15,34 @@ describe("background jobs", () => {
   it("uses a stable worker health queue name", () => {
     expect(workerHealthQueue).toBe("responder-worker-health");
     expect(investigationQueue).toBe("responder-investigations");
+  });
+
+  it("enforces Linear request singleton keys at the queue policy boundary", async () => {
+    const createQueue = vi.fn().mockResolvedValue(undefined);
+
+    await prepareWorkerQueues({ createQueue } as never);
+
+    expect(linearTicketQueue).toBe("responder-linear-tickets-v2");
+    expect(createQueue).toHaveBeenCalledWith(
+      linearTicketQueue,
+      expect.objectContaining({ policy: "exclusive" }),
+    );
+  });
+
+  it("uses a versioned exclusive queue for remediation side effects", async () => {
+    const createQueue = vi.fn().mockResolvedValue(undefined);
+
+    await prepareWorkerQueues({ createQueue } as never);
+
+    expect(remediationQueue).toBe("responder-remediations-v2");
+    expect(createQueue).toHaveBeenCalledWith(
+      remediationQueue,
+      expect.objectContaining({ policy: "exclusive", retryLimit: 0 }),
+    );
+    expect(createQueue).not.toHaveBeenCalledWith(
+      remediationQueue,
+      expect.objectContaining({ retryBackoff: true }),
+    );
   });
 
   it("accepts an investigation job", () => {

--- a/packages/core/src/jobs.ts
+++ b/packages/core/src/jobs.ts
@@ -7,7 +7,10 @@ import { issueEvidenceSchema, issueSeveritySchema } from "./investigations/repor
 
 export const workerHealthQueue = "responder-worker-health";
 export const investigationQueue = "responder-investigations";
-export const linearTicketQueue = "responder-linear-tickets";
+// Version queue names when introducing a policy: createQueue intentionally
+// leaves an existing queue's policy unchanged.
+export const linearTicketQueue = "responder-linear-tickets-v2";
+export const remediationQueue = "responder-remediations-v2";
 
 export const workerHealthJobSchema = z.object({
   marker: z.string().min(1),
@@ -103,10 +106,23 @@ export async function prepareWorkerQueues(boss: PgBoss): Promise<void> {
       retryDelay: 30,
       retryLimit: 2,
     }),
+    boss.createQueue(remediationQueue, {
+      deleteAfterSeconds: 604_800,
+      expireInSeconds: 3_600,
+      notify: true,
+      policy: "exclusive",
+      // Retrying the agent could repeat PR side effects. Terminal writes are
+      // independent of monitoring, and a worker sweep reconciles abandoned rows.
+      retryLimit: 0,
+    }),
     boss.createQueue(linearTicketQueue, {
       deleteAfterSeconds: 604_800,
       expireInSeconds: 900,
       notify: true,
+      // singletonKey is enforced only by pg-boss queue policies that opt into
+      // singleton semantics. Exclusive keeps one queued or active job per
+      // Linear request key while allowing unrelated requests to run together.
+      policy: "exclusive",
       retryBackoff: true,
       retryDelay: 60,
       retryLimit: 5,

--- a/packages/core/src/remediation-queue.test.ts
+++ b/packages/core/src/remediation-queue.test.ts
@@ -1,10 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
+  claimIssuePullRequestForRemediation: vi.fn(),
   failIssuePullRequest: vi.fn(),
+  listStaleCreatingIssuePullRequests: vi.fn(),
+  recoverAbandonedIssuePullRequest: vi.fn(),
   getIssuePullRequestForRemediation: vi.fn(),
   getRuntimeAgentConfig: vi.fn(),
-  markIssuePullRequestStarted: vi.fn(),
   setIssuePullRequestSession: vi.fn(),
 }));
 
@@ -12,13 +14,21 @@ vi.mock("./db/investigations.js", () => ({
   getRuntimeAgentConfig: mocks.getRuntimeAgentConfig,
 }));
 vi.mock("./db/pull-requests.js", () => ({
+  claimIssuePullRequestForRemediation:
+    mocks.claimIssuePullRequestForRemediation,
   failIssuePullRequest: mocks.failIssuePullRequest,
+  listStaleCreatingIssuePullRequests:
+    mocks.listStaleCreatingIssuePullRequests,
+  recoverAbandonedIssuePullRequest:
+    mocks.recoverAbandonedIssuePullRequest,
   getIssuePullRequestForRemediation: mocks.getIssuePullRequestForRemediation,
-  markIssuePullRequestStarted: mocks.markIssuePullRequestStarted,
   setIssuePullRequestSession: mocks.setIssuePullRequestSession,
 }));
 
-import { queueIssueRemediationJob } from "./remediation-queue.js";
+import {
+  queueIssueRemediationJob,
+  recoverAbandonedIssueRemediations,
+} from "./remediation-queue.js";
 
 const requestId = "05050505-0505-4505-8505-050505050505";
 const remediation = {
@@ -54,7 +64,7 @@ describe("remediation job queue", () => {
 
   it("queues a dedicated remediation job and records its session", async () => {
     const calls: string[] = [];
-    mocks.markIssuePullRequestStarted.mockImplementationOnce(async () => {
+    mocks.claimIssuePullRequestForRemediation.mockImplementationOnce(async () => {
       calls.push("started");
     });
     const queue = {
@@ -69,7 +79,7 @@ describe("remediation job queue", () => {
     ).resolves.toEqual({ jobId: "job-id", requestId });
 
     expect(queue.send).toHaveBeenCalledWith(
-      "responder-investigations",
+      "responder-remediations-v2",
       expect.objectContaining({
         kind: "remediation",
         remediationRequestId: requestId,
@@ -77,7 +87,9 @@ describe("remediation job queue", () => {
       }),
       { singletonKey: `remediation:${requestId}` },
     );
-    expect(mocks.markIssuePullRequestStarted).toHaveBeenCalledWith(requestId);
+    expect(
+      mocks.claimIssuePullRequestForRemediation,
+    ).toHaveBeenCalledWith(requestId);
     expect(calls).toEqual(["started", "sent"]);
     expect(mocks.setIssuePullRequestSession).toHaveBeenCalledWith(
       requestId,
@@ -98,7 +110,7 @@ describe("remediation job queue", () => {
     );
   });
 
-  it("marks a request failed when its remediation details cannot be loaded", async () => {
+  it("does not mutate a request when its remediation details cannot be loaded", async () => {
     const lookupError = new Error("database unavailable");
     mocks.getIssuePullRequestForRemediation.mockRejectedValue(lookupError);
     const queue = { send: vi.fn() };
@@ -106,10 +118,7 @@ describe("remediation job queue", () => {
     await expect(
       queueIssueRemediationJob(queue, requestId),
     ).rejects.toBe(lookupError);
-    expect(mocks.failIssuePullRequest).toHaveBeenCalledWith(
-      requestId,
-      "database unavailable",
-    );
+    expect(mocks.failIssuePullRequest).not.toHaveBeenCalled();
     expect(queue.send).not.toHaveBeenCalled();
   });
 
@@ -137,7 +146,7 @@ describe("remediation job queue", () => {
     consoleError.mockRestore();
   });
 
-  it("logs a null job result before recording the request failure", async () => {
+  it("does not fail the winning request after an exclusive-queue collision", async () => {
     const calls: string[] = [];
     const consoleError = vi
       .spyOn(console, "error")
@@ -145,9 +154,6 @@ describe("remediation job queue", () => {
         const event = JSON.parse(String(message)) as { event: string };
         calls.push(event.event);
       });
-    mocks.failIssuePullRequest.mockImplementationOnce(async () => {
-      calls.push("fail");
-    });
     const queue = { send: vi.fn().mockResolvedValue(null) };
 
     await expect(
@@ -156,9 +162,140 @@ describe("remediation job queue", () => {
     expect(calls).toEqual([
       "remediation_job_not_created",
       "remediation_queue_failed",
-      "fail",
     ]);
+    expect(mocks.failIssuePullRequest).not.toHaveBeenCalled();
 
     consoleError.mockRestore();
   });
+
+  it("does not let a losing concurrent claim fail the winning request", async () => {
+    const claimError = new Error("Pull request request is no longer active");
+    mocks.claimIssuePullRequestForRemediation.mockRejectedValue(claimError);
+    const queue = { send: vi.fn() };
+
+    await expect(
+      queueIssueRemediationJob(queue, requestId),
+    ).rejects.toBe(claimError);
+    expect(queue.send).not.toHaveBeenCalled();
+    expect(mocks.failIssuePullRequest).not.toHaveBeenCalled();
+  });
+});
+
+describe("abandoned remediation recovery", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("recovers only stale requests without a queued or active job", async () => {
+    const activeRequestId = "05050505-0505-4505-8505-050505050505";
+    const abandonedRequestId = "06060606-0606-4606-8606-060606060606";
+    const now = new Date("2026-08-17T14:00:00.000Z");
+    mocks.listStaleCreatingIssuePullRequests.mockResolvedValue([
+      { requestId: activeRequestId },
+      { requestId: abandonedRequestId },
+    ]);
+    mocks.recoverAbandonedIssuePullRequest.mockResolvedValue(true);
+    const queue = {
+      findJobs: vi.fn(async (_name: string, options: { key: string }) =>
+        options.key === `remediation:${activeRequestId}`
+          ? [{ state: "active" as const }]
+          : [{ state: "failed" as const }]
+      ),
+    };
+
+    await expect(
+      recoverAbandonedIssueRemediations(queue, now),
+    ).resolves.toEqual([abandonedRequestId]);
+
+    const staleBefore = new Date("2026-08-17T12:00:00.000Z");
+    expect(mocks.listStaleCreatingIssuePullRequests).toHaveBeenCalledWith(
+      staleBefore,
+    );
+    expect(queue.findJobs).toHaveBeenCalledWith(
+      "responder-remediations-v2",
+      { key: `remediation:${activeRequestId}` },
+    );
+    expect(mocks.recoverAbandonedIssuePullRequest).toHaveBeenCalledExactlyOnceWith(
+      abandonedRequestId,
+      staleBefore,
+    );
+  });
+
+  it("does not report a request whose atomic stale check loses a race", async () => {
+    const requestId = "06060606-0606-4606-8606-060606060606";
+    mocks.listStaleCreatingIssuePullRequests.mockResolvedValue([{ requestId }]);
+    mocks.recoverAbandonedIssuePullRequest.mockResolvedValue(false);
+    const queue = {
+      findJobs: vi.fn().mockResolvedValue([]),
+    };
+
+    await expect(
+      recoverAbandonedIssueRemediations(
+        queue,
+        new Date("2026-08-17T14:00:00.000Z"),
+      ),
+    ).resolves.toEqual([]);
+  });
+
+  it("keeps a stale request active while its legacy queue job is live", async () => {
+    const requestId = "06060606-0606-4606-8606-060606060606";
+    mocks.listStaleCreatingIssuePullRequests.mockResolvedValue([{ requestId }]);
+    const queue = {
+      findJobs: vi.fn(async (name: string) =>
+        name === "responder-investigations"
+          ? [{ state: "active" as const }]
+          : []
+      ),
+    };
+
+    await expect(
+      recoverAbandonedIssueRemediations(
+        queue,
+        new Date("2026-08-17T14:00:00.000Z"),
+      ),
+    ).resolves.toEqual([]);
+    expect(queue.findJobs).toHaveBeenCalledWith(
+      "responder-investigations",
+      { key: `remediation:${requestId}` },
+    );
+    expect(mocks.recoverAbandonedIssuePullRequest).not.toHaveBeenCalled();
+  });
+
+  it.each(["created", "retry", "active"])(
+    "keeps a stale request with a %s job active",
+    async (state) => {
+      const requestId = "06060606-0606-4606-8606-060606060606";
+      mocks.listStaleCreatingIssuePullRequests.mockResolvedValue([{ requestId }]);
+      const queue = {
+        findJobs: vi.fn().mockResolvedValue([{ state }]),
+      };
+
+      await expect(
+        recoverAbandonedIssueRemediations(
+          queue,
+          new Date("2026-08-17T14:00:00.000Z"),
+        ),
+      ).resolves.toEqual([]);
+      expect(mocks.recoverAbandonedIssuePullRequest).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(["completed", "failed", "cancelled"])(
+    "recovers a stale request with a %s job",
+    async (state) => {
+      const requestId = "06060606-0606-4606-8606-060606060606";
+      mocks.listStaleCreatingIssuePullRequests.mockResolvedValue([{ requestId }]);
+      mocks.recoverAbandonedIssuePullRequest.mockResolvedValue(true);
+      const queue = {
+        findJobs: vi.fn().mockResolvedValue([{ state }]),
+      };
+
+      await expect(
+        recoverAbandonedIssueRemediations(
+          queue,
+          new Date("2026-08-17T14:00:00.000Z"),
+        ),
+      ).resolves.toEqual([requestId]);
+    },
+  );
 });

--- a/packages/core/src/remediation-queue.ts
+++ b/packages/core/src/remediation-queue.ts
@@ -1,11 +1,24 @@
 import { getRuntimeAgentConfig } from "./db/investigations.js";
 import {
+  claimIssuePullRequestForRemediation,
   failIssuePullRequest,
   getIssuePullRequestForRemediation,
-  markIssuePullRequestStarted,
+  listStaleCreatingIssuePullRequests,
+  recoverAbandonedIssuePullRequest,
   setIssuePullRequestSession,
 } from "./db/pull-requests.js";
-import { investigationQueue, type RemediationJob } from "./jobs.js";
+import {
+  investigationQueue,
+  remediationQueue,
+  type RemediationJob,
+} from "./jobs.js";
+
+const abandonedRemediationRequestAgeMs = 2 * 60 * 60 * 1_000;
+const terminalRemediationJobStates = new Set([
+  "completed",
+  "failed",
+  "cancelled",
+]);
 
 export interface RemediationJobQueue {
   send(
@@ -15,13 +28,59 @@ export interface RemediationJobQueue {
   ): Promise<string | null>;
 }
 
+export interface RemediationRecoveryQueue {
+  findJobs(
+    name: string,
+    options: { key: string },
+  ): Promise<Array<{ state: string }>>;
+}
+
+export async function recoverAbandonedIssueRemediations(
+  queue: RemediationRecoveryQueue,
+  now = new Date(),
+): Promise<string[]> {
+  // The cutoff is twice the queue's one-hour execution limit. Queue state is
+  // still checked so a delayed but valid job is never mistaken for abandoned.
+  const staleBefore = new Date(
+    now.getTime() - abandonedRemediationRequestAgeMs,
+  );
+  const candidates = await listStaleCreatingIssuePullRequests(staleBefore);
+  const recovered: string[] = [];
+
+  for (const candidate of candidates) {
+    const key = `remediation:${candidate.requestId}`;
+    const jobs = (
+      await Promise.all([
+        queue.findJobs(remediationQueue, { key }),
+        // Workers still drain remediation jobs accepted by the former shared
+        // investigation queue during a rolling deployment.
+        queue.findJobs(investigationQueue, { key }),
+      ])
+    ).flat();
+    if (jobs.some((job) => !terminalRemediationJobStates.has(job.state))) {
+      continue;
+    }
+    if (
+      await recoverAbandonedIssuePullRequest(
+        candidate.requestId,
+        staleBefore,
+      )
+    ) {
+      recovered.push(candidate.requestId);
+    }
+  }
+
+  return recovered;
+}
+
 export async function queueIssueRemediationJob(
   queue: RemediationJobQueue,
   requestId: string,
 ) {
+  let claimed = false;
   try {
     const remediation = await getIssuePullRequestForRemediation(requestId);
-    if (!["queued", "creating"].includes(remediation.status)) {
+    if (remediation.status !== "queued") {
       throw new Error("Pull request request is no longer active");
     }
 
@@ -30,9 +89,10 @@ export async function queueIssueRemediationJob(
     );
     if (!config) throw new Error("Agent configuration is unavailable");
 
-    await markIssuePullRequestStarted(remediation.requestId);
+    await claimIssuePullRequestForRemediation(remediation.requestId);
+    claimed = true;
     const jobId = await queue.send(
-      investigationQueue,
+      remediationQueue,
       {
         kind: "remediation",
         config,
@@ -52,6 +112,9 @@ export async function queueIssueRemediationJob(
       { singletonKey: `remediation:${remediation.requestId}` },
     );
     if (!jobId) {
+      // An exclusive-queue collision means an existing job owns this request;
+      // do not let the losing enqueue attempt fail the winner's database row.
+      claimed = false;
       console.error(
         JSON.stringify({
           error: "The remediation job was not created",
@@ -86,10 +149,12 @@ export async function queueIssueRemediationJob(
         requestId,
       }),
     );
-    await failIssuePullRequest(
-      requestId,
-      error instanceof Error ? error.message : "Unable to start remediation",
-    );
+    if (claimed) {
+      await failIssuePullRequest(
+        requestId,
+        error instanceof Error ? error.message : "Unable to start remediation",
+      );
+    }
     throw error;
   }
 }

--- a/packages/core/src/secrets.test.ts
+++ b/packages/core/src/secrets.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it, vi } from "vitest";
+import { loadResponderSecrets } from "./secrets.js";
+
+describe("responder secrets", () => {
+  const jsonPath = "/run/responder/secrets.json";
+  const legacyPath = "/run/responder/secrets.env";
+
+  it("loads string values without changing their representation", () => {
+    const entries = [
+      { key: "QUOTED", value: `single ' and double " quotes` },
+      { key: "BACKSLASH", value: String.raw`C:\secrets\value` },
+      { key: "WHITESPACE", value: "tab\tnewline\nend" },
+      { key: "UNICODE", value: "Kampala 🌍 東京" },
+      { key: "EMPTY", value: "" },
+    ];
+    const environment: NodeJS.ProcessEnv = {
+      RESPONDER_SECRETS_JSON_FILE: jsonPath,
+    };
+
+    loadResponderSecrets(environment, vi.fn(), () => JSON.stringify(entries));
+
+    expect(environment).toMatchObject(
+      Object.fromEntries(entries.map(({ key, value }) => [key, value])),
+    );
+  });
+
+  it("preserves environment values that were already present", () => {
+    const environment: NodeJS.ProcessEnv = {
+      EXISTING_SECRET: "from-environment",
+      RESPONDER_SECRETS_JSON_FILE: jsonPath,
+    };
+
+    loadResponderSecrets(environment, vi.fn(), () =>
+      JSON.stringify([
+        { key: "EXISTING_SECRET", value: "from-file" },
+        { key: "NEW_SECRET", value: "new-value" },
+      ]),
+    );
+
+    expect(environment.EXISTING_SECRET).toBe("from-environment");
+    expect(environment.NEW_SECRET).toBe("new-value");
+  });
+
+  it.each([
+    ["invalid JSON", "{"],
+    ["an empty document", ""],
+    ["an empty array", "[]"],
+    ["a non-array value", "{}"],
+    ["a non-object entry", '["secret"]'],
+    ["a missing key", '[{"value":"secret"}]'],
+    ["an invalid key", '[{"key":"BAD-KEY","value":"secret"}]'],
+    ["a non-string value", '[{"key":"SECRET","value":1}]'],
+    ["a null byte", '[{"key":"SECRET","value":"\\u0000"}]'],
+  ])("fails closed for %s", (_description, contents) => {
+    const environment: NodeJS.ProcessEnv = {
+      RESPONDER_SECRETS_JSON_FILE: jsonPath,
+    };
+
+    expect(() =>
+      loadResponderSecrets(environment, vi.fn(), () => contents),
+    ).toThrow();
+    expect(environment.SECRET).toBeUndefined();
+  });
+
+  it("identifies the duplicate key and its index", () => {
+    const environment: NodeJS.ProcessEnv = {
+      RESPONDER_SECRETS_JSON_FILE: jsonPath,
+    };
+
+    expect(() =>
+      loadResponderSecrets(
+        environment,
+        vi.fn(),
+        () =>
+          '[{"key":"SECRET","value":"one"},{"key":"SECRET","value":"two"}]',
+      ),
+    ).toThrow("Responder secret at index 1 duplicates environment key SECRET");
+    expect(environment.SECRET).toBeUndefined();
+  });
+
+  it("fails closed when the configured JSON file is missing", () => {
+    const environment: NodeJS.ProcessEnv = {
+      RESPONDER_SECRETS_JSON_FILE: jsonPath,
+    };
+
+    expect(() =>
+      loadResponderSecrets(environment, vi.fn(), () => {
+        throw new Error("missing");
+      }),
+    ).toThrow("Unable to read responder secrets JSON file");
+  });
+
+  it("does not partially apply a malformed document", () => {
+    const environment: NodeJS.ProcessEnv = {
+      RESPONDER_SECRETS_JSON_FILE: jsonPath,
+    };
+
+    expect(() =>
+      loadResponderSecrets(
+        environment,
+        vi.fn(),
+        () =>
+          '[{"key":"VALID","value":"secret"},{"key":"INVALID-KEY","value":"secret"}]',
+      ),
+    ).toThrow();
+    expect(environment.VALID).toBeUndefined();
+  });
+
+  it("falls back to the legacy env file when JSON is not configured", () => {
+    const loadLegacyEnvFile = vi.fn();
+    const environment: NodeJS.ProcessEnv = {
+      RESPONDER_SECRETS_FILE: legacyPath,
+    };
+
+    loadResponderSecrets(environment, loadLegacyEnvFile);
+
+    expect(loadLegacyEnvFile).toHaveBeenCalledExactlyOnceWith(
+      legacyPath,
+    );
+  });
+
+  it("prefers JSON and does not load the legacy file", () => {
+    const loadLegacyEnvFile = vi.fn();
+    const environment: NodeJS.ProcessEnv = {
+      RESPONDER_SECRETS_FILE: legacyPath,
+      RESPONDER_SECRETS_JSON_FILE: jsonPath,
+    };
+
+    loadResponderSecrets(
+      environment,
+      loadLegacyEnvFile,
+      () => '[{"key":"SECRET","value":"json"}]',
+    );
+
+    expect(environment.SECRET).toBe("json");
+    expect(loadLegacyEnvFile).not.toHaveBeenCalled();
+  });
+
+  it("does not fall back to legacy secrets when the JSON file is invalid", () => {
+    const loadLegacyEnvFile = vi.fn();
+    const environment: NodeJS.ProcessEnv = {
+      RESPONDER_SECRETS_FILE: legacyPath,
+      RESPONDER_SECRETS_JSON_FILE: jsonPath,
+    };
+
+    expect(() =>
+      loadResponderSecrets(environment, loadLegacyEnvFile, () => "[]"),
+    ).toThrow("Responder secrets JSON file must contain a nonempty array");
+    expect(loadLegacyEnvFile).not.toHaveBeenCalled();
+  });
+
+  it.each(["RESPONDER_SECRETS_JSON_FILE", "RESPONDER_SECRETS_FILE"] as const)(
+    "rejects an empty %s path",
+    (key) => {
+      const environment: NodeJS.ProcessEnv = { [key]: "" };
+      expect(() => loadResponderSecrets(environment)).toThrow(
+        `${key} must not be empty`,
+      );
+    },
+  );
+
+  it.each([
+    ["RESPONDER_SECRETS_JSON_FILE", jsonPath],
+    ["RESPONDER_SECRETS_FILE", legacyPath],
+  ] as const)("rejects a nonstandard %s path", (key, expectedPath) => {
+    const environment: NodeJS.ProcessEnv = { [key]: "/tmp/secrets" };
+    expect(() => loadResponderSecrets(environment)).toThrow(
+      `${key} must be ${expectedPath}`,
+    );
+  });
+});

--- a/packages/core/src/secrets.ts
+++ b/packages/core/src/secrets.ts
@@ -1,0 +1,101 @@
+import { readFileSync } from "node:fs";
+
+const environmentKeyPattern = /^[A-Za-z_][A-Za-z0-9_]*$/;
+const responderSecretsJSONPath = "/run/responder/secrets.json";
+const responderSecretsLegacyPath = "/run/responder/secrets.env";
+
+type ResponderSecret = {
+  key: string;
+  value: string;
+};
+
+function parseResponderSecrets(contents: string): ResponderSecret[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(contents);
+  } catch {
+    throw new Error("Responder secrets JSON file must contain valid JSON");
+  }
+
+  if (!Array.isArray(parsed) || parsed.length === 0) {
+    throw new Error("Responder secrets JSON file must contain a nonempty array");
+  }
+
+  const keys = new Set<string>();
+  return parsed.map((entry, index) => {
+    if (typeof entry !== "object" || entry === null || Array.isArray(entry)) {
+      throw new Error(`Responder secret at index ${index} must be an object`);
+    }
+
+    const { key, value } = entry as Record<string, unknown>;
+    if (typeof key !== "string" || !environmentKeyPattern.test(key)) {
+      throw new Error(
+        `Responder secret at index ${index} has an invalid environment key`,
+      );
+    }
+    if (typeof value !== "string") {
+      throw new Error(
+        `Responder secret at index ${index} must have a string value`,
+      );
+    }
+    if (value.includes("\0")) {
+      throw new Error(
+        `Responder secret at index ${index} contains an unsupported null byte`,
+      );
+    }
+    if (keys.has(key)) {
+      throw new Error(
+        `Responder secret at index ${index} duplicates environment key ${key}`,
+      );
+    }
+    keys.add(key);
+
+    return { key, value };
+  });
+}
+
+export function loadResponderSecrets(
+  environment: NodeJS.ProcessEnv = process.env,
+  loadLegacyEnvFile: (path: string) => void = (path) =>
+    process.loadEnvFile(path),
+  readSecretsJSONFile: () => string = () =>
+    readFileSync(responderSecretsJSONPath, "utf8"),
+): void {
+  const jsonPath = environment.RESPONDER_SECRETS_JSON_FILE;
+  if (jsonPath !== undefined) {
+    if (jsonPath.length === 0) {
+      throw new Error("RESPONDER_SECRETS_JSON_FILE must not be empty");
+    }
+    if (jsonPath !== responderSecretsJSONPath) {
+      throw new Error(
+        `RESPONDER_SECRETS_JSON_FILE must be ${responderSecretsJSONPath}`,
+      );
+    }
+
+    let contents: string;
+    try {
+      contents = readSecretsJSONFile();
+    } catch {
+      throw new Error("Unable to read responder secrets JSON file");
+    }
+
+    const secrets = parseResponderSecrets(contents);
+    for (const { key, value } of secrets) {
+      if (!Object.hasOwn(environment, key)) environment[key] = value;
+    }
+    return;
+  }
+
+  const legacyPath = environment.RESPONDER_SECRETS_FILE;
+  if (legacyPath !== undefined) {
+    if (legacyPath.length === 0) {
+      throw new Error("RESPONDER_SECRETS_FILE must not be empty");
+    }
+    if (legacyPath !== responderSecretsLegacyPath) {
+      throw new Error(
+        `RESPONDER_SECRETS_FILE must be ${responderSecretsLegacyPath}`,
+      );
+    }
+    loadLegacyEnvFile(responderSecretsLegacyPath);
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,10 +6,11 @@ settings:
 
 overrides:
   '@daytona/sdk>shell-quote': 1.9.0
-  '@esbuild-kit/core-utils>esbuild': 0.25.12
+  '@esbuild-kit/core-utils>esbuild': 0.28.2
   '@eslint/eslintrc>js-yaml': 4.3.1
   ajv>fast-uri: 3.1.5
   concurrently>shell-quote: 1.9.0
+  drizzle-kit>esbuild: 0.28.2
   minimatch@3>brace-expansion: 1.1.18
   minimatch@10>brace-expansion: 5.0.9
 
@@ -37,7 +38,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: 6.0.4
-        version: 6.0.4(vite@8.2.1(@types/node@26.0.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.20.6)(yaml@2.9.0))
+        version: 6.0.4(vite@8.2.1(@types/node@26.0.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
       concurrently:
         specifier: 9.2.1
         version: 9.2.1
@@ -57,8 +58,8 @@ importers:
         specifier: 0.15.1
         version: 0.15.1
       tsx:
-        specifier: 4.20.6
-        version: 4.20.6
+        specifier: 4.23.12
+        version: 4.23.12
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -67,16 +68,16 @@ importers:
         version: 8.65.0(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
       vite:
         specifier: 8.2.1
-        version: 8.2.1(@types/node@26.0.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.20.6)(yaml@2.9.0)
+        version: 8.2.1(@types/node@26.0.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)
       vitest:
         specifier: 4.1.9
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(vite@8.2.1(@types/node@26.0.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.20.6)(yaml@2.9.0))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(vite@8.2.1(@types/node@26.0.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
 
   apps/control-plane:
     dependencies:
       '@better-auth/drizzle-adapter':
         specifier: 1.6.25
-        version: 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.4)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.4)(pg@8.22.0))
+        version: 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.5)(pg@8.22.0))
       '@daytona/sdk':
         specifier: 0.203.0
         version: 0.203.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
@@ -91,25 +92,25 @@ importers:
         version: link:../../packages/core
       '@sentry/hono':
         specifier: 10.69.0
-        version: 10.69.0(@hono/node-server@2.0.12(hono@4.12.34))(@sentry/node@10.69.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.221.0(@opentelemetry/api@1.9.1))(supports-color@8.1.1))(hono@4.12.34)
+        version: 10.69.0(@hono/node-server@2.0.12(hono@4.12.34))(@sentry/node@10.69.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.220.0(@opentelemetry/api@1.9.1))(supports-color@8.1.1))(hono@4.12.34)
       '@sentry/node':
         specifier: 10.69.0
-        version: 10.69.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.221.0(@opentelemetry/api@1.9.1))(supports-color@8.1.1)
+        version: 10.69.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.220.0(@opentelemetry/api@1.9.1))(supports-color@8.1.1)
       '@sentry/react':
         specifier: 10.69.0
         version: 10.69.0(react@19.2.6)
       '@xyflow/react':
         specifier: ^12.11.2
-        version: 12.11.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 12.11.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       better-auth:
         specifier: 1.6.25
-        version: 1.6.25(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.4)(pg@8.22.0))(pg@8.22.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(vite@8.2.1(@types/node@26.0.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.20.6)(yaml@2.9.0)))
+        version: 1.6.25(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.5)(pg@8.22.0))(pg@8.22.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(vite@8.2.1(@types/node@26.0.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)))
       hono:
         specifier: 4.12.34
         version: 4.12.34
       posthog-js:
         specifier: ^1.416.1
-        version: 1.416.1
+        version: 1.417.1
       react:
         specifier: 19.2.6
         version: 19.2.6
@@ -126,8 +127,8 @@ importers:
         specifier: 6.12.3
         version: 6.12.3
       tsx:
-        specifier: 4.20.6
-        version: 4.20.6
+        specifier: 4.23.12
+        version: 4.23.12
       zod:
         specifier: 4.4.3
         version: 4.4.3
@@ -137,16 +138,16 @@ importers:
         version: 5.4.0(supports-color@8.1.1)
       '@tailwindcss/vite':
         specifier: ^4.3.3
-        version: 4.3.3(vite@8.2.1(@types/node@26.0.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.20.6)(yaml@2.9.0))
+        version: 4.3.3(vite@8.2.1(@types/node@26.0.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
       '@vitejs/plugin-react':
         specifier: 6.0.4
-        version: 6.0.4(vite@8.2.1(@types/node@26.0.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.20.6)(yaml@2.9.0))
+        version: 6.0.4(vite@8.2.1(@types/node@26.0.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
       tailwindcss:
         specifier: ^4.3.3
         version: 4.3.3
       vite:
         specifier: 8.2.1
-        version: 8.2.1(@types/node@26.0.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.20.6)(yaml@2.9.0)
+        version: 8.2.1(@types/node@26.0.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)
 
   apps/worker:
     dependencies:
@@ -157,14 +158,14 @@ importers:
         specifier: 0.203.0
         version: 0.203.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
       '@daytonaio/sdk':
-        specifier: 0.162.0
-        version: 0.162.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)(ws@8.21.3)
+        specifier: npm:@daytona/sdk@0.203.0
+        version: '@daytona/sdk@0.203.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)'
       '@openai/agents':
         specifier: 0.14.2
         version: 0.14.2(@aws-sdk/credential-provider-node@3.972.80)(@smithy/signature-v4@5.7.2)(supports-color@8.1.1)(ws@8.21.3)(zod@4.4.3)
       '@openai/agents-extensions':
         specifier: 0.14.2
-        version: 0.14.2(@ai-sdk/provider@4.0.4)(@aws-sdk/credential-provider-node@3.972.80)(@daytonaio/sdk@0.162.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)(ws@8.21.3))(@openai/agents@0.14.2(@aws-sdk/credential-provider-node@3.972.80)(@smithy/signature-v4@5.7.2)(supports-color@8.1.1)(ws@8.21.3)(zod@4.4.3))(@smithy/signature-v4@5.7.2)(ai@7.0.41(zod@4.4.3))(supports-color@8.1.1)(ws@8.21.3)(zod@4.4.3)
+        version: 0.14.2(@aws-sdk/credential-provider-node@3.972.80)(@daytona/sdk@0.203.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1))(@openai/agents@0.14.2(@aws-sdk/credential-provider-node@3.972.80)(@smithy/signature-v4@5.7.2)(supports-color@8.1.1)(ws@8.21.3)(zod@4.4.3))(@smithy/signature-v4@5.7.2)(supports-color@8.1.1)(ws@8.21.3)(zod@4.4.3)
       '@opentelemetry/api':
         specifier: 1.9.1
         version: 1.9.1
@@ -173,7 +174,7 @@ importers:
         version: link:../../packages/core
       '@sentry/node':
         specifier: 10.69.0
-        version: 10.69.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.221.0(@opentelemetry/api@1.9.1))(supports-color@8.1.1)
+        version: 10.69.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.220.0(@opentelemetry/api@1.9.1))(supports-color@8.1.1)
       '@smithy/protocol-http':
         specifier: 5.6.2
         version: 5.6.2
@@ -188,10 +189,10 @@ importers:
         version: 0.2.7(supports-color@8.1.1)
       openai:
         specifier: 6.49.0
-        version: 6.49.0(@aws-sdk/credential-provider-node@3.972.79)(@smithy/signature-v4@5.7.2)(ws@8.21.3)(zod@4.4.3)
+        version: 6.49.0(@aws-sdk/credential-provider-node@3.972.80)(@smithy/signature-v4@5.7.2)(ws@8.21.3)(zod@4.4.3)
       tsx:
-        specifier: 4.20.6
-        version: 4.20.6
+        specifier: 4.23.12
+        version: 4.23.12
       zod:
         specifier: 4.4.3
         version: 4.4.3
@@ -199,23 +200,26 @@ importers:
   packages/core:
     dependencies:
       '@aws-sdk/client-s3':
-        specifier: 3.1106.0
-        version: 3.1106.0
+        specifier: 3.1111.0
+        version: 3.1111.0
       '@aws-sdk/client-sts':
         specifier: 3.1111.0
         version: 3.1111.0
       '@aws-sdk/s3-request-presigner':
-        specifier: 3.1106.0
-        version: 3.1106.0
+        specifier: 3.1111.0
+        version: 3.1111.0
       '@modelcontextprotocol/sdk':
         specifier: 1.30.0
         version: 1.30.0(supports-color@8.1.1)(zod@4.4.3)
       autumn-js:
         specifier: 1.2.45
-        version: 1.2.45(better-auth@1.6.25(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.4)(pg@8.22.0))(pg@8.22.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(vite@8.2.1(@types/node@26.0.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))))(better-call@1.3.7(zod@4.4.3))(express@5.2.1(supports-color@8.1.1))(hono@4.12.34)(react@19.2.6)
+        version: 1.2.45(better-auth@1.6.25(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.5)(pg@8.22.0))(pg@8.22.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(vite@8.2.1(@types/node@26.0.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))))(better-call@1.3.7(zod@4.4.3))(express@5.2.1(supports-color@8.1.1))(hono@4.12.34)(react@19.2.6)
       drizzle-orm:
         specifier: 0.45.2
-        version: 0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.4)(pg@8.22.0)
+        version: 0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.5)(pg@8.22.0)
+      ipaddr.js:
+        specifier: 2.5.0
+        version: 2.5.0
       pg:
         specifier: 8.22.0
         version: 8.22.0
@@ -224,28 +228,15 @@ importers:
         version: 12.26.3
       posthog-node:
         specifier: ^5.47.0
-        version: 5.47.0(rxjs@7.8.2)
+        version: 5.49.1(rxjs@7.8.2)
+      undici:
+        specifier: 8.10.0
+        version: 8.10.0
       zod:
         specifier: 4.4.3
         version: 4.4.3
 
 packages:
-
-  '@ai-sdk/gateway@4.0.31':
-    resolution: {integrity: sha512-gEBBUP7nyfQY+K+xFllYJ374RbJoRUa5RN2NyLPu12OfMv5U09kNzZTvBDHnqx78P/7qEELyIg9C5k+RPiBkjg==}
-    engines: {node: '>=22'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
-
-  '@ai-sdk/provider-utils@5.0.14':
-    resolution: {integrity: sha512-HW+Ys98cr2BRQzP6jTlp2bRKIqt+oAjYNLm9gqUUQkLz7QERtaPgDZOoXHz9IXSXoOtz175p4Q17qKQdEX0Hag==}
-    engines: {node: '>=22'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
-
-  '@ai-sdk/provider@4.0.4':
-    resolution: {integrity: sha512-tbHKNLirllUNF3ZlkCsXnwab2ZV1Sl4b1H/Cp9ruCce15IBmskE8Gwkk0yo9xDWY+jho2of7lVXtwSsyrq7cwQ==}
-    engines: {node: '>=22'}
 
   '@apm-js-collab/code-transformer-bundler-plugins@0.7.4':
     resolution: {integrity: sha512-nAfOeZPSUAQvJa1iFT/5oCrTm5YQhMMrfCNthNnaXHZiOQhu1KGuLoIx7HtbAi3wfwaBYLaICPIeenIaEwcXIg==}
@@ -265,142 +256,82 @@ packages:
   '@aws-crypto/util@5.2.0':
     resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
 
-  '@aws-sdk/checksums@3.1000.27':
-    resolution: {integrity: sha512-insWOqKKNUrbN/dohEG7BJ0U5GkyqhjbMb/NHNaLUtq+7my2M8C4EnZZZoxMmXRqCC+P9dEr+KyJA2JGGzoKLg==}
+  '@aws-sdk/checksums@3.1000.28':
+    resolution: {integrity: sha512-VCpnmyHQ1IH49ni3LXnQj7DPr7rmcJmzYeiCkYdCcfgNtkvOj38cdcL9lapBWoItZWFACJPFJlymqC7/gem3Gw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/client-s3@3.1106.0':
-    resolution: {integrity: sha512-hUTlnyRRGlVdfvJLL3hCEnMm7CmunSzc/lxFVRX8g1fjJTMUVbyQCfhfMhp7dZ7JBftLU6OYresu3Hje4nvkJw==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/client-s3@3.1109.0':
-    resolution: {integrity: sha512-iPWzBeGkAe5H5+dBBGCOdIT4uMhpu12OK+nFnDzjvOChVnHIws4LeoG7Yl0kJHSRWZnNEkVcF4vQYTJny0e5xA==}
+  '@aws-sdk/client-s3@3.1111.0':
+    resolution: {integrity: sha512-VnLT6aSTN8tWl/NsXUysXNZor7wQBp9CRwufo7kt8cwGXvHLZ0S/cV1K9WFcREGboVYSo3NGQ3ZvU7LRidh2aQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/client-sts@3.1111.0':
     resolution: {integrity: sha512-b41gi3Z0tMt/e7RpiBwm2H+Fz+NvlczQ6vxy2pTsDp7WcwXLFCXeluvvl1Y/RBL4g7+4/qaRODkMUSSPBjUWcA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/core@3.977.7':
-    resolution: {integrity: sha512-I88Iov89NVmjSmJLKSv7Cn9M2J+a2942OkA8nZCbz+sl4ZeY4zEOcoLOrbt1GRfQ8zEQKnjAJdXixA3J/p1fDQ==}
-    engines: {node: '>=20.0.0'}
-
   '@aws-sdk/core@3.977.8':
     resolution: {integrity: sha512-7+Kcrkvrk9lM/m7jRhHpT4jCdvzGHsuaSRbF8TdzzkY1mRzp/Ogwf9c7H29k4gGhey0BBWhCWr16+t0J61gwmg==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-env@3.972.68':
-    resolution: {integrity: sha512-2a20A/IdNOwUvaDq91iqqS7BA0XlNMfW3iLGZGZLJv0EbUqhSxB0PIx4rQQqssvWj1uXImb3/UCCdHz/+1dOiA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-env@3.972.69':
     resolution: {integrity: sha512-AreCFzcB4kH2HF9031Ot0jSJr3KXvRg6e8uDeub20JEVdZU3Bv0sTq1plc7VsT3KiqutlzH7l0j50UcCWHUioA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-http@3.972.70':
-    resolution: {integrity: sha512-0yRem2Fs52r/Nn6UAqIlpjexfaYj8ziEozOe9tamtAVT/5bzFLKx8O2r7MaRqgS3hGKHIa1Jij9nKHSsNnb04A==}
-    engines: {node: '>=20.0.0'}
-
   '@aws-sdk/credential-provider-http@3.972.71':
     resolution: {integrity: sha512-A8ObcqVmDMnk4F9NozZ7JwmUu9Q4xyBJkmyq1C5U+wNM9ht9J7+EuuyabsLWXZnOoTqFaJuYBYTKf5CTipkEjA==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-ini@3.973.13':
-    resolution: {integrity: sha512-2M39DE02XpYYaSWYk/4AsImXYUU/1L2xmTMLUpMMWq7DfLv191/vCRy3baKtdr45AkJQyVgSjmuVOLm15SwrRQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-ini@3.973.14':
     resolution: {integrity: sha512-7c+Wti2LsERNWMfm7ySz3/6RPopFW3Nmn7s63Xpcq6R/tRuY5hpvkHA2xVgi5ukJbvok9l0IDtVEvqTtg+X7dw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-login@3.972.75':
-    resolution: {integrity: sha512-jaTESuJlQsoUZ44f/i2puyPt8VlF/dMMJ9HM3cStYtk7eKX4N9UWi83OLixUkoOJH3BwWlPLCq9YIK9nfWhVBg==}
-    engines: {node: '>=20.0.0'}
-
   '@aws-sdk/credential-provider-login@3.972.76':
     resolution: {integrity: sha512-LVixwOnEJfrrfKHeZjBA8pIMTZjNDq8ak8VpcoWUuCJDrSnBNU8POJksULMgvN089P0MXtQYH2Zs627/MK1K0g==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-node@3.972.79':
-    resolution: {integrity: sha512-RIw5dof1EHkWubrZzPC941CDtnFG1iAXsxbFgLkhdYZXHc4icU13c/uxSMI0J5eUx9bxa7LjfpdjfClBB1QsDA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-node@3.972.80':
     resolution: {integrity: sha512-bE2qh8ww4iClO1jHsBXdOE8FUgzDbdxbyorNjSCoPSkQd51k3jODItuPZfuwcLHZqDXsH+bI4AMHhqtuyR7mSg==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-process@3.972.68':
-    resolution: {integrity: sha512-nLP3Pda2MQTFJ25hKBMmUuB9Uv+bTZQNlufbeCwklP549Vwnkd8bRLJoCKp5k6xjmdyptrPrOfGOhN0mKuca8A==}
-    engines: {node: '>=20.0.0'}
-
   '@aws-sdk/credential-provider-process@3.972.69':
     resolution: {integrity: sha512-9kpTNdZTrcqXTfhxM7fgl9Z68ek3Fu5oe3Yf+A/pJGibEqpgZxz2tSY7SinmyCIU2PJ+ygY4FPoBBnLpocMtrQ==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-sso@3.973.12':
-    resolution: {integrity: sha512-EmgyyHn+f9WCcelp3L/vci+LGbX8GigWaVphRArjVo5Pktkr9YnLy/mQ6VDkDyBD72dtfRNTgHmD2ts4rTDXKQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-sso@3.973.13':
     resolution: {integrity: sha512-Oc81qauMPzUoTnAS2YKpNwY6sY/LUyQTEeaf6yP197WMxkEBQfcKLR1MFpD7+pNTubXnfkH6gwpji+Gc7iyD2Q==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-web-identity@3.972.74':
-    resolution: {integrity: sha512-0YfczxGXF3RjGj8z7QG/Ho2HnLGKDHfPSHiTs47UU1U/+mmwISDN+rvGKt2zh+3FX8NdT4xd95LGBGyhQw2dgQ==}
-    engines: {node: '>=20.0.0'}
-
   '@aws-sdk/credential-provider-web-identity@3.972.75':
     resolution: {integrity: sha512-YPN6uoGDgjjjeVFZrcOeCJqmB6zpXoeeNgIjqe+DexJaWqdjVfCCe+VAZwli9Z2h8KhFW8oxkO39emQ1tyz/Mw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/lib-storage@3.1109.0':
-    resolution: {integrity: sha512-l05ablXGuiLHmuhQZhisBQcK1ZgwP1CsTeb+7x9X942qP9ba6RAMqSfh8R7QGTkN5c9PowWfDVLNbouQDTrQiw==}
+  '@aws-sdk/lib-storage@3.1111.0':
+    resolution: {integrity: sha512-UjLJE0Zxv/m8Xgd3DLBXssZYISgoEPZpJiPWY+MadEdP36oOcjHVsR8ToUq6MMmKdzuBFYB6qGHWS/yKAG4fow==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
-      '@aws-sdk/client-s3': ^3.1109.0
+      '@aws-sdk/client-s3': ^3.1111.0
 
-  '@aws-sdk/middleware-sdk-s3@3.972.73':
-    resolution: {integrity: sha512-oy7sRA5HvHcAvkcKX6F8RI240jcOf3c8y/Gqjs9qemIibdKQqGBIi0uwa+47ZRYqGLpdEO28TQU4G73yUzo06Q==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/nested-clients@3.997.42':
-    resolution: {integrity: sha512-XWRyon2MTHXD/zMoo0Mbge6Vwf+iE0qQaM/RyGO6NfZ9WukCFiQL27nQVZjYy2JwSIg+iXZxKOX95OBXqlSM4w==}
+  '@aws-sdk/middleware-sdk-s3@3.972.74':
+    resolution: {integrity: sha512-2lzoV2z2QO5KJZYGOCnIZ1WVQgzMECvwuzr1xb034a++8QW4U4eGrmC2u4yg1xvNv4TLL/Uv5DLyuAiw0b9z7Q==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/nested-clients@3.997.43':
     resolution: {integrity: sha512-bit+VpqWNyi3wHxFoTsTliNXimCSL2r2OeDTm7ZrG+YsTZ2D7ofDJ6r/t9PVBn80i6/v0X2h9Tgw6QP2MAKfPw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/s3-request-presigner@3.1106.0':
-    resolution: {integrity: sha512-ZI5SCkyz8jB3Qr6NPSJ7R4A/PkniQvbD1DO8APwhMsubFcfwPSJMMUxrkv9k1E20ikRk7skpM9itZh+0wI9K/w==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/signature-v4-multi-region@3.996.44':
-    resolution: {integrity: sha512-ZSfQ35Qn4MhSY+A0Whyr+KBx+wJKZUyBsOrjB2pSHOafRzbFe47T8XcXM8hZqUAC69qnqIy0C9ArxTuud0CC2w==}
+  '@aws-sdk/s3-request-presigner@3.1111.0':
+    resolution: {integrity: sha512-ACp/VtDTw6AjFW5Q3M59uAMrBbAHeQS0UBIOIgUROO98Z3uhpiy37k9RmvxbXYVugmTcdNTy4DPVQtLG8sDy6g==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/signature-v4-multi-region@3.996.45':
     resolution: {integrity: sha512-bBuyztukzXq6plzFGHAWiQt0QXo+HL8b8lX5cFTzkez/74PtS1c0qPFCIVuHkyoT+miH2qOjAcm1/yoro2ESPA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/token-providers@3.1108.0':
-    resolution: {integrity: sha512-rI80zxDxGJ6904eC/YbjkdjY6JdaZvQ01kOmrMvw7cFQGIHo27fhnIVbMSVDS4T6foQImjxYSRoOu/uSJscXDw==}
-    engines: {node: '>=20.0.0'}
-
   '@aws-sdk/token-providers@3.1111.0':
     resolution: {integrity: sha512-JfljgoVtl+s3Qy21n9a7Z48uCQaOXcN74KJ3TEQfPoB293GrXFSt6HSQJF1sTZ8c/5QedEvd3NjJQMO4u9qa5A==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/types@3.974.3':
-    resolution: {integrity: sha512-ECAqfpNsef+7MO8qtR0h9KcFIBAygaE7Cm6UOiQl+ft+uVap+1G7bNEjs4mdJE2OnA4m6k7i8peH8uGIAsOMGw==}
-    engines: {node: '>=20.0.0'}
-
   '@aws-sdk/types@3.974.4':
     resolution: {integrity: sha512-dSFDNG00MEz0/xl5gxL62giLd1iYyJsTxZ1I1DOj6lC+bbgLB4TRsYClJg3b62dhXT1uATzsTNXPnC+33EJV3A==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/xml-builder@3.972.38':
-    resolution: {integrity: sha512-grf7mzfVxBS5AlsuTvBN7uDpzqohFww9fRPCO+EBSUdvtsYMcPSKdz54h/7XiscqNcUM1Ae1MF7JLHmiYYuzbQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/xml-builder@3.972.39':
@@ -423,8 +354,8 @@ packages:
     resolution: {integrity: sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/generator@7.29.7':
-    resolution: {integrity: sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==}
+  '@babel/generator@7.29.8':
+    resolution: {integrity: sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-compilation-targets@7.29.7':
@@ -461,8 +392,8 @@ packages:
     resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/parser@7.29.7':
-    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
+  '@babel/parser@7.29.8':
+    resolution: {integrity: sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -470,12 +401,12 @@ packages:
     resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/traverse@7.29.7':
-    resolution: {integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==}
+  '@babel/traverse@7.29.8':
+    resolution: {integrity: sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/types@7.29.7':
-    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
+  '@babel/types@7.29.8':
+    resolution: {integrity: sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==}
     engines: {node: '>=6.9.0'}
 
   '@better-auth/core@1.6.25':
@@ -554,14 +485,14 @@ packages:
   '@better-auth/utils@0.4.2':
     resolution: {integrity: sha512-AUxrvu+HaaODsUyzDxFgwd/8RZ1yZaYo42LXKSrU2oGgR38pS1ij8nqQKNgtTWoYGpNevNXtCfgTy6loHveW9A==}
 
+  '@better-auth/utils@0.4.3':
+    resolution: {integrity: sha512-/X4gRYJBwRuLFjjANVpTDJJkAhLD6Sf8SIBypQ+Q2kDW1MnCsyxUujJzdKYsp59i4c41+AaMtpY/WQAQumqtOA==}
+
   '@better-fetch/fetch@1.3.1':
     resolution: {integrity: sha512-ABkD1WhyfPZprKRQI3bhATjeiFuNWC9PXhfGWqL+sg/gKrM977oFrYkdb4msM3hgUGonr7KlOsOFT5TU2rht9g==}
 
   '@daytona/analytics-api-client@0.203.0':
     resolution: {integrity: sha512-sUELDOmSJW73kG8xsEOUVAE+SGAhPIaLThIBJc6Zbp+AnEMObeUNwXFh9r9ATCdYULoDkTVVA8mMqzP46io9LQ==}
-
-  '@daytona/api-client@0.162.0':
-    resolution: {integrity: sha512-cKhncpTZgTFHsrQB7AuayBwmGaNcQCY/Qcycb2VMlYUlobWEEXlqPZaVdvgeZakRwJA6DfVtMF87kek9cTRubg==}
 
   '@daytona/api-client@0.203.0':
     resolution: {integrity: sha512-d72iv8+FECQo0h4G9fOIAr7iVuJaa/c1KJXfG2LeeI3uG+uCWh+E0d8pfgW9nAMQS4wD1ZoTuuzPPUedSn7g7Q==}
@@ -569,15 +500,8 @@ packages:
   '@daytona/sdk@0.203.0':
     resolution: {integrity: sha512-jYukJh035kiCkELdPIIEJTY+LR5iTUPzElaspFRXmh1x6VVGEIOsIElir24b9mXtKB2gV/MJTViOkCwKUFFdqA==}
 
-  '@daytona/toolbox-api-client@0.162.0':
-    resolution: {integrity: sha512-kj4qCzynGQYF5/718YVs3T3wqRhFh9NGDjHTRpUDnGXX/PyLI6O8zD6GlftJFMdgJjp8d8DFOTVvPgAO9/mXAw==}
-
   '@daytona/toolbox-api-client@0.203.0':
     resolution: {integrity: sha512-J3X72PLZOrzR4KUQj6EHdNU4ALZnN8FBPt49h7Q7UqGWdeq21ZmgQ69acOcGZyDq/rc6xPlHKgfQ5W5YLYHdpg==}
-
-  '@daytonaio/sdk@0.162.0':
-    resolution: {integrity: sha512-MPvYsZWEwVJymNYpH6bnFMzPb+FwqGrvBG9zkmUQzQbHSqi+urpngJSYfxCmNZkOz7SxYk07HFga9iFzWM0pww==}
-    deprecated: 'Moved to @daytona/sdk, same API, no breaking changes. Please update: npm uninstall @daytonaio/sdk && npm i @daytona/sdk'
 
   '@drizzle-team/brocli@0.10.2':
     resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
@@ -590,34 +514,16 @@ packages:
     resolution: {integrity: sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==}
     deprecated: 'Merged into tsx: https://tsx.hirok.io'
 
-  '@esbuild/aix-ppc64@0.25.12':
-    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [aix]
-
   '@esbuild/aix-ppc64@0.28.2':
     resolution: {integrity: sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.25.12':
-    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [android]
-
   '@esbuild/android-arm64@0.28.2':
     resolution: {integrity: sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [android]
-
-  '@esbuild/android-arm@0.25.12':
-    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
-    engines: {node: '>=18'}
-    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.28.2':
@@ -626,34 +532,16 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.25.12':
-    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [android]
-
   '@esbuild/android-x64@0.28.2':
     resolution: {integrity: sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.25.12':
-    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [darwin]
-
   '@esbuild/darwin-arm64@0.28.2':
     resolution: {integrity: sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [darwin]
-
-  '@esbuild/darwin-x64@0.25.12':
-    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.28.2':
@@ -662,22 +550,10 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.25.12':
-    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [freebsd]
-
   '@esbuild/freebsd-arm64@0.28.2':
     resolution: {integrity: sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [freebsd]
-
-  '@esbuild/freebsd-x64@0.25.12':
-    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.28.2':
@@ -686,22 +562,10 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.25.12':
-    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [linux]
-
   '@esbuild/linux-arm64@0.28.2':
     resolution: {integrity: sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [linux]
-
-  '@esbuild/linux-arm@0.25.12':
-    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
-    engines: {node: '>=18'}
-    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.28.2':
@@ -710,22 +574,10 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.25.12':
-    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [linux]
-
   '@esbuild/linux-ia32@0.28.2':
     resolution: {integrity: sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==}
     engines: {node: '>=18'}
     cpu: [ia32]
-    os: [linux]
-
-  '@esbuild/linux-loong64@0.25.12':
-    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
-    engines: {node: '>=18'}
-    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.28.2':
@@ -734,22 +586,10 @@ packages:
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.25.12':
-    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
-    engines: {node: '>=18'}
-    cpu: [mips64el]
-    os: [linux]
-
   '@esbuild/linux-mips64el@0.28.2':
     resolution: {integrity: sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==}
     engines: {node: '>=18'}
     cpu: [mips64el]
-    os: [linux]
-
-  '@esbuild/linux-ppc64@0.25.12':
-    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.28.2':
@@ -758,22 +598,10 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.25.12':
-    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
-    engines: {node: '>=18'}
-    cpu: [riscv64]
-    os: [linux]
-
   '@esbuild/linux-riscv64@0.28.2':
     resolution: {integrity: sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==}
     engines: {node: '>=18'}
     cpu: [riscv64]
-    os: [linux]
-
-  '@esbuild/linux-s390x@0.25.12':
-    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
-    engines: {node: '>=18'}
-    cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-s390x@0.28.2':
@@ -782,34 +610,16 @@ packages:
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-x64@0.25.12':
-    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [linux]
-
   '@esbuild/linux-x64@0.28.2':
     resolution: {integrity: sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/netbsd-arm64@0.25.12':
-    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [netbsd]
-
   '@esbuild/netbsd-arm64@0.28.2':
     resolution: {integrity: sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [netbsd]
-
-  '@esbuild/netbsd-x64@0.25.12':
-    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [netbsd]
 
   '@esbuild/netbsd-x64@0.28.2':
@@ -818,22 +628,10 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/openbsd-arm64@0.25.12':
-    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openbsd]
-
   '@esbuild/openbsd-arm64@0.28.2':
     resolution: {integrity: sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [openbsd]
-
-  '@esbuild/openbsd-x64@0.25.12':
-    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.28.2':
@@ -842,23 +640,11 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openharmony-arm64@0.25.12':
-    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openharmony]
-
   '@esbuild/openharmony-arm64@0.28.2':
     resolution: {integrity: sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
-
-  '@esbuild/sunos-x64@0.25.12':
-    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [sunos]
 
   '@esbuild/sunos-x64@0.28.2':
     resolution: {integrity: sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==}
@@ -866,34 +652,16 @@ packages:
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/win32-arm64@0.25.12':
-    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [win32]
-
   '@esbuild/win32-arm64@0.28.2':
     resolution: {integrity: sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.25.12':
-    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [win32]
-
   '@esbuild/win32-ia32@0.28.2':
     resolution: {integrity: sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==}
     engines: {node: '>=18'}
     cpu: [ia32]
-    os: [win32]
-
-  '@esbuild/win32-x64@0.25.12':
-    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.28.2':
@@ -1014,16 +782,12 @@ packages:
       '@cfworker/json-schema':
         optional: true
 
-  '@neondatabase/serverless@1.0.2':
-    resolution: {integrity: sha512-I5sbpSIAHiB+b6UttofhrN/UJXII+4tZPAq1qugzwCwLIL8EZLV7F/JyHUrEIiGgQpEXzpnjlJ+zwcEhheGvCw==}
-    engines: {node: '>=19.0.0'}
-
-  '@noble/ciphers@2.2.0':
-    resolution: {integrity: sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA==}
+  '@noble/ciphers@2.3.0':
+    resolution: {integrity: sha512-Clu/xdfgVTf9o7ngLOURaxePwR0j8sjclKEtVij10/jGulwFsPWCvvRgG/XjUVf8Nei+jLG6uwyXzUTGY1DQrw==}
     engines: {node: '>= 20.19.0'}
 
-  '@noble/hashes@2.2.0':
-    resolution: {integrity: sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==}
+  '@noble/hashes@2.3.0':
+    resolution: {integrity: sha512-oN+QwyX7VSHotibwubG3kpzbwKrfnyR6OOO+3Nk/53ADL7FmgHHz4TgrbaYKvvOw09u6QTx0oiH1cNCIOuN0CQ==}
     engines: {node: '>= 20.19.0'}
 
   '@nodelib/fs.scandir@2.1.5':
@@ -1099,16 +863,8 @@ packages:
     peerDependencies:
       zod: ^4.0.0
 
-  '@opentelemetry/api-logs@0.207.0':
-    resolution: {integrity: sha512-lAb0jQRVyleQQGiuuvCOTDVspc14nx6XJjP4FspJ1sNARo3Regq4ZZbrc3rN4b1TYSuUCvgH+UXUPug4SLOqEQ==}
-    engines: {node: '>=8.0.0'}
-
   '@opentelemetry/api-logs@0.220.0':
     resolution: {integrity: sha512-CmVa4ImJ+ynfrPMNaAXHET6Bhb44SwzmfyVJFq9ni2jgXJR/l7C6gfVFddNmHP+ZOkP9cf4f9DBe68qVLTHc9w==}
-    engines: {node: '>=8.0.0'}
-
-  '@opentelemetry/api-logs@0.221.0':
-    resolution: {integrity: sha512-OlanaW1vv7ufTqQ3/fPLI4arGt5ZoM+P8abOMki6uEYnpRazepSWDwDnnw+la7kE26SHVC18//SMccrDvLKOXQ==}
     engines: {node: '>=8.0.0'}
 
   '@opentelemetry/api@1.9.1':
@@ -1120,12 +876,6 @@ packages:
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.9.0
-
-  '@opentelemetry/context-async-hooks@2.2.0':
-    resolution: {integrity: sha512-qRkLWiUEZNAmYapZ7KGS5C4OmBLcP/H2foXeOEaowYCR0wi89fHejrfYfbuLVCMLp/dWZXKvQusdbUEZjERfwQ==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.0.0 <1.10.0'
 
   '@opentelemetry/context-async-hooks@2.9.0':
     resolution: {integrity: sha512-OQ0vzvbZBiUhjqLnUaoNfYmP8553Crr3aggB4y0ZUi815mZ7idpdJXQmoKdeBKJelYttoBlLSSHubmyw3wvX4w==}
@@ -1139,32 +889,14 @@ packages:
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
 
-  '@opentelemetry/core@2.2.0':
-    resolution: {integrity: sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.0.0 <1.10.0'
-
   '@opentelemetry/core@2.9.0':
     resolution: {integrity: sha512-m2nckMT80NnmjTYSPjJQObBJ+8dgkoajEOUbznL8AHZ3T3yHRk2P7gI1PhEBc1+lOnrYE9UWrWHqJDsmqjmNbw==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
 
-  '@opentelemetry/exporter-logs-otlp-grpc@0.207.0':
-    resolution: {integrity: sha512-K92RN+kQGTMzFDsCzsYNGqOsXRUnko/Ckk+t/yPJao72MewOLgBUTWVHhebgkNfRCYqDz1v3K0aPT9OJkemvgg==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
   '@opentelemetry/exporter-logs-otlp-grpc@0.220.0':
     resolution: {integrity: sha512-s0sRPCSlXYqlgObOpCftomJllp3LfUL9FobQ5csg2172ydVhSEnu1ptpsVBJadazs5nUNp7vDuLE03FAFWTLOQ==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/exporter-logs-otlp-http@0.207.0':
-    resolution: {integrity: sha512-JpOh7MguEUls8eRfkVVW3yRhClo5b9LqwWTOg8+i4gjr/+8eiCtquJnC7whvpTIGyff06cLZ2NsEj+CVP3Mjeg==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
@@ -1175,20 +907,8 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
-  '@opentelemetry/exporter-logs-otlp-proto@0.207.0':
-    resolution: {integrity: sha512-RQJEV/K6KPbQrIUbsrRkEe0ufks1o5OGLHy6jbDD8tRjeCsbFHWfg99lYBRqBV33PYZJXsigqMaAbjWGTFYzLw==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
   '@opentelemetry/exporter-logs-otlp-proto@0.220.0':
     resolution: {integrity: sha512-8LZAxdJ0ENDAFwr4j0oY35mHBltiSzvlhdQAPGiC7p9VnxtuSq4SW1gfBAdW6t6hiQG6OwUl8w7KHaOdJPKHWg==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/exporter-metrics-otlp-grpc@0.207.0':
-    resolution: {integrity: sha512-6flX89W54gkwmqYShdcTBR1AEF5C1Ob0O8pDgmLPikTKyEv27lByr9yBmO5WrP0+5qJuNPHrLfgFQFYi6npDGA==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
@@ -1199,20 +919,8 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
-  '@opentelemetry/exporter-metrics-otlp-http@0.207.0':
-    resolution: {integrity: sha512-fG8FAJmvXOrKXGIRN8+y41U41IfVXxPRVwyB05LoMqYSjugx/FSBkMZUZXUT/wclTdmBKtS5MKoi0bEKkmRhSw==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
   '@opentelemetry/exporter-metrics-otlp-http@0.220.0':
     resolution: {integrity: sha512-Yqt3RBw/bRVncaE9qIIhk4WfjbAQqXuP9FgAaU+IKPndnLEp/cUqZlSC324+bpmduRz7DoTjig8Ub0PeILWXUA==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/exporter-metrics-otlp-proto@0.207.0':
-    resolution: {integrity: sha512-kDBxiTeQjaRlUQzS1COT9ic+et174toZH6jxaVuVAvGqmxOkgjpLOjrI5ff8SMMQE69r03L3Ll3nPKekLopLwg==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
@@ -1223,20 +931,8 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
-  '@opentelemetry/exporter-prometheus@0.207.0':
-    resolution: {integrity: sha512-Y5p1s39FvIRmU+F1++j7ly8/KSqhMmn6cMfpQqiDCqDjdDHwUtSq0XI0WwL3HYGnZeaR/VV4BNmsYQJ7GAPrhw==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
   '@opentelemetry/exporter-prometheus@0.220.0':
     resolution: {integrity: sha512-JZD5DL/NBpVd2BHefvYosm3G40UZ/KzExLv5tc0eZe0CtrsHHtcOk3YPUxR2EINmUeBf8+w5UReTV8fFPn95lA==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/exporter-trace-otlp-grpc@0.207.0':
-    resolution: {integrity: sha512-7u2ZmcIx6D4KG/+5np4X2qA0o+O0K8cnUDhR4WI/vr5ZZ0la9J9RG+tkSjC7Yz+2XgL6760gSIM7/nyd3yaBLA==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
@@ -1247,26 +943,8 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
-  '@opentelemetry/exporter-trace-otlp-http@0.207.0':
-    resolution: {integrity: sha512-HSRBzXHIC7C8UfPQdu15zEEoBGv0yWkhEwxqgPCHVUKUQ9NLHVGXkVrf65Uaj7UwmAkC1gQfkuVYvLlD//AnUQ==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
   '@opentelemetry/exporter-trace-otlp-http@0.220.0':
     resolution: {integrity: sha512-/+ExB3lRkf+erv4PnoywyL7RHKITidxtUpUTS55k7OQ0dB42S7gEF1gry7swb9MSm1hYLUhJg4QQh9W8SpwwqA==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/exporter-trace-otlp-http@0.221.0':
-    resolution: {integrity: sha512-AySXiKoC+meiWm6zdVj5T2LnPDZuatveBby1cMOeQteIWsYXAUxs8Sru13G2pVSPrUXz6vF+og7QVBX6GdC/oQ==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/exporter-trace-otlp-proto@0.207.0':
-    resolution: {integrity: sha512-ruUQB4FkWtxHjNmSXjrhmJZFvyMm+tBzHyMm7YPQshApy4wvZUTcrpPyP/A/rCl/8M4BwoVIZdiwijMdbZaq4w==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
@@ -1277,32 +955,14 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
-  '@opentelemetry/exporter-zipkin@2.2.0':
-    resolution: {integrity: sha512-VV4QzhGCT7cWrGasBWxelBjqbNBbyHicWWS/66KoZoe9BzYwFB72SH2/kkc4uAviQlO8iwv2okIJy+/jqqEHTg==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.0.0
-
   '@opentelemetry/exporter-zipkin@2.9.0':
     resolution: {integrity: sha512-RwINoce2BH8T4obT5pMcAla2sWma1YZvYuaktWmTluQ0PkQdvv5D060rWI1+kawX+J2qBRcMbwrZJJNcMJUauQ==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.0.0
 
-  '@opentelemetry/instrumentation-http@0.207.0':
-    resolution: {integrity: sha512-FC4i5hVixTzuhg4SV2ycTEAYx+0E2hm+GwbdoVPSA6kna0pPVI4etzaA9UkpJ9ussumQheFXP6rkGIaFJjMxsw==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
   '@opentelemetry/instrumentation-http@0.220.0':
     resolution: {integrity: sha512-Szt4dO2Boz2CDr38DaSw/lnqwhwKl+IAdgNGEGgSm2Anb+fwPtIAGmIwkhsLLN69QQZQE96JxjMKYY4rlRkYKw==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/instrumentation@0.207.0':
-    resolution: {integrity: sha512-y6eeli9+TLKnznrR8AZlQMSJT7wILpXH+6EYq5Vf/4Ao+huI7EedxQHwRgVUOMLFbe7VFDvHJrX9/f4lcwnJsA==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
@@ -1313,26 +973,8 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
-  '@opentelemetry/otlp-exporter-base@0.207.0':
-    resolution: {integrity: sha512-4RQluMVVGMrHok/3SVeSJ6EnRNkA2MINcX88sh+d/7DjGUrewW/WT88IsMEci0wUM+5ykTpPPNbEOoW+jwHnbw==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
   '@opentelemetry/otlp-exporter-base@0.220.0':
     resolution: {integrity: sha512-CXYo8UD5Mn9YbgebO2EL4wejtA+gxLmLiu6HCk2KH2BR7XhFN6/6p1UlCb23DYCjeYkndevLHuejCCN1yx4+OQ==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/otlp-exporter-base@0.221.0':
-    resolution: {integrity: sha512-UFPIq80OH3Ns/oPFHRj14d4DTOxUo+MUFU8hUiCq5jTqFhdeJnfVSANHT+xp92409cA+oxzvlZCe6NM1wvCuBA==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/otlp-grpc-exporter-base@0.207.0':
-    resolution: {integrity: sha512-eKFjKNdsPed4q9yYqeI5gBTLjXxDM/8jwhiC0icw3zKxHVGBySoDsed5J5q/PGY/3quzenTr3FiTxA3NiNT+nw==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
@@ -1343,38 +985,14 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
-  '@opentelemetry/otlp-transformer@0.207.0':
-    resolution: {integrity: sha512-+6DRZLqM02uTIY5GASMZWUwr52sLfNiEe20+OEaZKhztCs3+2LxoTjb6JxFRd9q1qNqckXKYlUKjbH/AhG8/ZA==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
   '@opentelemetry/otlp-transformer@0.220.0':
     resolution: {integrity: sha512-lXGrv7KXZ0gNH9SVNUaa6vv6phVYGvJxfXAlMbzbakiXru75f5MZl8Z7oqiMMQD77riVHJCFlQvbZs/VVN2/4A==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
-  '@opentelemetry/otlp-transformer@0.221.0':
-    resolution: {integrity: sha512-lg6lkOU08Az23jVcn/0Els9HP+V8PnR4Km6p0KgpTggS0n/WuhnmY64rSh83Of9iR9nD+dpWr6adlcX8KzAwjg==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/propagator-b3@2.2.0':
-    resolution: {integrity: sha512-9CrbTLFi5Ee4uepxg2qlpQIozoJuoAZU5sKMx0Mn7Oh+p7UrgCiEV6C02FOxxdYVRRFQVCinYR8Kf6eMSQsIsw==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.0.0 <1.10.0'
-
   '@opentelemetry/propagator-b3@2.9.0':
     resolution: {integrity: sha512-WrOT1WsOUG+B7hstD2RYoMPIOK76G8E9AQHhMjUvrQaGx/oA7rPWQvvr1Rqv7+yy4R0ZMVwWLC4vW2xnkgWPAQ==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.0.0 <1.10.0'
-
-  '@opentelemetry/propagator-jaeger@2.2.0':
-    resolution: {integrity: sha512-FfeOHOrdhiNzecoB1jZKp2fybqmqMPJUXe2ZOydP7QzmTPYcfPeuaclTLYVhK3HyJf71kt8sTl92nV4YIaLaKA==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
@@ -1391,23 +1009,11 @@ packages:
     peerDependencies:
       '@opentelemetry/api': '>=1.3.0 <1.10.0'
 
-  '@opentelemetry/resources@2.2.0':
-    resolution: {integrity: sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.3.0 <1.10.0'
-
   '@opentelemetry/resources@2.9.0':
     resolution: {integrity: sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.3.0 <1.10.0'
-
-  '@opentelemetry/sdk-logs@0.207.0':
-    resolution: {integrity: sha512-4MEQmn04y+WFe6cyzdrXf58hZxilvY59lzZj2AccuHW/+BxLn/rGVN/Irsi/F0qfBOpMOrrCLKTExoSL2zoQmg==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.4.0 <1.10.0'
 
   '@opentelemetry/sdk-logs@0.220.0':
     resolution: {integrity: sha512-WywcTkQtv2iNmt+6y5Kcd4rzvx9bLVsBa2Nwcmg01IUaBTkTow3W4d9KE5vNBpEDtb9tp21WcRBY/lANRrApYA==}
@@ -1415,35 +1021,11 @@ packages:
     peerDependencies:
       '@opentelemetry/api': '>=1.4.0 <1.10.0'
 
-  '@opentelemetry/sdk-logs@0.221.0':
-    resolution: {integrity: sha512-FaDcazjyMp7TZZZAsqbo4IkovP0UegoCu0EBkiNt+qCqvUf7FPAsfcrZ3+ZEkKgXZ/jHafop+JoGPDk3A0SmLg==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.4.0 <1.10.0'
-
-  '@opentelemetry/sdk-metrics@2.10.0':
-    resolution: {integrity: sha512-t6r1VSvXNtSDnPXU1FbZeetJb7yyovHmgu0wRSoftxtE0g2rSNhQZQUy69sRUCL+iioJpX8SN/S6wq6ZtvLySQ==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.9.0 <1.10.0'
-
-  '@opentelemetry/sdk-metrics@2.2.0':
-    resolution: {integrity: sha512-G5KYP6+VJMZzpGipQw7Giif48h6SGQ2PFKEYCybeXJsOCB4fp8azqMAAzE5lnnHK3ZVwYQrgmFbsUJO/zOnwGw==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.9.0 <1.10.0'
-
   '@opentelemetry/sdk-metrics@2.9.0':
     resolution: {integrity: sha512-Xx8RGS4H5XEBl01WuCreMIpiah9cCXMbSkeuIePPdD2cUpq/vUzYmj8E/MK1OsbOc93FuAD4jfn2WOacKwLn7Q==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.9.0 <1.10.0'
-
-  '@opentelemetry/sdk-node@0.207.0':
-    resolution: {integrity: sha512-hnRsX/M8uj0WaXOBvFenQ8XsE8FLVh2uSnn1rkWu4mx+qu7EKGUZvZng6y/95cyzsqOfiaDDr08Ek4jppkIDNg==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.3.0 <1.10.0'
 
   '@opentelemetry/sdk-node@0.220.0':
     resolution: {integrity: sha512-wHtGyHhSKHNH3fym33xRu4Ef/HXTFvX8eQ42xdQdEO9LYx9Y2qNyBDJytyqVlvmo6abWZlNYTUthuAGUMYqYnQ==}
@@ -1457,23 +1039,11 @@ packages:
     peerDependencies:
       '@opentelemetry/api': '>=1.3.0 <1.10.0'
 
-  '@opentelemetry/sdk-trace-base@2.2.0':
-    resolution: {integrity: sha512-xWQgL0Bmctsalg6PaXExmzdedSp3gyKV8mQBwK/j9VGdCDu2fmXIb2gAehBKbkXCpJ4HPkgv3QfoJWRT4dHWbw==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.3.0 <1.10.0'
-
   '@opentelemetry/sdk-trace-base@2.9.0':
     resolution: {integrity: sha512-cp9zmTl62R8PJrpvFcmc8N2JQU/xfa0S+61q511Nji+QxCfZ8Ifvg7H27G8cANe4crg4RTrWsVvanHiXjSp6ag==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.3.0 <1.10.0'
-
-  '@opentelemetry/sdk-trace-node@2.2.0':
-    resolution: {integrity: sha512-+OaRja3f0IqGG2kptVeYsrZQK9nKRSpfFrKtRBq4uh6nIB8bTBgaGvYQrQoRrQWQMA5dK5yLhDMDc0dvYvCOIQ==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.0.0 <1.10.0'
 
   '@opentelemetry/sdk-trace-node@2.9.0':
     resolution: {integrity: sha512-ec9a7ps37huy5itYk0MalaZdSLlM6AXWp/FhtEjgMpp5leEGojBDvAl/UWttQnkMZOvFHKzRESn8TD3yKTF5nQ==}
@@ -1508,23 +1078,11 @@ packages:
   '@posthog/browser-common@0.5.0':
     resolution: {integrity: sha512-8DaxVZS1bQPbA514RePurLNbYjei3P4jhnC206DwVv5XThmZM3QdlsXenI2ujE3pLbgQ79hYn9o1Kda8I3WK/Q==}
 
-  '@posthog/core@1.46.0':
-    resolution: {integrity: sha512-9w/bzHkf8V26YDAk7bO+Y2M0O9LMJg53lw3TOpirWRY77CEq4EQ3FkrtxP6BM48qaeZ/ILmRcfz+u1jjeTLetg==}
+  '@posthog/core@1.48.1':
+    resolution: {integrity: sha512-mxw31XdYgt/SnlwqLPAcltK67q+QmsiYjVLGQ4GbBc8OJ7O4yRFSDwAXt8QsokHokeyEZtTRWM6jDHL7LYMx1A==}
 
-  '@posthog/core@1.47.1':
-    resolution: {integrity: sha512-d38C5DulL3gCox4g0VGyb/Lhn548fBvj9f35LZGVasPspOs3jyApxROJyDXoWwIRivOjCOIShZQAdYkZVn9J3w==}
-
-  '@posthog/core@1.48.0':
-    resolution: {integrity: sha512-ezKjVLw9y3Q235PUY+2hRr5DN9t6j2jF1mFAvnvhCCu/Ha6/qBv3zmVJBaHu9PnqqSNtx2St3ggN8Z3TTu/12A==}
-
-  '@posthog/types@1.399.0':
-    resolution: {integrity: sha512-/WDwBzqIPko8VJ1B+0rlso2XQEz9+2sqtsY9Tqy3p1GhgTqsFakcz/PmMpAnA321LTEZVRcO6x5hAwABV4yrDw==}
-
-  '@posthog/types@1.403.0':
-    resolution: {integrity: sha512-QbkO0epmdq38xhxwP214YRi0vgpZiXqhamaTjKT6kVGJYTtsE5qZ1GTgLp12IYehg/rd+whYYErH3/DeX8pj3Q==}
-
-  '@posthog/types@1.403.1':
-    resolution: {integrity: sha512-0U9Xastjyy17cmtjtNai3d/+xf8bRJgPMYyu8svyWQRQsBULoPzqz5mTXm6l2dsj9dFoj+sezGjoe5yi5xOP4w==}
+  '@posthog/types@1.404.1':
+    resolution: {integrity: sha512-i2Gei6ARfOSBeTN4s2yUP1p97s2UNI+1NWmtLjhnR/V6t3RFOfI1sBWKcJNWHjtoOCCWoAFU+PNPY6SgT2VtEQ==}
 
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
@@ -1814,44 +1372,32 @@ packages:
     resolution: {integrity: sha512-fFJgCxs5hDyAm9BbZJ+LbA+LK2tjX5OoD0v0ARU4StR6KQmGUduoPs69yJ9AfqZ0om3Rlp5JDliiwFcNkasORA==}
     engines: {node: '>= 18'}
 
-  '@smithy/core@3.31.1':
-    resolution: {integrity: sha512-CyogUINxvi7C7LDsh8Syo6hVJOT9ckz4rG8dRZfTJ8r91HkMY59PnNooaj7WcHyxEkxPfBAmbgztZU+xTo76lg==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/core@3.33.2':
     resolution: {integrity: sha512-CUGXpnPkVdjUCbix+83sWLW9VFgQOm44MDOx/ihITJMAnOZKvL8YYIc7DR9pP/tZ8CIRvMiON/TucvygqbHO3w==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/credential-provider-imds@4.4.16':
-    resolution: {integrity: sha512-QfuLWAkLzptffFW980AFeHZFdqds2B64rpEd3uJ6lgs3xVn9QegGMUgUcj+4d7dRrAsya3r58ZKpku97WcFb4w==}
+  '@smithy/credential-provider-imds@4.5.2':
+    resolution: {integrity: sha512-A9uSdn72ozbRUSit0eib0TW7nXuNPlaeM0zcGkJ+nE6tFcSDbnmtwoxbTCFBukVQcszDAyvsd7+rTduPTXpygg==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/fetch-http-handler@5.6.13':
-    resolution: {integrity: sha512-4fW86pEUOMbrD5nkbyl/tTvPHHWJFbuB2odl6ps9lWfHoXf9HWh3Q/Smh59qH1g7+c/BSZghX6bbUk4gsiMs8A==}
+  '@smithy/fetch-http-handler@5.7.2':
+    resolution: {integrity: sha512-nZyWTmSpJEXl6VtWVMBJve/7x12DZu6sIX1z1a+ZMaHlQQRs9Zpu6NbTe/gmxYXVRpkjxyDYpZ5gx2IM6f/Wkw==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/is-array-buffer@2.2.0':
     resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
     engines: {node: '>=14.0.0'}
 
-  '@smithy/node-http-handler@4.9.13':
-    resolution: {integrity: sha512-Nmd/Nl35zfYrd+a6OO2cDJb3GPh9bgTjIUhcM+JFfjpp8/osCgboDV5nCT1I01Pv6R13eSKDKLSoVa5ZB6Zsfw==}
+  '@smithy/node-http-handler@4.11.2':
+    resolution: {integrity: sha512-avwAh9HM3h2lcfjvP3zYIZGf+XVgLQ91wOJ2qoFbNpW1UZeZb33aGlhTZvtkANHfcGhJroRY64525OjfgOg30g==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/protocol-http@5.6.2':
     resolution: {integrity: sha512-Asd04MaxODN6FNY8EPTeCAM4kPNi3jDUAjZU0Y4F9rHvpLUrrUo7KLcxFgSthywFr6dZfIyDLIJda6jxmVTk5w==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/signature-v4@5.6.12':
-    resolution: {integrity: sha512-I6KLtq3H0qqSuV9vLglfi8puHqzygzWHOnI4z/Rdoo+q50vvo18vBRdPAvvEtcaKROz7Zn6qnPa14kRfPH6PcQ==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/signature-v4@5.7.2':
     resolution: {integrity: sha512-P7Ki6px6OOrxVtx8K7nLmyx4SlXUW/uTKDdMG44UHefmPGSRMBKe2v+TM59WdLcpUIrBrnuCsIqiM2MbsZjmhw==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/types@4.16.1':
-    resolution: {integrity: sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/types@4.17.2':
@@ -2017,9 +1563,6 @@ packages:
   '@types/node@15.14.9':
     resolution: {integrity: sha512-qjd88DrCxupx/kJD5yQgZdcYKZKSIGBVDIBE1/LTGcNm3d2Np/jxojkdePDdfnBHJc5W7vSMpbJ1aB7p/Py69A==}
 
-  '@types/node@22.20.0':
-    resolution: {integrity: sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==}
-
   '@types/node@26.0.0':
     resolution: {integrity: sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA==}
 
@@ -2117,10 +1660,6 @@ packages:
     resolution: {integrity: sha512-z0R5JgmRsX38eSBtbbmgXoaGhfg4U4gYl6MCk+h2OqkJKTt24LoFPDsbOP1H0WUWDn53l9UXRgTAHt5M51P9Tw==}
     hasBin: true
 
-  '@vercel/oidc@3.2.0':
-    resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
-    engines: {node: '>= 20'}
-
   '@vitejs/plugin-react@6.0.4':
     resolution: {integrity: sha512-XcCQz0TBpBgljhj0gMuuDj49i6Ytqh5q1osT/Gp5uAVJUCTWxyskk/l1jwYYiu2xcNHHipdMz40EGfM1VdamVg==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2163,11 +1702,8 @@ packages:
   '@vitest/utils@4.1.9':
     resolution: {integrity: sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==}
 
-  '@workflow/serde@4.1.0':
-    resolution: {integrity: sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==}
-
-  '@xyflow/react@12.11.2':
-    resolution: {integrity: sha512-eLAlDWJfWnQEhJwGMjlWdAXO9eYllKpliUmPQlAmOLxz6mExXuzMVDUKLMquixgkrtmMFFtug3jGKmYYld12cA==}
+  '@xyflow/react@12.11.3':
+    resolution: {integrity: sha512-G3jogHz2GWUtIOkhavUGno2YzY9u6fILIJBttfsBendb0/HWB90JG+sOTAvlIMEwyvq9zgy9V9ZQSwyQjR5QzQ==}
     peerDependencies:
       '@types/react': '>=17'
       '@types/react-dom': '>=17'
@@ -2179,17 +1715,12 @@ packages:
       '@types/react-dom':
         optional: true
 
-  '@xyflow/system@0.0.79':
-    resolution: {integrity: sha512-czLyOh91NF0hIzbNzwi8I6GlqG23BHh2435OddfI6uiaLH3xdrdygO93gqgH1Bv9mhy8XPFQJOBn1FTq4LvEWA==}
+  '@xyflow/system@0.0.80':
+    resolution: {integrity: sha512-ywc3ZqG91brzWrH1WlwMdIX4goOfrpBy6AbLdVSaof/Xx9l138ijIKRExM6EkMro2F+OImGmSiA/WKcXvKVcfA==}
 
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
-
-  acorn-import-attributes@1.9.5:
-    resolution: {integrity: sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==}
-    peerDependencies:
-      acorn: ^8
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -2204,12 +1735,6 @@ packages:
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
-
-  ai@7.0.41:
-    resolution: {integrity: sha512-GvV7uet1dz3wZFAnLd8rS+rSwIh57b8YvbV/gPaSxKsJkj1wGVnlWbu9pqKG3Op68/mglkz0lIkpsJXy2rBX1A==}
-    engines: {node: '>=22'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
 
   ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
@@ -2286,8 +1811,8 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  baseline-browser-mapping@2.11.6:
-    resolution: {integrity: sha512-69D/imtToCsIcAl8WBS2YaRwA4jO/j0HhU+hELqMEu9f54MoUtI6+XH5mrKU8rEFNEk/Ui1I2MK4/JkWacclGw==}
+  baseline-browser-mapping@2.11.14:
+    resolution: {integrity: sha512-JyJ954WzuIR8/FFzX0o5krdSTrBAkcCSRfWSleRsIHSWV+cZe2FI1PKggVkFke1hBldRs+LRxUczzE9iPmgZww==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -2379,8 +1904,8 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
-  browserslist@4.28.7:
-    resolution: {integrity: sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==}
+  browserslist@4.28.8:
+    resolution: {integrity: sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
@@ -2410,8 +1935,8 @@ packages:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
 
-  caniuse-lite@1.0.30001806:
-    resolution: {integrity: sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==}
+  caniuse-lite@1.0.30001809:
+    resolution: {integrity: sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -2444,8 +1969,8 @@ packages:
     resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
     engines: {node: '>=18'}
 
-  cjs-module-lexer@2.2.0:
-    resolution: {integrity: sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==}
+  cjs-module-lexer@2.2.1:
+    resolution: {integrity: sha512-Ca8swihM+/4yKecYHY52kgJd300hi2lADU/a1RxNTRe+RJ9jvqQlESpbz9DnG9mowez8qwXHB8qYdIUw9e+F5Q==}
 
   classcat@5.0.5:
     resolution: {integrity: sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==}
@@ -2492,8 +2017,8 @@ packages:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
 
-  content-type@2.0.0:
-    resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
+  content-type@2.1.0:
+    resolution: {integrity: sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==}
     engines: {node: '>=18'}
 
   convert-source-map@2.0.0:
@@ -2511,15 +2036,15 @@ packages:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
 
-  core-js@3.49.0:
-    resolution: {integrity: sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==}
+  core-js@3.50.0:
+    resolution: {integrity: sha512-BRWgOLKkFeCgRudR6zrs8p9XJZcE14grzKMMssoYrk6krtuEZ7MTKPIY5RzOnqsEKIR9kst7wNzphttraT+Yqw==}
 
   cors@2.8.6:
     resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
     engines: {node: '>= 0.10'}
 
-  cron-parser@5.7.0:
-    resolution: {integrity: sha512-iSpDHpwwW/GhIg4JVODYlWUEpMNSimaHvqOhHpOz1W+Y97z1lL1nf+dpcF17cNwFRpTtKN9devgi1fxflp3Phw==}
+  cron-parser@5.10.0:
+    resolution: {integrity: sha512-izNAxJyRWUP8ljBoDSub5WyrVOUlT4SLGShswE7eoRBpp6QUsSycYxLBMJlbshgPBMcPT/nrfgjNY2918ayv2A==}
     engines: {node: '>=18'}
 
   cross-spawn@7.0.6:
@@ -2579,8 +2104,8 @@ packages:
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
 
-  decode-uri-component@0.4.1:
-    resolution: {integrity: sha512-+8VxcR21HhTy8nOt6jf20w0c9CADrw1O8d+VZ/YzzCt4bJ3uBjw+D1q2osAB8RnpwwaeYBxy0HyKQxD5JBMuuQ==}
+  decode-uri-component@0.5.0:
+    resolution: {integrity: sha512-1BiQVoK8C9gUbQU6NzAtO/tkz2qOFpEObMWpcFvhx4fYnj4Oc5yzaJN/LD36ihkVUdXyh5ZekzX+yM+ty/SrPg==}
     engines: {node: '>=14.16'}
 
   deep-is@0.1.4:
@@ -2722,8 +2247,8 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
-  electron-to-chromium@1.5.398:
-    resolution: {integrity: sha512-AsvhAxopJGh6museTDMIjn6JpDYOfgu4RLlygomt87MUwBUqTfd/1EiPtx10/LZE8xpTvkP2E9Gafq7lkLtodQ==}
+  electron-to-chromium@1.5.407:
+    resolution: {integrity: sha512-4R8XgQOdfxexCd/u63lRm6wCHjECwI45MV9wxAs2ggtfWe2hwlo1ql97jKsju2IcJ+jFSTwBssyYoiWhh7mauQ==}
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
@@ -2761,11 +2286,6 @@ packages:
   es-set-tostringtag@2.1.0:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
-
-  esbuild@0.25.12:
-    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
-    engines: {node: '>=18'}
-    hasBin: true
 
   esbuild@0.28.2:
     resolution: {integrity: sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==}
@@ -2854,8 +2374,8 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
-  eventsource-parser@3.1.0:
-    resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
+  eventsource-parser@3.1.1:
+    resolution: {integrity: sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==}
     engines: {node: '>=18.0.0'}
 
   eventsource@3.0.7:
@@ -2870,8 +2390,8 @@ packages:
     resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
     engines: {node: '>=12.0.0'}
 
-  express-rate-limit@8.6.1:
-    resolution: {integrity: sha512-0D493aP61w0TJ2A0wy27riRsO7FMQ7FK+KUHOKCSfPvYo0R55aiC6emCVgFUeShH0fq0ICPVzNcgoS+BsbXQCA==}
+  express-rate-limit@8.6.2:
+    resolution: {integrity: sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==}
     engines: {node: '>= 16'}
     peerDependencies:
       express: '>= 4.11'
@@ -2941,8 +2461,8 @@ packages:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
     engines: {node: '>=16'}
 
-  flatted@3.4.3:
-    resolution: {integrity: sha512-/zipXxyO6rGvuNGDiULY9MvEGSkb2gaG4GGH4ygMi0ZZzyMHdUZBmntJmx5x1G2VuPytCwGN4xsJP6cw+sK+vQ==}
+  flatted@3.4.4:
+    resolution: {integrity: sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==}
 
   follow-redirects@1.16.0:
     resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
@@ -2997,8 +2517,8 @@ packages:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
 
-  get-tsconfig@4.14.0:
-    resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
+  get-tsconfig@4.14.2:
+    resolution: {integrity: sha512-XpwZALwwl/BaKTAyC6+c5T8y6kCg2jk+XGqOVrKIQmW49pNypYLMRjCUXqa28tQgJlhS2RlzP7sc+Rx7W6qsfw==}
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -3089,9 +2609,6 @@ packages:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
 
-  import-in-the-middle@2.0.6:
-    resolution: {integrity: sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw==}
-
   import-in-the-middle@3.3.3:
     resolution: {integrity: sha512-AiohS3H80sXO6owEltjGX+glb7qXaDhBoJb9XcQVH4UI207xu/bDLUcadVKp7Qe576reg9yr/PXZjV5qx8gfbA==}
     engines: {node: '>=18'}
@@ -3106,13 +2623,17 @@ packages:
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
 
-  ip-address@10.4.0:
-    resolution: {integrity: sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==}
+  ip-address@10.5.0:
+    resolution: {integrity: sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==}
     engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
+
+  ipaddr.js@2.5.0:
+    resolution: {integrity: sha512-aq+t5NAc+cS6rZQQVWC2x98CPqGtKKTMDd4Gaodv0wShnItdKg/51djkGJ1hqH+Oy0ivDftCbSLCQob8zso01w==}
+    engines: {node: '>= 10'}
 
   is-alphabetical@2.0.1:
     resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
@@ -3161,8 +2682,8 @@ packages:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
 
-  jose@6.2.4:
-    resolution: {integrity: sha512-N8acGzVsQy6M/fjFcxtysNc4Q379TcM5dM/qKkNtsHFji88yANnXTr7BLeP75iPnFwBfQzM/jg2BZ9+HZrHCZA==}
+  jose@6.2.9:
+    resolution: {integrity: sha512-XrchZOFZUl/T3vTwRe8XK+cJrGtMF4th1ARnDfwbBXFKThGhlsxEE4Zu03AD/bjJSt/9jT/mxrOCkJWOg77aPA==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -3188,9 +2709,6 @@ packages:
   json-schema-typed@8.0.2:
     resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
-  json-schema@0.4.0:
-    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
-
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
@@ -3202,8 +2720,8 @@ packages:
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
-  kysely@0.29.4:
-    resolution: {integrity: sha512-y5mVgQNkMbs1eK9Xyc0pmNdabN2wHhRYY/5r4W5HrUT1rYCEPeVNSj1RUJeSDKT3U0p+mXCvLgkrFuIafYI6BA==}
+  kysely@0.29.5:
+    resolution: {integrity: sha512-ooa+eSbBNPTo3MycPEuW5jdrxQdQwdtB3LC3h43FiXQbIry5tR0C5lDG7eealK0E4D7XjrnOP5DIUg/LyjRMYQ==}
     engines: {node: '>=22.0.0'}
 
   levn@0.4.1:
@@ -3541,8 +3059,8 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  nanostores@1.4.2:
-    resolution: {integrity: sha512-Wxv8Roefr2nqtiRG0bnaFlpYqpIVtOEeJZHaH+4nGgOK1/7n6OHOuHCb/bhqrNQgZM8fyd0s1PqhdrJc9Ib44g==}
+  nanostores@1.5.0:
+    resolution: {integrity: sha512-E0SrU7uLV/k4E6YbBIpQNDnRj00vgE5wlutM1sYVSAXDtHQosiRCGS9eKMKyiGg4ChXfDiJmTB+NCR3yXr6UAw==}
     engines: {node: ^20.0.0 || >=22.0.0}
 
   natural-compare@1.4.0:
@@ -3561,8 +3079,8 @@ packages:
       encoding:
         optional: true
 
-  node-releases@2.0.51:
-    resolution: {integrity: sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==}
+  node-releases@2.0.53:
+    resolution: {integrity: sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==}
     engines: {node: '>=18'}
 
   non-error@0.1.0:
@@ -3673,8 +3191,8 @@ packages:
     peerDependencies:
       pg: '>=8.0'
 
-  pg-protocol@1.15.0:
-    resolution: {integrity: sha512-cq9sECI5s0+uPUXjbz8ioyPJni6RzsRib0US67i5IoTZKw8fNeYlVE7u8F4dG7vEJJtc5wdD1K189lCCUwqWTQ==}
+  pg-protocol@1.16.0:
+    resolution: {integrity: sha512-sILXutLVjCLjcDuOmvhX5e2Z4cS5qG/6Bu3VkpFwdf/633ElGLpEh9bgmuI5I4sqKqkifQiGyiCcx1HdtrK7tg==}
 
   pg-types@2.2.0:
     resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
@@ -3746,11 +3264,11 @@ packages:
     resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
     engines: {node: '>=0.10.0'}
 
-  posthog-js@1.416.1:
-    resolution: {integrity: sha512-/4tFG0As9A/Wyi5dJ0F+/z1vkpndWl9uQtT+6TCD6snIkTZ/MMRiOjJHzY6b38cCQuy5zatr+kTKAuQB/BL1eA==}
+  posthog-js@1.417.1:
+    resolution: {integrity: sha512-QpZnHA2PieGq9+W03LBw23DnN9CD1zM37DcXnpZkg+C5iAwYXLiZs8qof0Yi/BhY35PYuhVmv93nhztyHjVaJw==}
 
-  posthog-node@5.47.0:
-    resolution: {integrity: sha512-dp8h6rdfu9WzFSbJJxsuplmjgDFUsVFce1QPmlhWF/Fy/XWf56JRx4AZNzXRrKVb1F1p+2yWg6adLZEKcvBOzw==}
+  posthog-node@5.49.1:
+    resolution: {integrity: sha512-kmjvzc7K8y+wQX7r3oIkLfKc2BzDJPXMJor5D8gAxpGE7qLNlk4HO2y1brc5587GxtdsZzqtGOxfBJXUBE2MiQ==}
     engines: {node: ^20.20.0 || >=22.22.0}
     peerDependencies:
       rxjs: ^7.0.0
@@ -3803,8 +3321,8 @@ packages:
   query-selector-shadow-dom@1.0.1:
     resolution: {integrity: sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==}
 
-  query-string@9.4.1:
-    resolution: {integrity: sha512-lSyJeN3RuaG7DZGWThtYRhk96+kEyZ/+doZpERuWbjeFL+Ok3vEat/swU498rAI0NcVt5/RJp8UDuLz7FckxrA==}
+  query-string@9.5.0:
+    resolution: {integrity: sha512-YlJmwNyi0RGYjlxYcuDncMsxFU7YyutbuI7gTm8ySxIGBlwx5yiBCOD5ig9ZNoHkawk/1Dey0N5mEfcUybMVAA==}
     engines: {node: '>=18'}
 
   queue-microtask@1.2.3:
@@ -4089,8 +3607,8 @@ packages:
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
-  tinyexec@1.2.4:
-    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
+  tinyexec@1.3.0:
+    resolution: {integrity: sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==}
     engines: {node: '>=18'}
 
   tinyglobby@0.2.17:
@@ -4131,11 +3649,6 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
-  tsx@4.20.6:
-    resolution: {integrity: sha512-ytQKuwgmrrkDTFP4LjR0ToE2nqgy886GpvRSpU0JAnrdBYppuY5rLkRUYPU1yCryb24SsKBTL/hlDQAEFVwtZg==}
-    engines: {node: '>=18.0.0'}
-    hasBin: true
-
   tsx@4.23.12:
     resolution: {integrity: sha512-FDf4L4sYzKtzWYhU/Xm0AQFdTjdIxNo9ElTf2mxXM6k8YMHXzYUe4yODVaXP4V9uMFbVg8c0qyBccK2OOxb45Q==}
     engines: {node: '>=18.0.0'}
@@ -4165,11 +3678,12 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  undici-types@6.21.0:
-    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
-
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
+
+  undici@8.10.0:
+    resolution: {integrity: sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==}
+    engines: {node: '>=22.19.0'}
 
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
@@ -4193,8 +3707,8 @@ packages:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
 
-  update-browserslist-db@1.2.3:
-    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+  update-browserslist-db@1.3.1:
+    resolution: {integrity: sha512-ZZ61DsRsOnakl74HAmp3oSN4aXUmEWXf+i/yv0h7tIBfICc3VdrFErQKUUKPgu3AMsTUMbcongALEN4l6GSUrQ==}
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
@@ -4381,6 +3895,10 @@ packages:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
 
+  yargs@17.7.3:
+    resolution: {integrity: sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==}
+    engines: {node: '>=12'}
+
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
@@ -4422,28 +3940,6 @@ packages:
 
 snapshots:
 
-  '@ai-sdk/gateway@4.0.31(zod@4.4.3)':
-    dependencies:
-      '@ai-sdk/provider': 4.0.4
-      '@ai-sdk/provider-utils': 5.0.14(zod@4.4.3)
-      '@vercel/oidc': 3.2.0
-      zod: 4.4.3
-    optional: true
-
-  '@ai-sdk/provider-utils@5.0.14(zod@4.4.3)':
-    dependencies:
-      '@ai-sdk/provider': 4.0.4
-      '@standard-schema/spec': 1.1.0
-      '@workflow/serde': 4.1.0
-      eventsource-parser: 3.1.0
-      zod: 4.4.3
-    optional: true
-
-  '@ai-sdk/provider@4.0.4':
-    dependencies:
-      json-schema: 0.4.0
-    optional: true
-
   '@apm-js-collab/code-transformer-bundler-plugins@0.7.4':
     dependencies:
       '@apm-js-collab/code-transformer': 0.18.1
@@ -4471,49 +3967,35 @@ snapshots:
   '@aws-crypto/sha256-js@5.2.0':
     dependencies:
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.974.3
+      '@aws-sdk/types': 3.974.4
       tslib: 2.8.1
 
   '@aws-crypto/util@5.2.0':
     dependencies:
-      '@aws-sdk/types': 3.974.3
+      '@aws-sdk/types': 3.974.4
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
 
-  '@aws-sdk/checksums@3.1000.27':
+  '@aws-sdk/checksums@3.1000.28':
     dependencies:
-      '@aws-sdk/core': 3.977.7
-      '@aws-sdk/types': 3.974.3
-      '@smithy/core': 3.31.1
-      '@smithy/types': 4.16.1
+      '@aws-sdk/core': 3.977.8
+      '@aws-sdk/types': 3.974.4
+      '@smithy/core': 3.33.2
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
 
-  '@aws-sdk/client-s3@3.1106.0':
+  '@aws-sdk/client-s3@3.1111.0':
     dependencies:
-      '@aws-sdk/checksums': 3.1000.27
-      '@aws-sdk/core': 3.977.7
-      '@aws-sdk/credential-provider-node': 3.972.79
-      '@aws-sdk/middleware-sdk-s3': 3.972.73
-      '@aws-sdk/signature-v4-multi-region': 3.996.44
-      '@aws-sdk/types': 3.974.3
-      '@smithy/core': 3.31.1
-      '@smithy/fetch-http-handler': 5.6.13
-      '@smithy/node-http-handler': 4.9.13
-      '@smithy/types': 4.16.1
-      tslib: 2.8.1
-
-  '@aws-sdk/client-s3@3.1109.0':
-    dependencies:
-      '@aws-sdk/checksums': 3.1000.27
-      '@aws-sdk/core': 3.977.7
-      '@aws-sdk/credential-provider-node': 3.972.79
-      '@aws-sdk/middleware-sdk-s3': 3.972.73
-      '@aws-sdk/signature-v4-multi-region': 3.996.44
-      '@aws-sdk/types': 3.974.3
-      '@smithy/core': 3.31.1
-      '@smithy/fetch-http-handler': 5.6.13
-      '@smithy/node-http-handler': 4.9.13
-      '@smithy/types': 4.16.1
+      '@aws-sdk/checksums': 3.1000.28
+      '@aws-sdk/core': 3.977.8
+      '@aws-sdk/credential-provider-node': 3.972.80
+      '@aws-sdk/middleware-sdk-s3': 3.972.74
+      '@aws-sdk/signature-v4-multi-region': 3.996.45
+      '@aws-sdk/types': 3.974.4
+      '@smithy/core': 3.33.2
+      '@smithy/fetch-http-handler': 5.7.2
+      '@smithy/node-http-handler': 4.11.2
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
 
   '@aws-sdk/client-sts@3.1111.0':
@@ -4522,21 +4004,10 @@ snapshots:
       '@aws-sdk/credential-provider-node': 3.972.80
       '@aws-sdk/signature-v4-multi-region': 3.996.45
       '@aws-sdk/types': 3.974.4
-      '@smithy/core': 3.31.1
-      '@smithy/fetch-http-handler': 5.6.13
-      '@smithy/node-http-handler': 4.9.13
-      '@smithy/types': 4.16.1
-      tslib: 2.8.1
-
-  '@aws-sdk/core@3.977.7':
-    dependencies:
-      '@aws-sdk/types': 3.974.3
-      '@aws-sdk/xml-builder': 3.972.38
-      '@aws/lambda-invoke-store': 0.3.0
-      '@smithy/core': 3.31.1
-      '@smithy/signature-v4': 5.6.12
-      '@smithy/types': 4.16.1
-      bowser: 2.14.1
+      '@smithy/core': 3.33.2
+      '@smithy/fetch-http-handler': 5.7.2
+      '@smithy/node-http-handler': 4.11.2
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
 
   '@aws-sdk/core@3.977.8':
@@ -4544,62 +4015,28 @@ snapshots:
       '@aws-sdk/types': 3.974.4
       '@aws-sdk/xml-builder': 3.972.39
       '@aws/lambda-invoke-store': 0.3.0
-      '@smithy/core': 3.31.1
-      '@smithy/signature-v4': 5.6.12
-      '@smithy/types': 4.16.1
+      '@smithy/core': 3.33.2
+      '@smithy/signature-v4': 5.7.2
+      '@smithy/types': 4.17.2
       bowser: 2.14.1
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-env@3.972.68':
-    dependencies:
-      '@aws-sdk/core': 3.977.7
-      '@aws-sdk/types': 3.974.3
-      '@smithy/core': 3.31.1
-      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-env@3.972.69':
     dependencies:
       '@aws-sdk/core': 3.977.8
       '@aws-sdk/types': 3.974.4
-      '@smithy/core': 3.31.1
-      '@smithy/types': 4.16.1
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-http@3.972.70':
-    dependencies:
-      '@aws-sdk/core': 3.977.7
-      '@aws-sdk/types': 3.974.3
-      '@smithy/core': 3.31.1
-      '@smithy/fetch-http-handler': 5.6.13
-      '@smithy/node-http-handler': 4.9.13
-      '@smithy/types': 4.16.1
+      '@smithy/core': 3.33.2
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-http@3.972.71':
     dependencies:
       '@aws-sdk/core': 3.977.8
       '@aws-sdk/types': 3.974.4
-      '@smithy/core': 3.31.1
-      '@smithy/fetch-http-handler': 5.6.13
-      '@smithy/node-http-handler': 4.9.13
-      '@smithy/types': 4.16.1
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-ini@3.973.13':
-    dependencies:
-      '@aws-sdk/core': 3.977.7
-      '@aws-sdk/credential-provider-env': 3.972.68
-      '@aws-sdk/credential-provider-http': 3.972.70
-      '@aws-sdk/credential-provider-login': 3.972.75
-      '@aws-sdk/credential-provider-process': 3.972.68
-      '@aws-sdk/credential-provider-sso': 3.973.12
-      '@aws-sdk/credential-provider-web-identity': 3.972.74
-      '@aws-sdk/nested-clients': 3.997.42
-      '@aws-sdk/types': 3.974.3
-      '@smithy/core': 3.31.1
-      '@smithy/credential-provider-imds': 4.4.16
-      '@smithy/types': 4.16.1
+      '@smithy/core': 3.33.2
+      '@smithy/fetch-http-handler': 5.7.2
+      '@smithy/node-http-handler': 4.11.2
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-ini@3.973.14':
@@ -4613,18 +4050,9 @@ snapshots:
       '@aws-sdk/credential-provider-web-identity': 3.972.75
       '@aws-sdk/nested-clients': 3.997.43
       '@aws-sdk/types': 3.974.4
-      '@smithy/core': 3.31.1
-      '@smithy/credential-provider-imds': 4.4.16
-      '@smithy/types': 4.16.1
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-login@3.972.75':
-    dependencies:
-      '@aws-sdk/core': 3.977.7
-      '@aws-sdk/nested-clients': 3.997.42
-      '@aws-sdk/types': 3.974.3
-      '@smithy/core': 3.31.1
-      '@smithy/types': 4.16.1
+      '@smithy/core': 3.33.2
+      '@smithy/credential-provider-imds': 4.5.2
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-login@3.972.76':
@@ -4632,22 +4060,8 @@ snapshots:
       '@aws-sdk/core': 3.977.8
       '@aws-sdk/nested-clients': 3.997.43
       '@aws-sdk/types': 3.974.4
-      '@smithy/core': 3.31.1
-      '@smithy/types': 4.16.1
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-node@3.972.79':
-    dependencies:
-      '@aws-sdk/credential-provider-env': 3.972.68
-      '@aws-sdk/credential-provider-http': 3.972.70
-      '@aws-sdk/credential-provider-ini': 3.973.13
-      '@aws-sdk/credential-provider-process': 3.972.68
-      '@aws-sdk/credential-provider-sso': 3.973.12
-      '@aws-sdk/credential-provider-web-identity': 3.972.74
-      '@aws-sdk/types': 3.974.3
-      '@smithy/core': 3.31.1
-      '@smithy/credential-provider-imds': 4.4.16
-      '@smithy/types': 4.16.1
+      '@smithy/core': 3.33.2
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-node@3.972.80':
@@ -4659,35 +4073,17 @@ snapshots:
       '@aws-sdk/credential-provider-sso': 3.973.13
       '@aws-sdk/credential-provider-web-identity': 3.972.75
       '@aws-sdk/types': 3.974.4
-      '@smithy/core': 3.31.1
-      '@smithy/credential-provider-imds': 4.4.16
-      '@smithy/types': 4.16.1
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-process@3.972.68':
-    dependencies:
-      '@aws-sdk/core': 3.977.7
-      '@aws-sdk/types': 3.974.3
-      '@smithy/core': 3.31.1
-      '@smithy/types': 4.16.1
+      '@smithy/core': 3.33.2
+      '@smithy/credential-provider-imds': 4.5.2
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-process@3.972.69':
     dependencies:
       '@aws-sdk/core': 3.977.8
       '@aws-sdk/types': 3.974.4
-      '@smithy/core': 3.31.1
-      '@smithy/types': 4.16.1
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-sso@3.973.12':
-    dependencies:
-      '@aws-sdk/core': 3.977.7
-      '@aws-sdk/nested-clients': 3.997.42
-      '@aws-sdk/token-providers': 3.1108.0
-      '@aws-sdk/types': 3.974.3
-      '@smithy/core': 3.31.1
-      '@smithy/types': 4.16.1
+      '@smithy/core': 3.33.2
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-sso@3.973.13':
@@ -4696,17 +4092,8 @@ snapshots:
       '@aws-sdk/nested-clients': 3.997.43
       '@aws-sdk/token-providers': 3.1111.0
       '@aws-sdk/types': 3.974.4
-      '@smithy/core': 3.31.1
-      '@smithy/types': 4.16.1
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-web-identity@3.972.74':
-    dependencies:
-      '@aws-sdk/core': 3.977.7
-      '@aws-sdk/nested-clients': 3.997.42
-      '@aws-sdk/types': 3.974.3
-      '@smithy/core': 3.31.1
-      '@smithy/types': 4.16.1
+      '@smithy/core': 3.33.2
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-web-identity@3.972.75':
@@ -4714,38 +4101,27 @@ snapshots:
       '@aws-sdk/core': 3.977.8
       '@aws-sdk/nested-clients': 3.997.43
       '@aws-sdk/types': 3.974.4
-      '@smithy/core': 3.31.1
-      '@smithy/types': 4.16.1
+      '@smithy/core': 3.33.2
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
 
-  '@aws-sdk/lib-storage@3.1109.0(@aws-sdk/client-s3@3.1109.0)':
+  '@aws-sdk/lib-storage@3.1111.0(@aws-sdk/client-s3@3.1111.0)':
     dependencies:
-      '@aws-sdk/client-s3': 3.1109.0
-      '@smithy/core': 3.31.1
-      '@smithy/types': 4.16.1
+      '@aws-sdk/client-s3': 3.1111.0
+      '@smithy/core': 3.33.2
+      '@smithy/types': 4.17.2
       buffer: 5.6.0
       events: 3.3.0
       stream-browserify: 3.0.0
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-sdk-s3@3.972.73':
+  '@aws-sdk/middleware-sdk-s3@3.972.74':
     dependencies:
-      '@aws-sdk/core': 3.977.7
-      '@aws-sdk/signature-v4-multi-region': 3.996.44
-      '@aws-sdk/types': 3.974.3
-      '@smithy/core': 3.31.1
-      '@smithy/types': 4.16.1
-      tslib: 2.8.1
-
-  '@aws-sdk/nested-clients@3.997.42':
-    dependencies:
-      '@aws-sdk/core': 3.977.7
-      '@aws-sdk/signature-v4-multi-region': 3.996.44
-      '@aws-sdk/types': 3.974.3
-      '@smithy/core': 3.31.1
-      '@smithy/fetch-http-handler': 5.6.13
-      '@smithy/node-http-handler': 4.9.13
-      '@smithy/types': 4.16.1
+      '@aws-sdk/core': 3.977.8
+      '@aws-sdk/signature-v4-multi-region': 3.996.45
+      '@aws-sdk/types': 3.974.4
+      '@smithy/core': 3.33.2
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
 
   '@aws-sdk/nested-clients@3.997.43':
@@ -4753,42 +4129,26 @@ snapshots:
       '@aws-sdk/core': 3.977.8
       '@aws-sdk/signature-v4-multi-region': 3.996.45
       '@aws-sdk/types': 3.974.4
-      '@smithy/core': 3.31.1
-      '@smithy/fetch-http-handler': 5.6.13
-      '@smithy/node-http-handler': 4.9.13
-      '@smithy/types': 4.16.1
+      '@smithy/core': 3.33.2
+      '@smithy/fetch-http-handler': 5.7.2
+      '@smithy/node-http-handler': 4.11.2
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
 
-  '@aws-sdk/s3-request-presigner@3.1106.0':
+  '@aws-sdk/s3-request-presigner@3.1111.0':
     dependencies:
-      '@aws-sdk/core': 3.977.7
-      '@aws-sdk/signature-v4-multi-region': 3.996.44
-      '@aws-sdk/types': 3.974.3
-      '@smithy/core': 3.31.1
-      '@smithy/types': 4.16.1
-      tslib: 2.8.1
-
-  '@aws-sdk/signature-v4-multi-region@3.996.44':
-    dependencies:
-      '@aws-sdk/types': 3.974.3
-      '@smithy/signature-v4': 5.6.12
-      '@smithy/types': 4.16.1
+      '@aws-sdk/core': 3.977.8
+      '@aws-sdk/signature-v4-multi-region': 3.996.45
+      '@aws-sdk/types': 3.974.4
+      '@smithy/core': 3.33.2
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
 
   '@aws-sdk/signature-v4-multi-region@3.996.45':
     dependencies:
       '@aws-sdk/types': 3.974.4
-      '@smithy/signature-v4': 5.6.12
-      '@smithy/types': 4.16.1
-      tslib: 2.8.1
-
-  '@aws-sdk/token-providers@3.1108.0':
-    dependencies:
-      '@aws-sdk/core': 3.977.7
-      '@aws-sdk/nested-clients': 3.997.42
-      '@aws-sdk/types': 3.974.3
-      '@smithy/core': 3.31.1
-      '@smithy/types': 4.16.1
+      '@smithy/signature-v4': 5.7.2
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
 
   '@aws-sdk/token-providers@3.1111.0':
@@ -4796,28 +4156,18 @@ snapshots:
       '@aws-sdk/core': 3.977.8
       '@aws-sdk/nested-clients': 3.997.43
       '@aws-sdk/types': 3.974.4
-      '@smithy/core': 3.31.1
-      '@smithy/types': 4.16.1
-      tslib: 2.8.1
-
-  '@aws-sdk/types@3.974.3':
-    dependencies:
-      '@smithy/types': 4.16.1
+      '@smithy/core': 3.33.2
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
 
   '@aws-sdk/types@3.974.4':
     dependencies:
-      '@smithy/types': 4.16.1
-      tslib: 2.8.1
-
-  '@aws-sdk/xml-builder@3.972.38':
-    dependencies:
-      '@smithy/types': 4.16.1
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
 
   '@aws-sdk/xml-builder@3.972.39':
     dependencies:
-      '@smithy/types': 4.16.1
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
 
   '@aws/lambda-invoke-store@0.3.0': {}
@@ -4833,14 +4183,14 @@ snapshots:
   '@babel/core@7.29.7(supports-color@8.1.1)':
     dependencies:
       '@babel/code-frame': 7.29.7
-      '@babel/generator': 7.29.7
+      '@babel/generator': 7.29.8
       '@babel/helper-compilation-targets': 7.29.7
       '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/helpers': 7.29.7
-      '@babel/parser': 7.29.7
+      '@babel/parser': 7.29.8
       '@babel/template': 7.29.7
-      '@babel/traverse': 7.29.7(supports-color@8.1.1)
-      '@babel/types': 7.29.7
+      '@babel/traverse': 7.29.8(supports-color@8.1.1)
+      '@babel/types': 7.29.8
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
       debug: 4.4.3(supports-color@8.1.1)
@@ -4850,10 +4200,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/generator@7.29.7':
+  '@babel/generator@7.29.8':
     dependencies:
-      '@babel/parser': 7.29.7
-      '@babel/types': 7.29.7
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
@@ -4862,7 +4212,7 @@ snapshots:
     dependencies:
       '@babel/compat-data': 7.29.7
       '@babel/helper-validator-option': 7.29.7
-      browserslist: 4.28.7
+      browserslist: 4.28.8
       lru-cache: 5.1.1
       semver: 6.3.1
 
@@ -4870,8 +4220,8 @@ snapshots:
 
   '@babel/helper-module-imports@7.29.7(supports-color@8.1.1)':
     dependencies:
-      '@babel/traverse': 7.29.7(supports-color@8.1.1)
-      '@babel/types': 7.29.7
+      '@babel/traverse': 7.29.8(supports-color@8.1.1)
+      '@babel/types': 7.29.8
     transitivePeerDependencies:
       - supports-color
 
@@ -4880,7 +4230,7 @@ snapshots:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-module-imports': 7.29.7(supports-color@8.1.1)
       '@babel/helper-validator-identifier': 7.29.7
-      '@babel/traverse': 7.29.7(supports-color@8.1.1)
+      '@babel/traverse': 7.29.8(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -4893,98 +4243,95 @@ snapshots:
   '@babel/helpers@7.29.7':
     dependencies:
       '@babel/template': 7.29.7
-      '@babel/types': 7.29.7
+      '@babel/types': 7.29.8
 
-  '@babel/parser@7.29.7':
+  '@babel/parser@7.29.8':
     dependencies:
-      '@babel/types': 7.29.7
+      '@babel/types': 7.29.8
 
   '@babel/template@7.29.7':
     dependencies:
       '@babel/code-frame': 7.29.7
-      '@babel/parser': 7.29.7
-      '@babel/types': 7.29.7
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
 
-  '@babel/traverse@7.29.7(supports-color@8.1.1)':
+  '@babel/traverse@7.29.8(supports-color@8.1.1)':
     dependencies:
       '@babel/code-frame': 7.29.7
-      '@babel/generator': 7.29.7
+      '@babel/generator': 7.29.8
       '@babel/helper-globals': 7.29.7
-      '@babel/parser': 7.29.7
+      '@babel/parser': 7.29.8
       '@babel/template': 7.29.7
-      '@babel/types': 7.29.7
+      '@babel/types': 7.29.8
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/types@7.29.7':
+  '@babel/types@7.29.8':
     dependencies:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
 
-  '@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.4)(nanostores@1.4.2)':
+  '@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0)':
     dependencies:
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
       '@opentelemetry/semantic-conventions': 1.43.0
       '@standard-schema/spec': 1.1.0
       better-call: 1.3.7(zod@4.4.3)
-      jose: 6.2.4
-      kysely: 0.29.4
-      nanostores: 1.4.2
+      jose: 6.2.9
+      kysely: 0.29.5
+      nanostores: 1.5.0
       zod: 4.4.3
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
 
-  '@better-auth/drizzle-adapter@1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.4)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.4)(pg@8.22.0))':
+  '@better-auth/drizzle-adapter@1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.5)(pg@8.22.0))':
     dependencies:
-      '@better-auth/core': 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.4)(nanostores@1.4.2)
+      '@better-auth/core': 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0)
       '@better-auth/utils': 0.4.2
     optionalDependencies:
-      drizzle-orm: 0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.4)(pg@8.22.0)
+      drizzle-orm: 0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.5)(pg@8.22.0)
 
-  '@better-auth/kysely-adapter@1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.4)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(kysely@0.29.4)':
+  '@better-auth/kysely-adapter@1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)(kysely@0.29.5)':
     dependencies:
-      '@better-auth/core': 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.4)(nanostores@1.4.2)
+      '@better-auth/core': 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0)
       '@better-auth/utils': 0.4.2
     optionalDependencies:
-      kysely: 0.29.4
+      kysely: 0.29.5
 
-  '@better-auth/memory-adapter@1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.4)(nanostores@1.4.2))(@better-auth/utils@0.4.2)':
+  '@better-auth/memory-adapter@1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)':
     dependencies:
-      '@better-auth/core': 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.4)(nanostores@1.4.2)
+      '@better-auth/core': 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0)
       '@better-auth/utils': 0.4.2
 
-  '@better-auth/mongo-adapter@1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.4)(nanostores@1.4.2))(@better-auth/utils@0.4.2)':
+  '@better-auth/mongo-adapter@1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)':
     dependencies:
-      '@better-auth/core': 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.4)(nanostores@1.4.2)
+      '@better-auth/core': 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0)
       '@better-auth/utils': 0.4.2
 
-  '@better-auth/prisma-adapter@1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.4)(nanostores@1.4.2))(@better-auth/utils@0.4.2)':
+  '@better-auth/prisma-adapter@1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)':
     dependencies:
-      '@better-auth/core': 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.4)(nanostores@1.4.2)
+      '@better-auth/core': 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0)
       '@better-auth/utils': 0.4.2
 
-  '@better-auth/telemetry@1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.4)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)':
+  '@better-auth/telemetry@1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)':
     dependencies:
-      '@better-auth/core': 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.4)(nanostores@1.4.2)
+      '@better-auth/core': 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0)
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
 
   '@better-auth/utils@0.4.2':
     dependencies:
-      '@noble/hashes': 2.2.0
+      '@noble/hashes': 2.3.0
+
+  '@better-auth/utils@0.4.3':
+    dependencies:
+      '@noble/hashes': 2.3.0
 
   '@better-fetch/fetch@1.3.1': {}
 
   '@daytona/analytics-api-client@0.203.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)':
-    dependencies:
-      axios: 1.19.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-
-  '@daytona/api-client@0.162.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
       axios: 1.19.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
@@ -5000,8 +4347,8 @@ snapshots:
 
   '@daytona/sdk@0.203.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@aws-sdk/client-s3': 3.1109.0
-      '@aws-sdk/lib-storage': 3.1109.0(@aws-sdk/client-s3@3.1109.0)
+      '@aws-sdk/client-s3': 3.1111.0
+      '@aws-sdk/lib-storage': 3.1111.0(@aws-sdk/client-s3@3.1111.0)
       '@daytona/analytics-api-client': 0.203.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
       '@daytona/api-client': 0.203.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
       '@daytona/toolbox-api-client': 0.203.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
@@ -5033,13 +4380,6 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@daytona/toolbox-api-client@0.162.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)':
-    dependencies:
-      axios: 1.19.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-
   '@daytona/toolbox-api-client@0.203.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
       axios: 1.19.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
@@ -5047,199 +4387,91 @@ snapshots:
       - debug
       - supports-color
 
-  '@daytonaio/sdk@0.162.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)(ws@8.21.3)':
-    dependencies:
-      '@aws-sdk/client-s3': 3.1109.0
-      '@aws-sdk/lib-storage': 3.1109.0(@aws-sdk/client-s3@3.1109.0)
-      '@daytona/api-client': 0.162.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
-      '@daytona/toolbox-api-client': 0.162.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
-      '@iarna/toml': 2.2.5
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/exporter-trace-otlp-http': 0.207.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-http': 0.207.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)
-      '@opentelemetry/otlp-exporter-base': 0.207.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-node': 0.207.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)
-      '@opentelemetry/sdk-trace-base': 2.10.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/semantic-conventions': 1.43.0
-      axios: 1.19.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
-      busboy: 1.6.0
-      dotenv: 17.4.2
-      expand-tilde: 2.0.2
-      fast-glob: 3.3.3
-      form-data: 4.0.6
-      isomorphic-ws: 5.0.0(ws@8.21.3)
-      pathe: 2.0.3
-      shell-quote: 1.9.0
-      tar: 7.5.22
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-      - ws
-
   '@drizzle-team/brocli@0.10.2': {}
 
   '@esbuild-kit/core-utils@3.3.2':
     dependencies:
-      esbuild: 0.25.12
+      esbuild: 0.28.2
       source-map-support: 0.5.21
 
   '@esbuild-kit/esm-loader@2.6.5':
     dependencies:
       '@esbuild-kit/core-utils': 3.3.2
-      get-tsconfig: 4.14.0
-
-  '@esbuild/aix-ppc64@0.25.12':
-    optional: true
+      get-tsconfig: 4.14.2
 
   '@esbuild/aix-ppc64@0.28.2':
-    optional: true
-
-  '@esbuild/android-arm64@0.25.12':
     optional: true
 
   '@esbuild/android-arm64@0.28.2':
     optional: true
 
-  '@esbuild/android-arm@0.25.12':
-    optional: true
-
   '@esbuild/android-arm@0.28.2':
-    optional: true
-
-  '@esbuild/android-x64@0.25.12':
     optional: true
 
   '@esbuild/android-x64@0.28.2':
     optional: true
 
-  '@esbuild/darwin-arm64@0.25.12':
-    optional: true
-
   '@esbuild/darwin-arm64@0.28.2':
-    optional: true
-
-  '@esbuild/darwin-x64@0.25.12':
     optional: true
 
   '@esbuild/darwin-x64@0.28.2':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.25.12':
-    optional: true
-
   '@esbuild/freebsd-arm64@0.28.2':
-    optional: true
-
-  '@esbuild/freebsd-x64@0.25.12':
     optional: true
 
   '@esbuild/freebsd-x64@0.28.2':
     optional: true
 
-  '@esbuild/linux-arm64@0.25.12':
-    optional: true
-
   '@esbuild/linux-arm64@0.28.2':
-    optional: true
-
-  '@esbuild/linux-arm@0.25.12':
     optional: true
 
   '@esbuild/linux-arm@0.28.2':
     optional: true
 
-  '@esbuild/linux-ia32@0.25.12':
-    optional: true
-
   '@esbuild/linux-ia32@0.28.2':
-    optional: true
-
-  '@esbuild/linux-loong64@0.25.12':
     optional: true
 
   '@esbuild/linux-loong64@0.28.2':
     optional: true
 
-  '@esbuild/linux-mips64el@0.25.12':
-    optional: true
-
   '@esbuild/linux-mips64el@0.28.2':
-    optional: true
-
-  '@esbuild/linux-ppc64@0.25.12':
     optional: true
 
   '@esbuild/linux-ppc64@0.28.2':
     optional: true
 
-  '@esbuild/linux-riscv64@0.25.12':
-    optional: true
-
   '@esbuild/linux-riscv64@0.28.2':
-    optional: true
-
-  '@esbuild/linux-s390x@0.25.12':
     optional: true
 
   '@esbuild/linux-s390x@0.28.2':
     optional: true
 
-  '@esbuild/linux-x64@0.25.12':
-    optional: true
-
   '@esbuild/linux-x64@0.28.2':
-    optional: true
-
-  '@esbuild/netbsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/netbsd-arm64@0.28.2':
     optional: true
 
-  '@esbuild/netbsd-x64@0.25.12':
-    optional: true
-
   '@esbuild/netbsd-x64@0.28.2':
-    optional: true
-
-  '@esbuild/openbsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/openbsd-arm64@0.28.2':
     optional: true
 
-  '@esbuild/openbsd-x64@0.25.12':
-    optional: true
-
   '@esbuild/openbsd-x64@0.28.2':
-    optional: true
-
-  '@esbuild/openharmony-arm64@0.25.12':
     optional: true
 
   '@esbuild/openharmony-arm64@0.28.2':
     optional: true
 
-  '@esbuild/sunos-x64@0.25.12':
-    optional: true
-
   '@esbuild/sunos-x64@0.28.2':
-    optional: true
-
-  '@esbuild/win32-arm64@0.25.12':
     optional: true
 
   '@esbuild/win32-arm64@0.28.2':
     optional: true
 
-  '@esbuild/win32-ia32@0.25.12':
-    optional: true
-
   '@esbuild/win32-ia32@0.28.2':
-    optional: true
-
-  '@esbuild/win32-x64@0.25.12':
     optional: true
 
   '@esbuild/win32-x64@0.28.2':
@@ -5303,7 +4535,7 @@ snapshots:
       lodash.camelcase: 4.3.0
       long: 5.3.2
       protobufjs: 7.6.5
-      yargs: 17.7.2
+      yargs: 17.7.3
 
   '@hono/node-server@2.0.12(hono@4.12.34)':
     dependencies:
@@ -5361,11 +4593,11 @@ snapshots:
       cors: 2.8.6
       cross-spawn: 7.0.6
       eventsource: 3.0.7
-      eventsource-parser: 3.1.0
+      eventsource-parser: 3.1.1
       express: 5.2.1(supports-color@8.1.1)
-      express-rate-limit: 8.6.1(express@5.2.1(supports-color@8.1.1))(supports-color@8.1.1)
+      express-rate-limit: 8.6.2(express@5.2.1(supports-color@8.1.1))(supports-color@8.1.1)
       hono: 4.12.34
-      jose: 6.2.4
+      jose: 6.2.9
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
       raw-body: 3.0.2
@@ -5383,11 +4615,11 @@ snapshots:
       cors: 2.8.6
       cross-spawn: 7.0.6
       eventsource: 3.0.7
-      eventsource-parser: 3.1.0
+      eventsource-parser: 3.1.1
       express: 5.2.1(supports-color@8.1.1)
-      express-rate-limit: 8.6.1(express@5.2.1(supports-color@8.1.1))(supports-color@8.1.1)
+      express-rate-limit: 8.6.2(express@5.2.1(supports-color@8.1.1))(supports-color@8.1.1)
       hono: 4.12.34
-      jose: 6.2.4
+      jose: 6.2.9
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
       raw-body: 3.0.2
@@ -5396,15 +4628,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@neondatabase/serverless@1.0.2':
-    dependencies:
-      '@types/node': 22.20.0
-      '@types/pg': 8.20.0
-    optional: true
+  '@noble/ciphers@2.3.0': {}
 
-  '@noble/ciphers@2.2.0': {}
-
-  '@noble/hashes@2.2.0': {}
+  '@noble/hashes@2.3.0': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -5433,7 +4659,7 @@ snapshots:
       - supports-color
       - ws
 
-  '@openai/agents-extensions@0.14.2(@ai-sdk/provider@4.0.4)(@aws-sdk/credential-provider-node@3.972.80)(@daytonaio/sdk@0.162.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)(ws@8.21.3))(@openai/agents@0.14.2(@aws-sdk/credential-provider-node@3.972.80)(@smithy/signature-v4@5.7.2)(supports-color@8.1.1)(ws@8.21.3)(zod@4.4.3))(@smithy/signature-v4@5.7.2)(ai@7.0.41(zod@4.4.3))(supports-color@8.1.1)(ws@8.21.3)(zod@4.4.3)':
+  '@openai/agents-extensions@0.14.2(@aws-sdk/credential-provider-node@3.972.80)(@daytona/sdk@0.203.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1))(@openai/agents@0.14.2(@aws-sdk/credential-provider-node@3.972.80)(@smithy/signature-v4@5.7.2)(supports-color@8.1.1)(ws@8.21.3)(zod@4.4.3))(@smithy/signature-v4@5.7.2)(supports-color@8.1.1)(ws@8.21.3)(zod@4.4.3)':
     dependencies:
       '@openai/agents': 0.14.2(@aws-sdk/credential-provider-node@3.972.80)(@smithy/signature-v4@5.7.2)(supports-color@8.1.1)(ws@8.21.3)(zod@4.4.3)
       '@openai/agents-core': 0.14.2(@aws-sdk/credential-provider-node@3.972.80)(@smithy/signature-v4@5.7.2)(supports-color@8.1.1)(ws@8.21.3)(zod@4.4.3)
@@ -5442,9 +4668,7 @@ snapshots:
       ws: 8.21.3
       zod: 4.4.3
     optionalDependencies:
-      '@ai-sdk/provider': 4.0.4
-      '@daytonaio/sdk': 0.162.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)(ws@8.21.3)
-      ai: 7.0.41(zod@4.4.3)
+      '@daytonaio/sdk': '@daytona/sdk@0.203.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)'
     transitivePeerDependencies:
       - '@aws-sdk/credential-provider-node'
       - '@cfworker/json-schema'
@@ -5456,7 +4680,7 @@ snapshots:
     dependencies:
       '@openai/agents-core': 0.14.2(@aws-sdk/credential-provider-node@3.972.80)(@smithy/signature-v4@5.7.2)(supports-color@8.1.1)(ws@8.21.3)(zod@4.4.3)
       debug: 4.4.3(supports-color@8.1.1)
-      openai: 6.49.0(@aws-sdk/credential-provider-node@3.972.79)(@smithy/signature-v4@5.7.2)(ws@8.21.3)(zod@4.4.3)
+      openai: 6.49.0(@aws-sdk/credential-provider-node@3.972.80)(@smithy/signature-v4@5.7.2)(ws@8.21.3)(zod@4.4.3)
       zod: 4.4.3
     transitivePeerDependencies:
       - '@aws-sdk/credential-provider-node'
@@ -5488,7 +4712,7 @@ snapshots:
       '@openai/agents-openai': 0.14.2(@aws-sdk/credential-provider-node@3.972.80)(@smithy/signature-v4@5.7.2)(supports-color@8.1.1)(ws@8.21.3)(zod@4.4.3)
       '@openai/agents-realtime': 0.14.2(@aws-sdk/credential-provider-node@3.972.80)(@smithy/signature-v4@5.7.2)(supports-color@8.1.1)(zod@4.4.3)
       debug: 4.4.3(supports-color@8.1.1)
-      openai: 6.49.0(@aws-sdk/credential-provider-node@3.972.79)(@smithy/signature-v4@5.7.2)(ws@8.21.3)(zod@4.4.3)
+      openai: 6.49.0(@aws-sdk/credential-provider-node@3.972.80)(@smithy/signature-v4@5.7.2)(ws@8.21.3)(zod@4.4.3)
       zod: 4.4.3
     transitivePeerDependencies:
       - '@aws-sdk/credential-provider-node'
@@ -5500,18 +4724,9 @@ snapshots:
       - utf-8-validate
       - ws
 
-  '@opentelemetry/api-logs@0.207.0':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-
   '@opentelemetry/api-logs@0.220.0':
     dependencies:
       '@opentelemetry/api': 1.9.1
-
-  '@opentelemetry/api-logs@0.221.0':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-    optional: true
 
   '@opentelemetry/api@1.9.1': {}
 
@@ -5520,10 +4735,6 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
       yaml: 2.9.0
-
-  '@opentelemetry/context-async-hooks@2.2.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
 
   '@opentelemetry/context-async-hooks@2.9.0(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -5534,25 +4745,10 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/semantic-conventions': 1.43.0
 
-  '@opentelemetry/core@2.2.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/semantic-conventions': 1.43.0
-
   '@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/semantic-conventions': 1.43.0
-
-  '@opentelemetry/exporter-logs-otlp-grpc@0.207.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@grpc/grpc-js': 1.14.4
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/otlp-exporter-base': 0.207.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/otlp-grpc-exporter-base': 0.207.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/otlp-transformer': 0.207.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-logs': 0.207.0(@opentelemetry/api@1.9.1)
 
   '@opentelemetry/exporter-logs-otlp-grpc@0.220.0(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -5564,15 +4760,6 @@ snapshots:
       '@opentelemetry/otlp-transformer': 0.220.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-logs': 0.220.0(@opentelemetry/api@1.9.1)
 
-  '@opentelemetry/exporter-logs-otlp-http@0.207.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/api-logs': 0.207.0
-      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/otlp-exporter-base': 0.207.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/otlp-transformer': 0.207.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-logs': 0.207.0(@opentelemetry/api@1.9.1)
-
   '@opentelemetry/exporter-logs-otlp-http@0.220.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
@@ -5582,35 +4769,12 @@ snapshots:
       '@opentelemetry/otlp-transformer': 0.220.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-logs': 0.220.0(@opentelemetry/api@1.9.1)
 
-  '@opentelemetry/exporter-logs-otlp-proto@0.207.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/api-logs': 0.207.0
-      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/otlp-exporter-base': 0.207.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/otlp-transformer': 0.207.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-logs': 0.207.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-trace-base': 2.2.0(@opentelemetry/api@1.9.1)
-
   '@opentelemetry/exporter-logs-otlp-proto@0.220.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/otlp-exporter-base': 0.220.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/otlp-transformer': 0.220.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-logs': 0.220.0(@opentelemetry/api@1.9.1)
-
-  '@opentelemetry/exporter-metrics-otlp-grpc@0.207.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@grpc/grpc-js': 1.14.4
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/exporter-metrics-otlp-http': 0.207.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/otlp-exporter-base': 0.207.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/otlp-grpc-exporter-base': 0.207.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/otlp-transformer': 0.207.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-metrics': 2.2.0(@opentelemetry/api@1.9.1)
 
   '@opentelemetry/exporter-metrics-otlp-grpc@0.220.0(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -5624,15 +4788,6 @@ snapshots:
       '@opentelemetry/resources': 2.9.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-metrics': 2.9.0(@opentelemetry/api@1.9.1)
 
-  '@opentelemetry/exporter-metrics-otlp-http@0.207.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/otlp-exporter-base': 0.207.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/otlp-transformer': 0.207.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-metrics': 2.2.0(@opentelemetry/api@1.9.1)
-
   '@opentelemetry/exporter-metrics-otlp-http@0.220.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
@@ -5641,16 +4796,6 @@ snapshots:
       '@opentelemetry/otlp-transformer': 0.220.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources': 2.9.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-metrics': 2.9.0(@opentelemetry/api@1.9.1)
-
-  '@opentelemetry/exporter-metrics-otlp-proto@0.207.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/exporter-metrics-otlp-http': 0.207.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/otlp-exporter-base': 0.207.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/otlp-transformer': 0.207.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-metrics': 2.2.0(@opentelemetry/api@1.9.1)
 
   '@opentelemetry/exporter-metrics-otlp-proto@0.220.0(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -5662,13 +4807,6 @@ snapshots:
       '@opentelemetry/resources': 2.9.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-metrics': 2.9.0(@opentelemetry/api@1.9.1)
 
-  '@opentelemetry/exporter-prometheus@0.207.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-metrics': 2.2.0(@opentelemetry/api@1.9.1)
-
   '@opentelemetry/exporter-prometheus@0.220.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
@@ -5676,17 +4814,6 @@ snapshots:
       '@opentelemetry/resources': 2.9.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-metrics': 2.9.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.43.0
-
-  '@opentelemetry/exporter-trace-otlp-grpc@0.207.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@grpc/grpc-js': 1.14.4
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/otlp-exporter-base': 0.207.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/otlp-grpc-exporter-base': 0.207.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/otlp-transformer': 0.207.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-trace-base': 2.2.0(@opentelemetry/api@1.9.1)
 
   '@opentelemetry/exporter-trace-otlp-grpc@0.220.0(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -5697,15 +4824,6 @@ snapshots:
       '@opentelemetry/otlp-transformer': 0.220.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace': 2.9.0(@opentelemetry/api@1.9.1)
 
-  '@opentelemetry/exporter-trace-otlp-http@0.207.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/otlp-exporter-base': 0.207.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/otlp-transformer': 0.207.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-trace-base': 2.2.0(@opentelemetry/api@1.9.1)
-
   '@opentelemetry/exporter-trace-otlp-http@0.220.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
@@ -5714,23 +4832,6 @@ snapshots:
       '@opentelemetry/otlp-transformer': 0.220.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources': 2.9.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace': 2.9.0(@opentelemetry/api@1.9.1)
-
-  '@opentelemetry/exporter-trace-otlp-http@0.221.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/otlp-exporter-base': 0.221.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/otlp-transformer': 0.221.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-trace': 2.10.0(@opentelemetry/api@1.9.1)
-    optional: true
-
-  '@opentelemetry/exporter-trace-otlp-proto@0.207.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/otlp-exporter-base': 0.207.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/otlp-transformer': 0.207.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-trace-base': 2.2.0(@opentelemetry/api@1.9.1)
 
   '@opentelemetry/exporter-trace-otlp-proto@0.220.0(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -5741,14 +4842,6 @@ snapshots:
       '@opentelemetry/resources': 2.9.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace': 2.9.0(@opentelemetry/api@1.9.1)
 
-  '@opentelemetry/exporter-zipkin@2.2.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-trace-base': 2.2.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/semantic-conventions': 1.43.0
-
   '@opentelemetry/exporter-zipkin@2.9.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
@@ -5757,16 +4850,6 @@ snapshots:
       '@opentelemetry/sdk-trace': 2.9.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.43.0
 
-  '@opentelemetry/instrumentation-http@0.207.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.207.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)
-      '@opentelemetry/semantic-conventions': 1.43.0
-      forwarded-parse: 2.1.2
-    transitivePeerDependencies:
-      - supports-color
-
   '@opentelemetry/instrumentation-http@0.220.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
@@ -5774,15 +4857,6 @@ snapshots:
       '@opentelemetry/instrumentation': 0.220.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)
       '@opentelemetry/semantic-conventions': 1.43.0
       forwarded-parse: 2.1.2
-    transitivePeerDependencies:
-      - supports-color
-
-  '@opentelemetry/instrumentation@0.207.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/api-logs': 0.207.0
-      import-in-the-middle: 2.0.6
-      require-in-the-middle: 8.0.1(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -5795,32 +4869,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/otlp-exporter-base@0.207.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/otlp-transformer': 0.207.0(@opentelemetry/api@1.9.1)
-
   '@opentelemetry/otlp-exporter-base@0.220.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/otlp-transformer': 0.220.0(@opentelemetry/api@1.9.1)
-
-  '@opentelemetry/otlp-exporter-base@0.221.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/otlp-transformer': 0.221.0(@opentelemetry/api@1.9.1)
-    optional: true
-
-  '@opentelemetry/otlp-grpc-exporter-base@0.207.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@grpc/grpc-js': 1.14.4
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/otlp-exporter-base': 0.207.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/otlp-transformer': 0.207.0(@opentelemetry/api@1.9.1)
 
   '@opentelemetry/otlp-grpc-exporter-base@0.220.0(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -5829,17 +4882,6 @@ snapshots:
       '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/otlp-exporter-base': 0.220.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/otlp-transformer': 0.220.0(@opentelemetry/api@1.9.1)
-
-  '@opentelemetry/otlp-transformer@0.207.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/api-logs': 0.207.0
-      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-logs': 0.207.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-metrics': 2.2.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-trace-base': 2.2.0(@opentelemetry/api@1.9.1)
-      protobufjs: 7.6.5
 
   '@opentelemetry/otlp-transformer@0.220.0(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -5851,31 +4893,10 @@ snapshots:
       '@opentelemetry/sdk-metrics': 2.9.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace': 2.9.0(@opentelemetry/api@1.9.1)
 
-  '@opentelemetry/otlp-transformer@0.221.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/api-logs': 0.221.0
-      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-logs': 0.221.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-metrics': 2.10.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-trace': 2.10.0(@opentelemetry/api@1.9.1)
-    optional: true
-
-  '@opentelemetry/propagator-b3@2.2.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.1)
-
   '@opentelemetry/propagator-b3@2.9.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
-
-  '@opentelemetry/propagator-jaeger@2.2.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.1)
 
   '@opentelemetry/propagator-jaeger@2.9.0(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -5888,24 +4909,11 @@ snapshots:
       '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.43.0
 
-  '@opentelemetry/resources@2.2.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/semantic-conventions': 1.43.0
-
   '@opentelemetry/resources@2.9.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.43.0
-
-  '@opentelemetry/sdk-logs@0.207.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/api-logs': 0.207.0
-      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.1)
 
   '@opentelemetry/sdk-logs@0.220.0(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -5915,61 +4923,11 @@ snapshots:
       '@opentelemetry/resources': 2.9.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.43.0
 
-  '@opentelemetry/sdk-logs@0.221.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/api-logs': 0.221.0
-      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/semantic-conventions': 1.43.0
-    optional: true
-
-  '@opentelemetry/sdk-metrics@2.10.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
-    optional: true
-
-  '@opentelemetry/sdk-metrics@2.2.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.1)
-
   '@opentelemetry/sdk-metrics@2.9.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources': 2.9.0(@opentelemetry/api@1.9.1)
-
-  '@opentelemetry/sdk-node@0.207.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/api-logs': 0.207.0
-      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/exporter-logs-otlp-grpc': 0.207.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/exporter-logs-otlp-http': 0.207.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/exporter-logs-otlp-proto': 0.207.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/exporter-metrics-otlp-grpc': 0.207.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/exporter-metrics-otlp-http': 0.207.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/exporter-metrics-otlp-proto': 0.207.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/exporter-prometheus': 0.207.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/exporter-trace-otlp-grpc': 0.207.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/exporter-trace-otlp-http': 0.207.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/exporter-trace-otlp-proto': 0.207.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/exporter-zipkin': 2.2.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.207.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)
-      '@opentelemetry/propagator-b3': 2.2.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/propagator-jaeger': 2.2.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-logs': 0.207.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-metrics': 2.2.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-trace-base': 2.2.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-trace-node': 2.2.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/semantic-conventions': 1.43.0
-    transitivePeerDependencies:
-      - supports-color
 
   '@opentelemetry/sdk-node@0.220.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)':
     dependencies:
@@ -6012,13 +4970,6 @@ snapshots:
       '@opentelemetry/sdk-trace': 2.10.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.43.0
 
-  '@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/semantic-conventions': 1.43.0
-
   '@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
@@ -6026,13 +4977,6 @@ snapshots:
       '@opentelemetry/resources': 2.9.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace': 2.9.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.43.0
-
-  '@opentelemetry/sdk-trace-node@2.2.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/context-async-hooks': 2.2.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-trace-base': 2.2.0(@opentelemetry/api@1.9.1)
 
   '@opentelemetry/sdk-trace-node@2.9.0(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -6065,26 +5009,14 @@ snapshots:
 
   '@posthog/browser-common@0.5.0':
     dependencies:
-      '@posthog/core': 1.47.1
-      '@posthog/types': 1.403.0
+      '@posthog/core': 1.48.1
+      '@posthog/types': 1.404.1
 
-  '@posthog/core@1.46.0':
+  '@posthog/core@1.48.1':
     dependencies:
-      '@posthog/types': 1.399.0
+      '@posthog/types': 1.404.1
 
-  '@posthog/core@1.47.1':
-    dependencies:
-      '@posthog/types': 1.403.0
-
-  '@posthog/core@1.48.0':
-    dependencies:
-      '@posthog/types': 1.403.1
-
-  '@posthog/types@1.399.0': {}
-
-  '@posthog/types@1.403.0': {}
-
-  '@posthog/types@1.403.1': {}
+  '@posthog/types@1.404.1': {}
 
   '@protobufjs/aspromise@1.1.2': {}
 
@@ -6235,7 +5167,7 @@ snapshots:
     dependencies:
       '@sentry/core': 10.69.0
 
-  '@sentry/hono@10.69.0(@hono/node-server@2.0.12(hono@4.12.34))(@sentry/node@10.69.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.221.0(@opentelemetry/api@1.9.1))(supports-color@8.1.1))(hono@4.12.34)':
+  '@sentry/hono@10.69.0(@hono/node-server@2.0.12(hono@4.12.34))(@sentry/node@10.69.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.220.0(@opentelemetry/api@1.9.1))(supports-color@8.1.1))(hono@4.12.34)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@sentry/conventions': 0.16.0
@@ -6243,9 +5175,9 @@ snapshots:
       hono: 4.12.34
     optionalDependencies:
       '@hono/node-server': 2.0.12(hono@4.12.34)
-      '@sentry/node': 10.69.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.221.0(@opentelemetry/api@1.9.1))(supports-color@8.1.1)
+      '@sentry/node': 10.69.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.220.0(@opentelemetry/api@1.9.1))(supports-color@8.1.1)
 
-  '@sentry/node-core@10.69.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.220.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))':
+  '@sentry/node-core@10.69.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.220.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))':
     dependencies:
       '@sentry/conventions': 0.16.0
       '@sentry/core': 10.69.0
@@ -6254,18 +5186,18 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/exporter-trace-otlp-http': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-trace-otlp-http': 0.220.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/instrumentation': 0.220.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)
       '@opentelemetry/sdk-trace-base': 2.10.0(@opentelemetry/api@1.9.1)
 
-  '@sentry/node@10.69.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.221.0(@opentelemetry/api@1.9.1))(supports-color@8.1.1)':
+  '@sentry/node@10.69.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.220.0(@opentelemetry/api@1.9.1))(supports-color@8.1.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/instrumentation': 0.220.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)
       '@opentelemetry/sdk-trace-base': 2.10.0(@opentelemetry/api@1.9.1)
       '@sentry/conventions': 0.16.0
       '@sentry/core': 10.69.0
-      '@sentry/node-core': 10.69.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.220.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))
+      '@sentry/node-core': 10.69.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.220.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))
       '@sentry/opentelemetry': 10.69.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))
       '@sentry/server-utils': 10.69.0(supports-color@8.1.1)
       import-in-the-middle: 3.3.3
@@ -6318,36 +5250,31 @@ snapshots:
       - supports-color
       - webpack
 
-  '@smithy/core@3.31.1':
-    dependencies:
-      '@smithy/types': 4.16.1
-      tslib: 2.8.1
-
   '@smithy/core@3.33.2':
     dependencies:
       '@smithy/types': 4.17.2
       tslib: 2.8.1
 
-  '@smithy/credential-provider-imds@4.4.16':
+  '@smithy/credential-provider-imds@4.5.2':
     dependencies:
-      '@smithy/core': 3.31.1
-      '@smithy/types': 4.16.1
+      '@smithy/core': 3.33.2
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
 
-  '@smithy/fetch-http-handler@5.6.13':
+  '@smithy/fetch-http-handler@5.7.2':
     dependencies:
-      '@smithy/core': 3.31.1
-      '@smithy/types': 4.16.1
+      '@smithy/core': 3.33.2
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
 
   '@smithy/is-array-buffer@2.2.0':
     dependencies:
       tslib: 2.8.1
 
-  '@smithy/node-http-handler@4.9.13':
+  '@smithy/node-http-handler@4.11.2':
     dependencies:
-      '@smithy/core': 3.31.1
-      '@smithy/types': 4.16.1
+      '@smithy/core': 3.33.2
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
 
   '@smithy/protocol-http@5.6.2':
@@ -6355,20 +5282,10 @@ snapshots:
       '@smithy/core': 3.33.2
       tslib: 2.8.1
 
-  '@smithy/signature-v4@5.6.12':
-    dependencies:
-      '@smithy/core': 3.31.1
-      '@smithy/types': 4.16.1
-      tslib: 2.8.1
-
   '@smithy/signature-v4@5.7.2':
     dependencies:
       '@smithy/core': 3.33.2
       '@smithy/types': 4.17.2
-      tslib: 2.8.1
-
-  '@smithy/types@4.16.1':
-    dependencies:
       tslib: 2.8.1
 
   '@smithy/types@4.17.2':
@@ -6452,12 +5369,12 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.3.3
       '@tailwindcss/oxide-win32-x64-msvc': 4.3.3
 
-  '@tailwindcss/vite@4.3.3(vite@8.2.1(@types/node@26.0.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.20.6)(yaml@2.9.0))':
+  '@tailwindcss/vite@4.3.3(vite@8.2.1(@types/node@26.0.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))':
     dependencies:
       '@tailwindcss/node': 4.3.3
       '@tailwindcss/oxide': 4.3.3
       tailwindcss: 4.3.3
-      vite: 8.2.1(@types/node@26.0.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.20.6)(yaml@2.9.0)
+      vite: 8.2.1(@types/node@26.0.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)
 
   '@types/chai@5.2.3':
     dependencies:
@@ -6511,11 +5428,6 @@ snapshots:
 
   '@types/node@15.14.9': {}
 
-  '@types/node@22.20.0':
-    dependencies:
-      undici-types: 6.21.0
-    optional: true
-
   '@types/node@26.0.0':
     dependencies:
       undici-types: 8.3.0
@@ -6523,7 +5435,7 @@ snapshots:
   '@types/pg@8.20.0':
     dependencies:
       '@types/node': 26.0.0
-      pg-protocol: 1.15.0
+      pg-protocol: 1.16.0
       pg-types: 2.2.0
 
   '@types/react-dom@19.2.3(@types/react@19.2.14)':
@@ -6656,13 +5568,10 @@ snapshots:
       - '@cfworker/json-schema'
       - supports-color
 
-  '@vercel/oidc@3.2.0':
-    optional: true
-
-  '@vitejs/plugin-react@6.0.4(vite@8.2.1(@types/node@26.0.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.20.6)(yaml@2.9.0))':
+  '@vitejs/plugin-react@6.0.4(vite@8.2.1(@types/node@26.0.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
-      vite: 8.2.1(@types/node@26.0.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.20.6)(yaml@2.9.0)
+      vite: 8.2.1(@types/node@26.0.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)
 
   '@vitest/expect@4.1.9':
     dependencies:
@@ -6673,14 +5582,6 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.1
 
-  '@vitest/mocker@4.1.9(vite@8.2.1(@types/node@26.0.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.20.6)(yaml@2.9.0))':
-    dependencies:
-      '@vitest/spy': 4.1.9
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 8.2.1(@types/node@26.0.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.20.6)(yaml@2.9.0)
-
   '@vitest/mocker@4.1.9(vite@8.2.1(@types/node@26.0.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.9
@@ -6688,7 +5589,6 @@ snapshots:
       magic-string: 0.30.21
     optionalDependencies:
       vite: 8.2.1(@types/node@26.0.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)
-    optional: true
 
   '@vitest/pretty-format@4.1.9':
     dependencies:
@@ -6714,12 +5614,9 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.1
 
-  '@workflow/serde@4.1.0':
-    optional: true
-
-  '@xyflow/react@12.11.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@xyflow/react@12.11.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@xyflow/system': 0.0.79
+      '@xyflow/system': 0.0.80
       classcat: 5.0.5
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
@@ -6730,7 +5627,7 @@ snapshots:
     transitivePeerDependencies:
       - immer
 
-  '@xyflow/system@0.0.79':
+  '@xyflow/system@0.0.80':
     dependencies:
       '@types/d3-drag': 3.0.7
       '@types/d3-interpolate': 3.0.4
@@ -6747,10 +5644,6 @@ snapshots:
       mime-types: 3.0.2
       negotiator: 1.0.0
 
-  acorn-import-attributes@1.9.5(acorn@8.18.0):
-    dependencies:
-      acorn: 8.18.0
-
   acorn-jsx@5.3.2(acorn@8.18.0):
     dependencies:
       acorn: 8.18.0
@@ -6762,14 +5655,6 @@ snapshots:
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
-
-  ai@7.0.41(zod@4.4.3):
-    dependencies:
-      '@ai-sdk/gateway': 4.0.31(zod@4.4.3)
-      '@ai-sdk/provider': 4.0.4
-      '@ai-sdk/provider-utils': 5.0.14(zod@4.4.3)
-      zod: 4.4.3
-    optional: true
 
   ajv-formats@3.0.1(ajv@8.20.0):
     optionalDependencies:
@@ -6803,13 +5688,13 @@ snapshots:
 
   asynckit@0.4.0: {}
 
-  autumn-js@1.2.45(better-auth@1.6.25(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.4)(pg@8.22.0))(pg@8.22.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(vite@8.2.1(@types/node@26.0.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))))(better-call@1.3.7(zod@4.4.3))(express@5.2.1(supports-color@8.1.1))(hono@4.12.34)(react@19.2.6):
+  autumn-js@1.2.45(better-auth@1.6.25(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.5)(pg@8.22.0))(pg@8.22.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(vite@8.2.1(@types/node@26.0.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))))(better-call@1.3.7(zod@4.4.3))(express@5.2.1(supports-color@8.1.1))(hono@4.12.34)(react@19.2.6):
     dependencies:
-      query-string: 9.4.1
+      query-string: 9.5.0
       rou3: 0.6.3
       zod: 4.4.3
     optionalDependencies:
-      better-auth: 1.6.25(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.4)(pg@8.22.0))(pg@8.22.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(vite@8.2.1(@types/node@26.0.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)))
+      better-auth: 1.6.25(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.5)(pg@8.22.0))(pg@8.22.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(vite@8.2.1(@types/node@26.0.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)))
       better-call: 1.3.7(zod@4.4.3)
       express: 5.2.1(supports-color@8.1.1)
       hono: 4.12.34
@@ -6833,60 +5718,30 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  baseline-browser-mapping@2.11.6: {}
+  baseline-browser-mapping@2.11.14: {}
 
-  better-auth@1.6.25(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.4)(pg@8.22.0))(pg@8.22.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(vite@8.2.1(@types/node@26.0.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.20.6)(yaml@2.9.0))):
+  better-auth@1.6.25(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.5)(pg@8.22.0))(pg@8.22.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(vite@8.2.1(@types/node@26.0.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))):
     dependencies:
-      '@better-auth/core': 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.4)(nanostores@1.4.2)
-      '@better-auth/drizzle-adapter': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.4)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.4)(pg@8.22.0))
-      '@better-auth/kysely-adapter': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.4)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(kysely@0.29.4)
-      '@better-auth/memory-adapter': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.4)(nanostores@1.4.2))(@better-auth/utils@0.4.2)
-      '@better-auth/mongo-adapter': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.4)(nanostores@1.4.2))(@better-auth/utils@0.4.2)
-      '@better-auth/prisma-adapter': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.4)(nanostores@1.4.2))(@better-auth/utils@0.4.2)
-      '@better-auth/telemetry': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.4)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)
+      '@better-auth/core': 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0)
+      '@better-auth/drizzle-adapter': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.5)(pg@8.22.0))
+      '@better-auth/kysely-adapter': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)(kysely@0.29.5)
+      '@better-auth/memory-adapter': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)
+      '@better-auth/mongo-adapter': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)
+      '@better-auth/prisma-adapter': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)
+      '@better-auth/telemetry': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
-      '@noble/ciphers': 2.2.0
-      '@noble/hashes': 2.2.0
+      '@noble/ciphers': 2.3.0
+      '@noble/hashes': 2.3.0
       better-call: 1.3.7(zod@4.4.3)
       defu: 6.1.7
-      jose: 6.2.4
-      kysely: 0.29.4
-      nanostores: 1.4.2
+      jose: 6.2.9
+      kysely: 0.29.5
+      nanostores: 1.5.0
       zod: 4.4.3
     optionalDependencies:
       drizzle-kit: 0.31.10
-      drizzle-orm: 0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.4)(pg@8.22.0)
-      pg: 8.22.0
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(vite@8.2.1(@types/node@26.0.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.20.6)(yaml@2.9.0))
-    transitivePeerDependencies:
-      - '@cloudflare/workers-types'
-      - '@opentelemetry/api'
-
-  better-auth@1.6.25(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.4)(pg@8.22.0))(pg@8.22.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(vite@8.2.1(@types/node@26.0.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))):
-    dependencies:
-      '@better-auth/core': 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.4)(nanostores@1.4.2)
-      '@better-auth/drizzle-adapter': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.4)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.4)(pg@8.22.0))
-      '@better-auth/kysely-adapter': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.4)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(kysely@0.29.4)
-      '@better-auth/memory-adapter': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.4)(nanostores@1.4.2))(@better-auth/utils@0.4.2)
-      '@better-auth/mongo-adapter': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.4)(nanostores@1.4.2))(@better-auth/utils@0.4.2)
-      '@better-auth/prisma-adapter': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.4)(nanostores@1.4.2))(@better-auth/utils@0.4.2)
-      '@better-auth/telemetry': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.4)(kysely@0.29.4)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)
-      '@better-auth/utils': 0.4.2
-      '@better-fetch/fetch': 1.3.1
-      '@noble/ciphers': 2.2.0
-      '@noble/hashes': 2.2.0
-      better-call: 1.3.7(zod@4.4.3)
-      defu: 6.1.7
-      jose: 6.2.4
-      kysely: 0.29.4
-      nanostores: 1.4.2
-      zod: 4.4.3
-    optionalDependencies:
-      drizzle-kit: 0.31.10
-      drizzle-orm: 0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.4)(pg@8.22.0)
+      drizzle-orm: 0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.5)(pg@8.22.0)
       pg: 8.22.0
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
@@ -6894,11 +5749,10 @@ snapshots:
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@opentelemetry/api'
-    optional: true
 
   better-call@1.3.7(zod@4.4.3):
     dependencies:
-      '@better-auth/utils': 0.4.2
+      '@better-auth/utils': 0.4.3
       '@better-fetch/fetch': 1.3.1
       rou3: 0.7.12
       set-cookie-parser: 3.1.2
@@ -6908,7 +5762,7 @@ snapshots:
   body-parser@2.3.0(supports-color@8.1.1):
     dependencies:
       bytes: 3.1.2
-      content-type: 2.0.0
+      content-type: 2.1.0
       debug: 4.4.3(supports-color@8.1.1)
       http-errors: 2.0.1
       iconv-lite: 0.7.3
@@ -6934,13 +5788,13 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
-  browserslist@4.28.7:
+  browserslist@4.28.8:
     dependencies:
-      baseline-browser-mapping: 2.11.6
-      caniuse-lite: 1.0.30001806
-      electron-to-chromium: 1.5.398
-      node-releases: 2.0.51
-      update-browserslist-db: 1.2.3(browserslist@4.28.7)
+      baseline-browser-mapping: 2.11.14
+      caniuse-lite: 1.0.30001809
+      electron-to-chromium: 1.5.407
+      node-releases: 2.0.53
+      update-browserslist-db: 1.3.1(browserslist@4.28.8)
 
   buffer-from@1.1.2: {}
 
@@ -6967,7 +5821,7 @@ snapshots:
 
   callsites@3.1.0: {}
 
-  caniuse-lite@1.0.30001806: {}
+  caniuse-lite@1.0.30001809: {}
 
   ccount@2.0.1: {}
 
@@ -6990,7 +5844,7 @@ snapshots:
 
   chownr@3.0.0: {}
 
-  cjs-module-lexer@2.2.0: {}
+  cjs-module-lexer@2.2.1: {}
 
   classcat@5.0.5: {}
 
@@ -7031,7 +5885,7 @@ snapshots:
 
   content-type@1.0.5: {}
 
-  content-type@2.0.0: {}
+  content-type@2.1.0: {}
 
   convert-source-map@2.0.0: {}
 
@@ -7041,14 +5895,14 @@ snapshots:
 
   cookie@1.1.1: {}
 
-  core-js@3.49.0: {}
+  core-js@3.50.0: {}
 
   cors@2.8.6:
     dependencies:
       object-assign: 4.1.1
       vary: 1.1.2
 
-  cron-parser@5.7.0:
+  cron-parser@5.10.0:
     dependencies:
       luxon: 3.7.2
 
@@ -7106,7 +5960,7 @@ snapshots:
     dependencies:
       character-entities: 2.0.2
 
-  decode-uri-component@0.4.1: {}
+  decode-uri-component@0.5.0: {}
 
   deep-is@0.1.4: {}
 
@@ -7136,15 +5990,14 @@ snapshots:
     dependencies:
       '@drizzle-team/brocli': 0.10.2
       '@esbuild-kit/esm-loader': 2.6.5
-      esbuild: 0.25.12
+      esbuild: 0.28.2
       tsx: 4.23.12
 
-  drizzle-orm@0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.4)(pg@8.22.0):
+  drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.5)(pg@8.22.0):
     optionalDependencies:
-      '@neondatabase/serverless': 1.0.2
       '@opentelemetry/api': 1.9.1
       '@types/pg': 8.20.0
-      kysely: 0.29.4
+      kysely: 0.29.5
       pg: 8.22.0
 
   dunder-proto@1.0.1:
@@ -7155,7 +6008,7 @@ snapshots:
 
   ee-first@1.1.1: {}
 
-  electron-to-chromium@1.5.398: {}
+  electron-to-chromium@1.5.407: {}
 
   emoji-regex@8.0.0: {}
 
@@ -7197,35 +6050,6 @@ snapshots:
       has-tostringtag: 1.0.2
       hasown: 2.0.4
 
-  esbuild@0.25.12:
-    optionalDependencies:
-      '@esbuild/aix-ppc64': 0.25.12
-      '@esbuild/android-arm': 0.25.12
-      '@esbuild/android-arm64': 0.25.12
-      '@esbuild/android-x64': 0.25.12
-      '@esbuild/darwin-arm64': 0.25.12
-      '@esbuild/darwin-x64': 0.25.12
-      '@esbuild/freebsd-arm64': 0.25.12
-      '@esbuild/freebsd-x64': 0.25.12
-      '@esbuild/linux-arm': 0.25.12
-      '@esbuild/linux-arm64': 0.25.12
-      '@esbuild/linux-ia32': 0.25.12
-      '@esbuild/linux-loong64': 0.25.12
-      '@esbuild/linux-mips64el': 0.25.12
-      '@esbuild/linux-ppc64': 0.25.12
-      '@esbuild/linux-riscv64': 0.25.12
-      '@esbuild/linux-s390x': 0.25.12
-      '@esbuild/linux-x64': 0.25.12
-      '@esbuild/netbsd-arm64': 0.25.12
-      '@esbuild/netbsd-x64': 0.25.12
-      '@esbuild/openbsd-arm64': 0.25.12
-      '@esbuild/openbsd-x64': 0.25.12
-      '@esbuild/openharmony-arm64': 0.25.12
-      '@esbuild/sunos-x64': 0.25.12
-      '@esbuild/win32-arm64': 0.25.12
-      '@esbuild/win32-ia32': 0.25.12
-      '@esbuild/win32-x64': 0.25.12
-
   esbuild@0.28.2:
     optionalDependencies:
       '@esbuild/aix-ppc64': 0.28.2
@@ -7264,7 +6088,7 @@ snapshots:
   eslint-plugin-react-hooks@7.1.1(eslint@9.39.2(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/parser': 7.29.7
+      '@babel/parser': 7.29.8
       eslint: 9.39.2(jiti@2.7.0)(supports-color@8.1.1)
       hermes-parser: 0.25.1
       zod: 4.4.3
@@ -7356,11 +6180,11 @@ snapshots:
 
   events@3.3.0: {}
 
-  eventsource-parser@3.1.0: {}
+  eventsource-parser@3.1.1: {}
 
   eventsource@3.0.7:
     dependencies:
-      eventsource-parser: 3.1.0
+      eventsource-parser: 3.1.1
 
   expand-tilde@2.0.2:
     dependencies:
@@ -7368,11 +6192,11 @@ snapshots:
 
   expect-type@1.4.0: {}
 
-  express-rate-limit@8.6.1(express@5.2.1(supports-color@8.1.1))(supports-color@8.1.1):
+  express-rate-limit@8.6.2(express@5.2.1(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       express: 5.2.1(supports-color@8.1.1)
-      ip-address: 10.4.0
+      ip-address: 10.5.0
     transitivePeerDependencies:
       - supports-color
 
@@ -7467,10 +6291,10 @@ snapshots:
 
   flat-cache@4.0.1:
     dependencies:
-      flatted: 3.4.3
+      flatted: 3.4.4
       keyv: 4.5.4
 
-  flatted@3.4.3: {}
+  flatted@3.4.4: {}
 
   follow-redirects@1.16.0(debug@4.4.3(supports-color@8.1.1)):
     optionalDependencies:
@@ -7520,7 +6344,7 @@ snapshots:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.2
 
-  get-tsconfig@4.14.0:
+  get-tsconfig@4.14.2:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
@@ -7624,16 +6448,9 @@ snapshots:
       parent-module: 1.0.1
       resolve-from: 4.0.0
 
-  import-in-the-middle@2.0.6:
-    dependencies:
-      acorn: 8.18.0
-      acorn-import-attributes: 1.9.5(acorn@8.18.0)
-      cjs-module-lexer: 2.2.0
-      module-details-from-path: 1.0.4
-
   import-in-the-middle@3.3.3:
     dependencies:
-      cjs-module-lexer: 2.2.0
+      cjs-module-lexer: 2.2.1
       es-module-lexer: 2.3.1
       module-details-from-path: 1.0.4
 
@@ -7643,9 +6460,11 @@ snapshots:
 
   inline-style-parser@0.2.7: {}
 
-  ip-address@10.4.0: {}
+  ip-address@10.5.0: {}
 
   ipaddr.js@1.9.1: {}
+
+  ipaddr.js@2.5.0: {}
 
   is-alphabetical@2.0.1: {}
 
@@ -7680,7 +6499,7 @@ snapshots:
 
   jiti@2.7.0: {}
 
-  jose@6.2.4: {}
+  jose@6.2.9: {}
 
   js-tokens@4.0.0: {}
 
@@ -7698,9 +6517,6 @@ snapshots:
 
   json-schema-typed@8.0.2: {}
 
-  json-schema@0.4.0:
-    optional: true
-
   json-stable-stringify-without-jsonify@1.0.1: {}
 
   json5@2.2.3: {}
@@ -7709,7 +6525,7 @@ snapshots:
     dependencies:
       json-buffer: 3.0.1
 
-  kysely@0.29.4: {}
+  kysely@0.29.5: {}
 
   levn@0.4.1:
     dependencies:
@@ -8107,7 +6923,7 @@ snapshots:
 
   nanoid@3.3.18: {}
 
-  nanostores@1.4.2: {}
+  nanostores@1.5.0: {}
 
   natural-compare@1.4.0: {}
 
@@ -8117,7 +6933,7 @@ snapshots:
     dependencies:
       whatwg-url: 5.0.0
 
-  node-releases@2.0.51: {}
+  node-releases@2.0.53: {}
 
   non-error@0.1.0: {}
 
@@ -8134,13 +6950,6 @@ snapshots:
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
-
-  openai@6.49.0(@aws-sdk/credential-provider-node@3.972.79)(@smithy/signature-v4@5.7.2)(ws@8.21.3)(zod@4.4.3):
-    optionalDependencies:
-      '@aws-sdk/credential-provider-node': 3.972.79
-      '@smithy/signature-v4': 5.7.2
-      ws: 8.21.3
-      zod: 4.4.3
 
   openai@6.49.0(@aws-sdk/credential-provider-node@3.972.80)(@smithy/signature-v4@5.7.2)(ws@8.21.3)(zod@4.4.3):
     optionalDependencies:
@@ -8199,7 +7008,7 @@ snapshots:
 
   pg-boss@12.26.3:
     dependencies:
-      cron-parser: 5.7.0
+      cron-parser: 5.10.0
       pg: 8.22.0
       serialize-error: 13.0.1
     transitivePeerDependencies:
@@ -8216,7 +7025,7 @@ snapshots:
     dependencies:
       pg: 8.22.0
 
-  pg-protocol@1.15.0: {}
+  pg-protocol@1.16.0: {}
 
   pg-types@2.2.0:
     dependencies:
@@ -8230,7 +7039,7 @@ snapshots:
     dependencies:
       pg-connection-string: 2.14.0
       pg-pool: 3.14.0(pg@8.22.0)
-      pg-protocol: 1.15.0
+      pg-protocol: 1.16.0
       pg-types: 2.2.0
       pgpass: 1.0.5
     optionalDependencies:
@@ -8276,12 +7085,12 @@ snapshots:
     dependencies:
       xtend: 4.0.2
 
-  posthog-js@1.416.1:
+  posthog-js@1.417.1:
     dependencies:
       '@posthog/browser-common': 0.5.0
-      '@posthog/core': 1.48.0
-      '@posthog/types': 1.403.1
-      core-js: 3.49.0
+      '@posthog/core': 1.48.1
+      '@posthog/types': 1.404.1
+      core-js: 3.50.0
       dompurify: 3.4.13
       fflate: 0.4.9
       preact: 10.29.8
@@ -8291,9 +7100,9 @@ snapshots:
     transitivePeerDependencies:
       - preact-render-to-string
 
-  posthog-node@5.47.0(rxjs@7.8.2):
+  posthog-node@5.49.1(rxjs@7.8.2):
     dependencies:
-      '@posthog/core': 1.46.0
+      '@posthog/core': 1.48.1
     optionalDependencies:
       rxjs: 7.8.2
 
@@ -8337,9 +7146,9 @@ snapshots:
 
   query-selector-shadow-dom@1.0.1: {}
 
-  query-string@9.4.1:
+  query-string@9.5.0:
     dependencies:
-      decode-uri-component: 0.4.1
+      decode-uri-component: 0.5.0
       filter-obj: 5.1.0
       split-on-first: 3.0.0
 
@@ -8674,7 +7483,7 @@ snapshots:
 
   tinybench@2.9.0: {}
 
-  tinyexec@1.2.4: {}
+  tinyexec@1.3.0: {}
 
   tinyglobby@0.2.17:
     dependencies:
@@ -8703,13 +7512,6 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsx@4.20.6:
-    dependencies:
-      esbuild: 0.25.12
-      get-tsconfig: 4.14.0
-    optionalDependencies:
-      fsevents: 2.3.3
-
   tsx@4.23.12:
     dependencies:
       esbuild: 0.28.2
@@ -8726,7 +7528,7 @@ snapshots:
 
   type-is@2.1.0:
     dependencies:
-      content-type: 2.0.0
+      content-type: 2.1.0
       media-typer: 1.1.1
       mime-types: 3.0.2
 
@@ -8743,10 +7545,9 @@ snapshots:
 
   typescript@6.0.3: {}
 
-  undici-types@6.21.0:
-    optional: true
-
   undici-types@8.3.0: {}
+
+  undici@8.10.0: {}
 
   unified@11.0.5:
     dependencies:
@@ -8783,9 +7584,9 @@ snapshots:
 
   unpipe@1.0.0: {}
 
-  update-browserslist-db@1.2.3(browserslist@4.28.7):
+  update-browserslist-db@1.3.1(browserslist@4.28.8):
     dependencies:
-      browserslist: 4.28.7
+      browserslist: 4.28.8
       escalade: 3.2.0
       picocolors: 1.1.1
 
@@ -8811,21 +7612,6 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite@8.2.1(@types/node@26.0.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.20.6)(yaml@2.9.0):
-    dependencies:
-      lightningcss: 1.33.0
-      picomatch: 4.0.5
-      postcss: 8.5.26
-      rolldown: 1.2.4
-      tinyglobby: 0.2.17
-    optionalDependencies:
-      '@types/node': 26.0.0
-      esbuild: 0.28.2
-      fsevents: 2.3.3
-      jiti: 2.7.0
-      tsx: 4.20.6
-      yaml: 2.9.0
-
   vite@8.2.1(@types/node@26.0.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.33.0
@@ -8840,35 +7626,6 @@ snapshots:
       jiti: 2.7.0
       tsx: 4.23.12
       yaml: 2.9.0
-    optional: true
-
-  vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(vite@8.2.1(@types/node@26.0.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.20.6)(yaml@2.9.0)):
-    dependencies:
-      '@vitest/expect': 4.1.9
-      '@vitest/mocker': 4.1.9(vite@8.2.1(@types/node@26.0.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.20.6)(yaml@2.9.0))
-      '@vitest/pretty-format': 4.1.9
-      '@vitest/runner': 4.1.9
-      '@vitest/snapshot': 4.1.9
-      '@vitest/spy': 4.1.9
-      '@vitest/utils': 4.1.9
-      es-module-lexer: 2.3.1
-      expect-type: 1.4.0
-      magic-string: 0.30.21
-      obug: 2.1.4
-      pathe: 2.0.3
-      picomatch: 4.0.5
-      std-env: 4.2.0
-      tinybench: 2.9.0
-      tinyexec: 1.2.4
-      tinyglobby: 0.2.17
-      tinyrainbow: 3.1.1
-      vite: 8.2.1(@types/node@26.0.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.20.6)(yaml@2.9.0)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@opentelemetry/api': 1.9.1
-      '@types/node': 26.0.0
-    transitivePeerDependencies:
-      - msw
 
   vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(vite@8.2.1(@types/node@26.0.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)):
     dependencies:
@@ -8887,7 +7644,7 @@ snapshots:
       picomatch: 4.0.5
       std-env: 4.2.0
       tinybench: 2.9.0
-      tinyexec: 1.2.4
+      tinyexec: 1.3.0
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.1
       vite: 8.2.1(@types/node@26.0.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)
@@ -8897,7 +7654,6 @@ snapshots:
       '@types/node': 26.0.0
     transitivePeerDependencies:
       - msw
-    optional: true
 
   web-vitals@5.3.0: {}
 
@@ -8946,6 +7702,16 @@ snapshots:
   yargs-parser@21.1.1: {}
 
   yargs@17.7.2:
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
+
+  yargs@17.7.3:
     dependencies:
       cliui: 8.0.1
       escalade: 3.2.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,14 +10,26 @@ allowBuilds:
   sharp: true
   unrs-resolver: true
 
+blockExoticSubdeps: true
+minimumReleaseAge: 1440
+
 overrides:
   '@daytona/sdk>shell-quote': 1.9.0
-  '@esbuild-kit/core-utils>esbuild': 0.25.12
+  '@esbuild-kit/core-utils>esbuild': 0.28.2
   '@eslint/eslintrc>js-yaml': 4.3.1
   'ajv>fast-uri': 3.1.5
   'concurrently>shell-quote': 1.9.0
+  'drizzle-kit>esbuild': 0.28.2
   'minimatch@3>brace-expansion': 1.1.18
   'minimatch@10>brace-expansion': 5.0.9
+
+peerDependencyRules:
+  allowedVersions:
+    '@daytonaio/sdk': 0.203.0
+
+trustPolicy: no-downgrade
+trustPolicyExclude:
+  - semver@6.3.1
 
 minimumReleaseAgeExclude:
   - '@posthog/core@1.48.0'

--- a/scripts/upstash-fetch-guard.test.mjs
+++ b/scripts/upstash-fetch-guard.test.mjs
@@ -1,0 +1,158 @@
+/* global AbortSignal, ReadableStream, Response */
+
+import { describe, expect, it, vi } from "vitest";
+import { createBoundedUpstashFetch } from "../apps/worker/src/upstash-fetch-guard.mjs";
+
+describe("Upstash child fetch guard", () => {
+  it("answers the upstream write probe locally to select read-only tokens", async () => {
+    const fetchImplementation = vi.fn();
+    const guardedFetch = createBoundedUpstashFetch(fetchImplementation, 1_000);
+
+    const response = await guardedFetch(
+      "https://api.upstash.com/v2/redis/database/readonly-check-nonexistent",
+      { method: "DELETE" },
+    );
+
+    expect(response.status).toBe(403);
+    await expect(response.text()).resolves.toContain("Readonly API key");
+    expect(fetchImplementation).not.toHaveBeenCalled();
+  });
+
+  it("blocks unexpected origins and management mutations", async () => {
+    const fetchImplementation = vi.fn();
+    const guardedFetch = createBoundedUpstashFetch(fetchImplementation, 1_000);
+
+    await expect(guardedFetch("https://example.com/data")).rejects.toThrow(
+      "unexpected request origin",
+    );
+    await expect(
+      guardedFetch("https://api.upstash.com/v2/redis/database/db-1", {
+        method: "POST",
+      }),
+    ).rejects.toThrow("management API mutation");
+    expect(fetchImplementation).not.toHaveBeenCalled();
+  });
+
+  it("allows fixed Upstash reads and Redis command posts", async () => {
+    const fetchImplementation = vi
+      .fn()
+      .mockImplementation(async () => Response.json({ result: "ok" }));
+    const guardedFetch = createBoundedUpstashFetch(fetchImplementation, 1_000);
+
+    await expect(
+      guardedFetch("https://api.upstash.com/v2/redis/databases"),
+    ).resolves.toBeInstanceOf(Response);
+    await expect(
+      guardedFetch("https://example-db.upstash.io", { method: "POST" }),
+    ).resolves.toBeInstanceOf(Response);
+    expect(fetchImplementation).toHaveBeenCalledTimes(2);
+    expect(fetchImplementation).toHaveBeenLastCalledWith(
+      "https://example-db.upstash.io",
+      expect.objectContaining({
+        redirect: "error",
+        signal: expect.any(AbortSignal),
+      }),
+    );
+  });
+
+  it("aborts a streaming response before unbounded parsing", async () => {
+    let cancelled = false;
+    const response = new Response(
+      new ReadableStream({
+        start(controller) {
+          controller.enqueue(new Uint8Array(600));
+          controller.enqueue(new Uint8Array(600));
+        },
+        cancel() {
+          cancelled = true;
+        },
+      }),
+    );
+    const guardedFetch = createBoundedUpstashFetch(
+      vi.fn().mockResolvedValue(response),
+      1_000,
+    );
+
+    const guardedResponse = await guardedFetch(
+      "https://example-db.upstash.io",
+      { method: "POST" },
+    );
+    await expect(guardedResponse.arrayBuffer()).rejects.toThrow(
+      "exceeded the 1 MiB investigation limit",
+    );
+    expect(cancelled).toBe(true);
+  });
+
+  it("rejects an excessive declared content length before reading", async () => {
+    let cancelled = false;
+    const response = new Response(
+      new ReadableStream({
+        cancel() {
+          cancelled = true;
+        },
+      }),
+      { headers: { "content-length": "1001" } },
+    );
+    const guardedFetch = createBoundedUpstashFetch(
+      vi.fn().mockResolvedValue(response),
+      1_000,
+    );
+
+    await expect(
+      guardedFetch("https://api.upstash.com/v2/redis/databases"),
+    ).rejects.toThrow("exceeded the 1 MiB investigation limit");
+    expect(cancelled).toBe(true);
+  });
+
+  it("aborts stalled child requests with a stable error", async () => {
+    const fetchImplementation = vi.fn(
+      (_input, init) =>
+        new Promise((_resolve, reject) => {
+          init.signal.addEventListener(
+            "abort",
+            () => reject(init.signal.reason),
+            { once: true },
+          );
+        }),
+    );
+    const guardedFetch = createBoundedUpstashFetch(
+      fetchImplementation,
+      1_000,
+      5,
+    );
+
+    await expect(
+      guardedFetch("https://api.upstash.com/v2/redis/databases"),
+    ).rejects.toThrow("exceeded the investigation timeout");
+  });
+
+  it("maps a stalled response body timeout to the same stable error", async () => {
+    const fetchImplementation = vi.fn((_input, init) =>
+      Promise.resolve(
+        new Response(
+          new ReadableStream({
+            start(controller) {
+              init.signal.addEventListener(
+                "abort",
+                () => controller.error(init.signal.reason),
+                { once: true },
+              );
+            },
+          }),
+        ),
+      ),
+    );
+    const guardedFetch = createBoundedUpstashFetch(
+      fetchImplementation,
+      1_000,
+      5,
+    );
+
+    const response = await guardedFetch(
+      "https://api.upstash.com/v2/redis/databases",
+    );
+    await expect(response.text()).rejects.toThrow(
+      "exceeded the investigation timeout",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Bind browser OAuth callbacks to the initiating user, organization, provider, and expiry, and verify Vercel installation, team, and selected-project identity.
- Harden custom MCP and Upstash access with destination, redirect, timeout, response-size, path, command, and concurrency controls.
- Preserve the full generated Vercel read catalog and sanitized provider diagnostics while redacting credentials.
- Make investigation, remediation, ticket, and pull-request transitions atomic and tenant-qualified, and recover abandoned remediation requests without replaying external side effects.
- Add fixed-path structured secret loading, dependency trust policies, request-body limits, and tenant-aware database constraints.

## Compatibility

- Linear remains on its existing `read,write` OAuth scope.
- Vercel callback validation does not narrow configured provider permissions.
- All 146 operations in the generated Vercel GET catalog remain available.
- Sanitized Vercel and Upstash outputs remain available to investigations and monitoring.
- Upstash `url` and `workflowUrl` fields continue to accept historical HTTP callback values only as exact-match log filters; they are never fetched.
- The renamed Daytona SDK peer exception remains exact so every SDK upgrade requires an explicit compatibility review.

## Rollout

- Run database migration `0024_security_hardening`; it reconciles duplicate active pull-request requests, bounds OAuth state ownership, and re-keys or safely retires legacy Linear accounts.
- Set `RESPONDER_SECRETS_JSON_FILE=/run/responder/secrets.json` for the lossless JSON secret format. The fixed legacy `/run/responder/secrets.env` path remains supported for rollback compatibility.
- Redeploy workers so the versioned exclusive queues and abandoned-remediation recovery loop are active.

## Validation

- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm peers check`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test` — 98 files, 639 tests
- `pnpm build`
- `pnpm audit --audit-level=low` — no known vulnerabilities
- Dependency supply-chain policy verification passed
- PostgreSQL 17 applied all 25 migrations from scratch
- Seeded migration validation covered clean, conflicting, and missing legacy Linear workspace IDs while verifying credential retirement
- Required CI and static-analysis checks passed on the final head
