### PR TITLE
Harden throttled repository fallback

### DIFF
--- a/apps/worker/src/repositories.test.ts
+++ b/apps/worker/src/repositories.test.ts
@@ -94,7 +94,10 @@ describe("Daytona repository checkout", () => {
       .mockResolvedValueOnce(new Response("rate limited", { status: 429 }));
     const downloadWithGit = vi
       .fn()
-      .mockResolvedValue(new Uint8Array([31, 139, 8, 0]));
+      .mockResolvedValue({
+        archive: new Uint8Array([31, 139, 8, 0]),
+        sha,
+      });
 
     await expect(
       checkoutRuntimeRepositories(session, "version-id", {
@@ -113,6 +116,38 @@ describe("Daytona repository checkout", () => {
     );
     expect(JSON.stringify(vi.mocked(session.materializeEntry).mock.calls)).not.toContain(
       "github-secret",
+    );
+  });
+
+  it("falls back to Git when branch resolution is rate limited", async () => {
+    const session = fakeSession();
+    const repository = {
+      defaultBranch: "main",
+      fullName: "example-org/example-repo",
+      installationId: 123,
+      private: true,
+    };
+    const downloadWithGit = vi.fn().mockResolvedValue({
+      archive: new Uint8Array([31, 139, 8, 0]),
+      sha,
+    });
+
+    await expect(
+      checkoutRuntimeRepositories(session, "version-id", {
+        createInstallationToken: vi.fn().mockResolvedValue("github-secret"),
+        downloadWithGit,
+        fetch: vi
+          .fn<typeof fetch>()
+          .mockResolvedValue(new Response("rate limited", { status: 429 })),
+        getRepositories: vi.fn().mockResolvedValue([repository]),
+      }),
+    ).resolves.toEqual([
+      expect.objectContaining({ repository: repository.fullName, sha }),
+    ]);
+    expect(downloadWithGit).toHaveBeenCalledWith(
+      repository,
+      "github-secret",
+      repository.defaultBranch,
     );
   });
 

--- a/apps/worker/src/repositories.ts
+++ b/apps/worker/src/repositories.ts
@@ -29,8 +29,8 @@ export interface RepositoryCheckoutDependencies {
   downloadWithGit?: (
     repository: RuntimeRepository,
     accessToken: string,
-    sha: string,
-  ) => Promise<Uint8Array>;
+    ref: string,
+  ) => Promise<{ archive: Uint8Array; sha: string }>;
   fetch: typeof fetch;
   getRepositories: (versionId: string) => Promise<RuntimeRepository[]>;
 }
@@ -44,9 +44,13 @@ const defaultDependencies: RepositoryCheckoutDependencies = {
 async function downloadRepositorySnapshotWithGit(
   repository: RuntimeRepository,
   accessToken: string,
-  sha: string,
-): Promise<Uint8Array> {
-  const temporaryRoot = await mkdtemp(join(tmpdir(), "responder-repository-"));
+  ref: string,
+): Promise<{ archive: Uint8Array; sha: string }> {
+  const temporaryBase =
+    process.env.RESPONDER_REPOSITORY_TEMP_DIR ?? tmpdir();
+  const temporaryRoot = await mkdtemp(
+    join(temporaryBase, "responder-repository-"),
+  );
   const gitDirectory = join(temporaryRoot, "repository.git");
   const archivePath = join(temporaryRoot, "repository.tar.gz");
   const gitEnvironment = {
@@ -83,10 +87,19 @@ async function downloadRepositorySnapshotWithGit(
         "--quiet",
         "--depth=1",
         "origin",
-        sha,
+        ref,
       ],
       { env: gitEnvironment, timeout: 120_000 },
     );
+    const { stdout } = await execFileAsync(
+      "git",
+      ["-C", gitDirectory, "rev-parse", "FETCH_HEAD"],
+      { timeout: 30_000 },
+    );
+    const sha = stdout.trim();
+    if (!/^[a-f0-9]{40}$/i.test(sha)) {
+      throw new Error("Git returned an invalid repository commit");
+    }
     await execFileAsync(
       "git",
       [
@@ -103,7 +116,7 @@ async function downloadRepositorySnapshotWithGit(
     if (archiveStats.size > maxArchiveBytes) {
       throw new Error("GitHub repository archive exceeds the 100 MB limit");
     }
-    return new Uint8Array(await readFile(archivePath));
+    return { archive: new Uint8Array(await readFile(archivePath)), sha };
   } catch (error) {
     if (
       error instanceof Error &&
@@ -112,7 +125,7 @@ async function downloadRepositorySnapshotWithGit(
       throw error;
     }
     throw new Error(
-      `Unable to download ${repository.fullName}@${sha} using Git fallback`,
+      `Unable to download ${repository.fullName}@${ref} using Git fallback`,
     );
   } finally {
     await rm(temporaryRoot, { force: true, recursive: true });
@@ -220,6 +233,14 @@ async function fetchRepositorySnapshot(
     { headers, signal: AbortSignal.timeout(30_000) },
   );
   if (!commitResponse.ok) {
+    if (commitResponse.status === 429) {
+      await commitResponse.body?.cancel();
+      return downloadWithGit(
+        repository,
+        accessToken,
+        repository.defaultBranch,
+      );
+    }
     throw new Error(
       `Unable to resolve ${repository.fullName}@${repository.defaultBranch}`,
     );
@@ -237,10 +258,11 @@ async function fetchRepositorySnapshot(
   if (!archiveResponse.ok) {
     if (archiveResponse.status === 429) {
       await archiveResponse.body?.cancel();
-      return {
-        archive: await downloadWithGit(repository, accessToken, sha),
-        sha,
-      };
+      const fallback = await downloadWithGit(repository, accessToken, sha);
+      if (fallback.sha !== sha) {
+        throw new Error(`Git returned an unexpected commit for ${repository.fullName}`);
+      }
+      return fallback;
     }
     throw new Error(`Unable to download ${repository.fullName}@${sha}`);
   }


### PR DESCRIPTION
## Summary
- use the exact Git fallback when branch resolution itself is rate limited
- resolve and validate the fetched commit before archiving
- support a dedicated writable scratch directory while preserving a read-only worker root

## Production evidence
- Verso failed on branch resolution during the shared GitHub rate limit
- Waniwani reached the fallback but the worker correctly rejected writes to its read-only root filesystem

## Validation
- application tests: 640 passed
- application typecheck: passed
- application lint: passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extends the Git fallback to trigger when GitHub rate-limits branch resolution, not just archive download, and validates the fetched commit before archiving. Previously we fell back only on archive 429 and assumed a provided SHA; now we also fall back on commit resolution 429, compute and verify the SHA, and write to a configurable scratch directory to support a read-only worker root.

- Migration: Update `RepositoryCheckoutDependencies.downloadWithGit` to `(repository, accessToken, ref) => Promise<{ archive: Uint8Array; sha: string }>` and pass a branch or SHA as `ref`. Provide a writable `RESPONDER_REPOSITORY_TEMP_DIR` if the worker root is read-only.

<sup>Written for commit 06ce2a3598c17fd3a229b0c740d388d4d059920a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/responder-oss/pull/35?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

