### PR TITLE
Recover transient repository downloads

### DIFF
--- a/apps/worker/src/repositories.test.ts
+++ b/apps/worker/src/repositories.test.ts
@@ -75,51 +75,91 @@ describe("Daytona repository checkout", () => {
     );
   });
 
-  it("falls back to an exact Git fetch when the archive host rate limits", async () => {
-    const session = fakeSession();
-    const repository = {
-      defaultBranch: "main",
-      fullName: "example-org/example-repo",
-      installationId: 123,
-      private: true,
-    };
-    const fetchMock = vi
-      .fn<typeof fetch>()
-      .mockResolvedValueOnce(
-        new Response(JSON.stringify({ sha }), {
-          headers: { "content-type": "application/json" },
-          status: 200,
-        }),
-      )
-      .mockResolvedValueOnce(new Response("rate limited", { status: 429 }));
-    const downloadWithGit = vi
-      .fn()
-      .mockResolvedValue({
+  it.each([429, 503])(
+    "falls back to an exact Git fetch when the archive host returns %i",
+    async (status) => {
+      const session = fakeSession();
+      const repository = {
+        defaultBranch: "main",
+        fullName: "example-org/example-repo",
+        installationId: 123,
+        private: true,
+      };
+      const fetchMock = vi
+        .fn<typeof fetch>()
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify({ sha }), {
+            headers: { "content-type": "application/json" },
+            status: 200,
+          }),
+        )
+        .mockResolvedValueOnce(
+          new Response("temporarily unavailable", { status }),
+        );
+      const downloadWithGit = vi.fn().mockResolvedValue({
         archive: new Uint8Array([31, 139, 8, 0]),
         sha,
       });
 
-    await expect(
-      checkoutRuntimeRepositories(session, "version-id", {
-        createInstallationToken: vi.fn().mockResolvedValue("github-secret"),
-        downloadWithGit,
-        fetch: fetchMock,
-        getRepositories: vi.fn().mockResolvedValue([repository]),
-      }),
-    ).resolves.toEqual([
-      expect.objectContaining({ repository: repository.fullName, sha }),
-    ]);
-    expect(downloadWithGit).toHaveBeenCalledWith(
-      repository,
-      "github-secret",
-      sha,
-    );
-    expect(JSON.stringify(vi.mocked(session.materializeEntry).mock.calls)).not.toContain(
-      "github-secret",
-    );
-  });
+      await expect(
+        checkoutRuntimeRepositories(session, "version-id", {
+          createInstallationToken: vi.fn().mockResolvedValue("github-secret"),
+          downloadWithGit,
+          fetch: fetchMock,
+          getRepositories: vi.fn().mockResolvedValue([repository]),
+        }),
+      ).resolves.toEqual([
+        expect.objectContaining({ repository: repository.fullName, sha }),
+      ]);
+      expect(downloadWithGit).toHaveBeenCalledWith(
+        repository,
+        "github-secret",
+        sha,
+      );
+      expect(
+        JSON.stringify(vi.mocked(session.materializeEntry).mock.calls),
+      ).not.toContain("github-secret");
+    },
+  );
 
-  it("falls back to Git when branch resolution is rate limited", async () => {
+  it.each([429, 503])(
+    "falls back to Git when branch resolution returns %i",
+    async (status) => {
+      const session = fakeSession();
+      const repository = {
+        defaultBranch: "main",
+        fullName: "example-org/example-repo",
+        installationId: 123,
+        private: true,
+      };
+      const downloadWithGit = vi.fn().mockResolvedValue({
+        archive: new Uint8Array([31, 139, 8, 0]),
+        sha,
+      });
+
+      await expect(
+        checkoutRuntimeRepositories(session, "version-id", {
+          createInstallationToken: vi.fn().mockResolvedValue("github-secret"),
+          downloadWithGit,
+          fetch: vi
+            .fn<typeof fetch>()
+            .mockResolvedValue(
+              new Response("temporarily unavailable", { status }),
+            ),
+          getRepositories: vi.fn().mockResolvedValue([repository]),
+        }),
+      ).resolves.toEqual([
+        expect.objectContaining({ repository: repository.fullName, sha }),
+      ]);
+      expect(downloadWithGit).toHaveBeenCalledWith(
+        repository,
+        "github-secret",
+        repository.defaultBranch,
+      );
+    },
+  );
+
+  it("falls back to Git when branch resolution times out", async () => {
     const session = fakeSession();
     const repository = {
       defaultBranch: "main",
@@ -138,7 +178,7 @@ describe("Daytona repository checkout", () => {
         downloadWithGit,
         fetch: vi
           .fn<typeof fetch>()
-          .mockResolvedValue(new Response("rate limited", { status: 429 })),
+          .mockRejectedValue(new DOMException("Timed out", "AbortError")),
         getRepositories: vi.fn().mockResolvedValue([repository]),
       }),
     ).resolves.toEqual([
@@ -148,6 +188,45 @@ describe("Daytona repository checkout", () => {
       repository,
       "github-secret",
       repository.defaultBranch,
+    );
+  });
+
+  it("falls back to Git when the archive request times out", async () => {
+    const session = fakeSession();
+    const repository = {
+      defaultBranch: "main",
+      fullName: "example-org/example-repo",
+      installationId: 123,
+      private: true,
+    };
+    const downloadWithGit = vi.fn().mockResolvedValue({
+      archive: new Uint8Array([31, 139, 8, 0]),
+      sha,
+    });
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ sha }), {
+          headers: { "content-type": "application/json" },
+          status: 200,
+        }),
+      )
+      .mockRejectedValueOnce(new DOMException("Timed out", "AbortError"));
+
+    await expect(
+      checkoutRuntimeRepositories(session, "version-id", {
+        createInstallationToken: vi.fn().mockResolvedValue("github-secret"),
+        downloadWithGit,
+        fetch: fetchMock,
+        getRepositories: vi.fn().mockResolvedValue([repository]),
+      }),
+    ).resolves.toEqual([
+      expect.objectContaining({ repository: repository.fullName, sha }),
+    ]);
+    expect(downloadWithGit).toHaveBeenCalledWith(
+      repository,
+      "github-secret",
+      sha,
     );
   });
 

--- a/apps/worker/src/repositories.ts
+++ b/apps/worker/src/repositories.ts
@@ -218,6 +218,31 @@ async function readResponseWithLimit(
   return archive;
 }
 
+function shouldUseGitFallback(response: Response): boolean {
+  return (
+    response.status === 429 ||
+    response.status >= 500 ||
+    (response.status === 403 &&
+      (response.headers.has("retry-after") ||
+        response.headers.get("x-ratelimit-remaining") === "0"))
+  );
+}
+
+async function downloadExactSnapshotWithGit(
+  repository: RuntimeRepository,
+  accessToken: string,
+  sha: string,
+  downloadWithGit: NonNullable<
+    RepositoryCheckoutDependencies["downloadWithGit"]
+  >,
+): Promise<{ archive: Uint8Array; sha: string }> {
+  const fallback = await downloadWithGit(repository, accessToken, sha);
+  if (fallback.sha !== sha) {
+    throw new Error(`Git returned an unexpected commit for ${repository.fullName}`);
+  }
+  return fallback;
+}
+
 async function fetchRepositorySnapshot(
   repository: RuntimeRepository,
   accessToken: string,
@@ -228,12 +253,17 @@ async function fetchRepositorySnapshot(
 ): Promise<{ archive: Uint8Array; sha: string }> {
   const headers = githubAppHeaders(accessToken);
   const branch = encodeURIComponent(repository.defaultBranch);
-  const commitResponse = await fetchImpl(
-    `https://api.github.com/repos/${repository.fullName}/commits/${branch}`,
-    { headers, signal: AbortSignal.timeout(30_000) },
-  );
+  let commitResponse: Response;
+  try {
+    commitResponse = await fetchImpl(
+      `https://api.github.com/repos/${repository.fullName}/commits/${branch}`,
+      { headers, signal: AbortSignal.timeout(30_000) },
+    );
+  } catch {
+    return downloadWithGit(repository, accessToken, repository.defaultBranch);
+  }
   if (!commitResponse.ok) {
-    if (commitResponse.status === 429) {
+    if (shouldUseGitFallback(commitResponse)) {
       await commitResponse.body?.cancel();
       return downloadWithGit(
         repository,
@@ -251,18 +281,29 @@ async function fetchRepositorySnapshot(
     throw new Error(`GitHub returned an invalid commit for ${repository.fullName}`);
   }
 
-  const archiveResponse = await fetchImpl(
-    `https://api.github.com/repos/${repository.fullName}/tarball/${sha}`,
-    { headers, signal: AbortSignal.timeout(60_000) },
-  );
+  let archiveResponse: Response;
+  try {
+    archiveResponse = await fetchImpl(
+      `https://api.github.com/repos/${repository.fullName}/tarball/${sha}`,
+      { headers, signal: AbortSignal.timeout(60_000) },
+    );
+  } catch {
+    return downloadExactSnapshotWithGit(
+      repository,
+      accessToken,
+      sha,
+      downloadWithGit,
+    );
+  }
   if (!archiveResponse.ok) {
-    if (archiveResponse.status === 429) {
+    if (shouldUseGitFallback(archiveResponse)) {
       await archiveResponse.body?.cancel();
-      const fallback = await downloadWithGit(repository, accessToken, sha);
-      if (fallback.sha !== sha) {
-        throw new Error(`Git returned an unexpected commit for ${repository.fullName}`);
-      }
-      return fallback;
+      return downloadExactSnapshotWithGit(
+        repository,
+        accessToken,
+        sha,
+        downloadWithGit,
+      );
     }
     throw new Error(`Unable to download ${repository.fullName}@${sha}`);
   }


### PR DESCRIPTION
## Summary

- fall back to authenticated Git fetch when GitHub commit or archive requests time out
- treat throttling, rate-limit responses, and 5xx responses as transient
- preserve exact-SHA verification for archive fallbacks

## Root cause

Production repository downloads intermittently returned non-429 transient failures from GitHub's commit and codeload paths. The existing fallback handled only HTTP 429, so investigations and remediations stopped even though authenticated Git fetch remained available.

## Validation

- `pnpm exec vitest run apps/worker/src/repositories.test.ts`
- `pnpm --filter @responder/worker typecheck`
- `pnpm exec eslint apps/worker/src/repositories.ts apps/worker/src/repositories.test.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recovers repository downloads by falling back to authenticated Git when GitHub commit or archive requests fail transiently. Previously we only fell back on 429; now we also handle timeouts, 5xx, and throttled 403s, while preserving exact-SHA verification for archive fallbacks.

- Expand fallback conditions for both commit lookup and archive download: 429, >=500, 403 with retry hints (`retry-after` or `x-ratelimit-remaining: 0`), and request timeouts.
- Commit-lookup fallbacks use the branch name; archive fallbacks require an exact SHA match via `downloadExactSnapshotWithGit`.
- Add tests for 429/503 and timeout paths; assert we do not leak installation tokens.
- Internal refactor (`shouldUseGitFallback`); no external API or config changes; no migration required.

<sup>Written for commit 89d800a783dac2d06b9367322fa18c034e084b34. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/responder-oss/pull/36?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

