### PR TITLE
Fall back when repository archives are throttled

### DIFF
--- a/apps/worker/Dockerfile
+++ b/apps/worker/Dockerfile
@@ -3,6 +3,10 @@ FROM node:24-bookworm-slim
 ENV NODE_ENV=production
 ENV TSX_DISABLE_CACHE=1
 
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends git \
+  && rm -rf /var/lib/apt/lists/*
+
 RUN corepack enable
 
 WORKDIR /app

--- a/apps/worker/src/repositories.test.ts
+++ b/apps/worker/src/repositories.test.ts
@@ -75,6 +75,47 @@ describe("Daytona repository checkout", () => {
     );
   });
 
+  it("falls back to an exact Git fetch when the archive host rate limits", async () => {
+    const session = fakeSession();
+    const repository = {
+      defaultBranch: "main",
+      fullName: "example-org/example-repo",
+      installationId: 123,
+      private: true,
+    };
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ sha }), {
+          headers: { "content-type": "application/json" },
+          status: 200,
+        }),
+      )
+      .mockResolvedValueOnce(new Response("rate limited", { status: 429 }));
+    const downloadWithGit = vi
+      .fn()
+      .mockResolvedValue(new Uint8Array([31, 139, 8, 0]));
+
+    await expect(
+      checkoutRuntimeRepositories(session, "version-id", {
+        createInstallationToken: vi.fn().mockResolvedValue("github-secret"),
+        downloadWithGit,
+        fetch: fetchMock,
+        getRepositories: vi.fn().mockResolvedValue([repository]),
+      }),
+    ).resolves.toEqual([
+      expect.objectContaining({ repository: repository.fullName, sha }),
+    ]);
+    expect(downloadWithGit).toHaveBeenCalledWith(
+      repository,
+      "github-secret",
+      sha,
+    );
+    expect(JSON.stringify(vi.mocked(session.materializeEntry).mock.calls)).not.toContain(
+      "github-secret",
+    );
+  });
+
   it("rejects repository names that could escape the workspace", () => {
     expect(() => repositoryWorkspacePath("superlog/../../secret")).toThrow(
       "Invalid GitHub repository name",

--- a/apps/worker/src/repositories.ts
+++ b/apps/worker/src/repositories.ts
@@ -1,4 +1,9 @@
 import type { DaytonaSandboxSession } from "@openai/agents-extensions/sandbox/daytona";
+import { execFile } from "node:child_process";
+import { mkdtemp, mkdir, readFile, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
 import {
   getRuntimeRepositories,
   type RuntimeRepository,
@@ -9,6 +14,7 @@ import {
 } from "@responder/core/integrations/github";
 const maxArchiveBytes = 100 * 1024 * 1024;
 const workspaceRoot = "/home/daytona/workspace";
+const execFileAsync = promisify(execFile);
 
 export interface CheckedOutRepository {
   branch: string;
@@ -20,6 +26,11 @@ export interface CheckedOutRepository {
 
 export interface RepositoryCheckoutDependencies {
   createInstallationToken: (installationId: number) => Promise<string>;
+  downloadWithGit?: (
+    repository: RuntimeRepository,
+    accessToken: string,
+    sha: string,
+  ) => Promise<Uint8Array>;
   fetch: typeof fetch;
   getRepositories: (versionId: string) => Promise<RuntimeRepository[]>;
 }
@@ -29,6 +40,84 @@ const defaultDependencies: RepositoryCheckoutDependencies = {
   fetch,
   getRepositories: getRuntimeRepositories,
 };
+
+async function downloadRepositorySnapshotWithGit(
+  repository: RuntimeRepository,
+  accessToken: string,
+  sha: string,
+): Promise<Uint8Array> {
+  const temporaryRoot = await mkdtemp(join(tmpdir(), "responder-repository-"));
+  const gitDirectory = join(temporaryRoot, "repository.git");
+  const archivePath = join(temporaryRoot, "repository.tar.gz");
+  const gitEnvironment = {
+    ...process.env,
+    GIT_CONFIG_COUNT: "1",
+    GIT_CONFIG_KEY_0: "http.extraHeader",
+    GIT_CONFIG_VALUE_0: `Authorization: Bearer ${accessToken}`,
+    GIT_TERMINAL_PROMPT: "0",
+  };
+
+  try {
+    await mkdir(gitDirectory);
+    await execFileAsync("git", ["-C", gitDirectory, "init", "--bare", "--quiet"], {
+      timeout: 30_000,
+    });
+    await execFileAsync(
+      "git",
+      [
+        "-C",
+        gitDirectory,
+        "remote",
+        "add",
+        "origin",
+        `https://github.com/${repository.fullName}.git`,
+      ],
+      { timeout: 30_000 },
+    );
+    await execFileAsync(
+      "git",
+      [
+        "-C",
+        gitDirectory,
+        "fetch",
+        "--quiet",
+        "--depth=1",
+        "origin",
+        sha,
+      ],
+      { env: gitEnvironment, timeout: 120_000 },
+    );
+    await execFileAsync(
+      "git",
+      [
+        "-C",
+        gitDirectory,
+        "archive",
+        "--format=tar.gz",
+        `--output=${archivePath}`,
+        "FETCH_HEAD",
+      ],
+      { timeout: 120_000 },
+    );
+    const archiveStats = await stat(archivePath);
+    if (archiveStats.size > maxArchiveBytes) {
+      throw new Error("GitHub repository archive exceeds the 100 MB limit");
+    }
+    return new Uint8Array(await readFile(archivePath));
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      error.message === "GitHub repository archive exceeds the 100 MB limit"
+    ) {
+      throw error;
+    }
+    throw new Error(
+      `Unable to download ${repository.fullName}@${sha} using Git fallback`,
+    );
+  } finally {
+    await rm(temporaryRoot, { force: true, recursive: true });
+  }
+}
 
 function shellQuote(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`;
@@ -120,6 +209,9 @@ async function fetchRepositorySnapshot(
   repository: RuntimeRepository,
   accessToken: string,
   fetchImpl: typeof fetch,
+  downloadWithGit: NonNullable<
+    RepositoryCheckoutDependencies["downloadWithGit"]
+  >,
 ): Promise<{ archive: Uint8Array; sha: string }> {
   const headers = githubAppHeaders(accessToken);
   const branch = encodeURIComponent(repository.defaultBranch);
@@ -143,6 +235,13 @@ async function fetchRepositorySnapshot(
     { headers, signal: AbortSignal.timeout(60_000) },
   );
   if (!archiveResponse.ok) {
+    if (archiveResponse.status === 429) {
+      await archiveResponse.body?.cancel();
+      return {
+        archive: await downloadWithGit(repository, accessToken, sha),
+        sha,
+      };
+    }
     throw new Error(`Unable to download ${repository.fullName}@${sha}`);
   }
   return { archive: await readResponseWithLimit(archiveResponse), sha };
@@ -171,6 +270,7 @@ export async function checkoutRuntimeRepositories(
       repository,
       token,
       dependencies.fetch,
+      dependencies.downloadWithGit ?? downloadRepositorySnapshotWithGit,
     );
     const [owner, name] = safeRepositoryParts(repository.fullName);
     const destination = repositoryWorkspacePath(repository.fullName);


### PR DESCRIPTION
## Summary
- detect HTTP 429 responses from repository archive downloads
- fetch the already-resolved commit through bounded Git commands as a fallback
- keep installation credentials out of sandbox inputs and command arguments
- include Git in the worker image

## Production evidence
- repository and commit API requests return 200
- archive redirects resolve to codeload.github.com and return 429 across Hodor, Verso, and Waniwani
- ordinary Git transport remains available

## Validation
- 525 tests passed
- typecheck passed
- lint passed
- worker image built successfully and includes Git

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Falls back to a bounded Git fetch when GitHub repository archives return HTTP 429. Previously we always downloaded the archive; now we detect 429 and fetch the resolved commit with `git` to produce a tar.gz, without exposing installation tokens to sandbox inputs.

- Detects 429 from the archive host and cancels the response body before falling back.
- Adds `downloadRepositorySnapshotWithGit`: initializes a bare repo, fetches `sha` with `--depth=1`, and runs `git archive` to tar.gz; enforces a 100 MB limit and cleans up temp files.
- Injects `git` into the `apps/worker` image; sets timeouts for all Git commands.
- Keeps installation tokens out of command arguments and sandbox materialization.
- Introduces a `downloadWithGit` dependency for testing; adds a unit test covering the fallback and token handling.

**Rollout**
- Build and deploy the updated `apps/worker` image; no configuration or API changes.
- Ensure outbound HTTPS to `github.com` is allowed for Git fetch.

<sup>Written for commit 0de974cb1db533dfdf816681ad4b8a0fea998938. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/responder-oss/pull/34?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

