### PR TITLE
Fix Sentry connection health and reconnect

### DIFF
--- a/apps/control-plane/server/integrations/routes.test.ts
+++ b/apps/control-plane/server/integrations/routes.test.ts
@@ -13,6 +13,7 @@ import {
   listConnectedSentryIntegrationAccounts,
   listOrganizationIntegrationAccounts,
   replaceIntegrationResources,
+  replaceIntegrationResourcesIfCredentialsMatch,
   setIntegrationAccountStatus,
   setIntegrationAccountStatusIfCredentialsMatch,
   updateIntegrationAccountCredentials,
@@ -61,6 +62,7 @@ vi.mock("../../../../packages/core/src/db/integrations.js", () => ({
   listConnectedSentryIntegrationAccounts: vi.fn(),
   listOrganizationIntegrationAccounts: vi.fn(),
   replaceIntegrationResources: vi.fn(),
+  replaceIntegrationResourcesIfCredentialsMatch: vi.fn(),
   replaceRepositories: vi.fn(),
   setIntegrationAccountStatus: vi.fn(),
   setIntegrationAccountStatusIfCredentialsMatch: vi.fn(),
@@ -130,6 +132,9 @@ function configureGitHub() {
 describe("integration callback routing", () => {
   beforeEach(() => {
     vi.mocked(getActiveTenant).mockResolvedValue(tenant);
+    vi.mocked(replaceIntegrationResourcesIfCredentialsMatch).mockResolvedValue(
+      true,
+    );
     vi.mocked(withIntegrationAccountCredentialLease).mockImplementation(
       async (input) => {
         const result = await input.operation("encrypted-credentials");
@@ -258,10 +263,13 @@ describe("integration callback routing", () => {
         },
       ],
     });
-    expect(replaceIntegrationResources).toHaveBeenCalledWith(
-      "30000000-0000-4000-8000-000000000000",
-      "sentry_project",
-      [
+    expect(replaceIntegrationResourcesIfCredentialsMatch).toHaveBeenCalledWith({
+      encryptedCredentials: "encrypted-credentials",
+      integrationAccountId: "30000000-0000-4000-8000-000000000000",
+      kind: "sentry_project",
+      organizationId: tenant.organizationId,
+      provider: "sentry",
+      resources: [
         {
           displayName: "Backend",
           externalId: "1",
@@ -272,7 +280,48 @@ describe("integration callback routing", () => {
           },
         },
       ],
+    });
+  });
+
+  it("discards a Sentry check superseded by reconnect", async () => {
+    vi.mocked(listConnectedSentryIntegrationAccounts).mockResolvedValue([
+      {
+        id: "30000000-0000-4000-8000-000000000000",
+        encryptedCredentials: "encrypted-credentials",
+        metadata: { organizationSlug: "example" },
+      },
+    ]);
+    vi.mocked(decryptCredentials).mockReturnValue({
+      accessToken: "sentry-token",
+      expiresAt: "2099-01-01T00:00:00.000Z",
+      installationId: "40000000-0000-4000-8000-000000000000",
+      refreshToken: "sentry-refresh-token",
+    });
+    vi.mocked(replaceIntegrationResourcesIfCredentialsMatch).mockResolvedValue(
+      false,
     );
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        Response.json([
+          { id: "1", name: "Backend", platform: "node", slug: "backend" },
+        ]),
+      ),
+    );
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const response = await app.request("/api/integrations/sentry/check", {
+      method: "POST",
+    });
+
+    expect(await response.json()).toEqual({
+      accounts: [
+        {
+          id: "30000000-0000-4000-8000-000000000000",
+          status: "unavailable",
+        },
+      ],
+    });
   });
 
   it("marks a Sentry account for reconnect after a live authorization failure", async () => {

--- a/apps/control-plane/server/integrations/routes.test.ts
+++ b/apps/control-plane/server/integrations/routes.test.ts
@@ -10,6 +10,7 @@ import {
   getOrganizationIntegrationAccount,
   getOrganizationIntegrationAccountByExternalId,
   getRecoverableSentryIntegrationAccount,
+  listConnectedSentryIntegrationAccounts,
   listOrganizationIntegrationAccounts,
   replaceIntegrationResources,
   setIntegrationAccountStatus,
@@ -55,6 +56,7 @@ vi.mock("../../../../packages/core/src/db/integrations.js", () => ({
   getOrganizationIntegrationAccount: vi.fn(),
   getOrganizationIntegrationAccountByExternalId: vi.fn(),
   getRecoverableSentryIntegrationAccount: vi.fn(),
+  listConnectedSentryIntegrationAccounts: vi.fn(),
   listOrganizationIntegrationAccounts: vi.fn(),
   replaceIntegrationResources: vi.fn(),
   replaceRepositories: vi.fn(),
@@ -159,6 +161,172 @@ describe("integration callback routing", () => {
       returnTo: undefined,
       routingUrl: "https://responder.example/api/integrations/sentry/callback",
     });
+  });
+
+  it("starts a fresh Sentry authorization when reconnecting", async () => {
+    vi.stubEnv("BETTER_AUTH_URL", "https://responder.example");
+    vi.stubEnv("SENTRY_APP_SLUG", "responder-test");
+    vi.stubEnv("SENTRY_CLIENT_ID", "sentry-client");
+    vi.stubEnv("SENTRY_CLIENT_SECRET", "sentry-secret");
+    vi.mocked(createIntegrationConnectionState).mockResolvedValue("fresh-state");
+
+    const response = await app.request(
+      "/api/integrations/sentry/start?mode=reconnect",
+    );
+
+    expect(response.status).toBe(302);
+    expect(new URL(response.headers.get("location")!).searchParams.get("state"))
+      .toBe("fresh-state");
+    expect(getRecoverableSentryIntegrationAccount).not.toHaveBeenCalled();
+  });
+
+  it("falls back to fresh Sentry authorization when an old retry fails", async () => {
+    vi.stubEnv("BETTER_AUTH_URL", "https://responder.example");
+    vi.stubEnv("SENTRY_APP_SLUG", "responder-test");
+    vi.stubEnv("SENTRY_CLIENT_ID", "sentry-client");
+    vi.stubEnv("SENTRY_CLIENT_SECRET", "sentry-secret");
+    vi.mocked(getRecoverableSentryIntegrationAccount).mockResolvedValue({
+      id: "30000000-0000-4000-8000-000000000000",
+      encryptedCredentials: "broken-credentials",
+      externalAccountId: "40000000-0000-4000-8000-000000000000",
+      metadata: { organizationSlug: "example" },
+    });
+    vi.mocked(decryptCredentials).mockImplementation(() => {
+      throw new Error("cannot decrypt");
+    });
+    vi.mocked(createIntegrationConnectionState).mockResolvedValue("fresh-state");
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const response = await app.request("/api/integrations/sentry/start");
+
+    expect(response.status).toBe(302);
+    expect(new URL(response.headers.get("location")!).searchParams.get("state"))
+      .toBe("fresh-state");
+    expect(setIntegrationAccountStatus).toHaveBeenCalledWith(
+      "30000000-0000-4000-8000-000000000000",
+      "error",
+    );
+  });
+
+  it("checks a connected Sentry account against the live projects API", async () => {
+    vi.mocked(listConnectedSentryIntegrationAccounts).mockResolvedValue([
+      {
+        id: "30000000-0000-4000-8000-000000000000",
+        encryptedCredentials: "encrypted-credentials",
+        metadata: { organizationSlug: "example" },
+      },
+    ]);
+    vi.mocked(decryptCredentials).mockReturnValue({
+      accessToken: "sentry-token",
+      expiresAt: "2099-01-01T00:00:00.000Z",
+      installationId: "40000000-0000-4000-8000-000000000000",
+      refreshToken: "sentry-refresh-token",
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        Response.json([
+          { id: "1", name: "Backend", platform: "node", slug: "backend" },
+        ]),
+      ),
+    );
+
+    const response = await app.request("/api/integrations/sentry/check", {
+      method: "POST",
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      accounts: [
+        {
+          id: "30000000-0000-4000-8000-000000000000",
+          resourceCount: 1,
+          status: "working",
+        },
+      ],
+    });
+    expect(replaceIntegrationResources).toHaveBeenCalledWith(
+      "30000000-0000-4000-8000-000000000000",
+      "sentry_project",
+      [
+        {
+          displayName: "Backend",
+          externalId: "1",
+          metadata: {
+            organizationSlug: "example",
+            platform: "node",
+            slug: "backend",
+          },
+        },
+      ],
+    );
+  });
+
+  it("marks a Sentry account for reconnect after a live authorization failure", async () => {
+    vi.mocked(listConnectedSentryIntegrationAccounts).mockResolvedValue([
+      {
+        id: "30000000-0000-4000-8000-000000000000",
+        encryptedCredentials: "encrypted-credentials",
+        metadata: { organizationSlug: "example" },
+      },
+    ]);
+    vi.mocked(decryptCredentials).mockReturnValue({
+      accessToken: "expired-token",
+      expiresAt: "2099-01-01T00:00:00.000Z",
+      installationId: "40000000-0000-4000-8000-000000000000",
+      refreshToken: "expired-refresh-token",
+    });
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(null, { status: 401 })));
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const response = await app.request("/api/integrations/sentry/check", {
+      method: "POST",
+    });
+
+    expect(await response.json()).toEqual({
+      accounts: [
+        {
+          id: "30000000-0000-4000-8000-000000000000",
+          status: "needs_reconnect",
+        },
+      ],
+    });
+    expect(setIntegrationAccountStatus).toHaveBeenCalledWith(
+      "30000000-0000-4000-8000-000000000000",
+      "error",
+    );
+  });
+
+  it("does not mark a Sentry account broken during a temporary API failure", async () => {
+    vi.mocked(listConnectedSentryIntegrationAccounts).mockResolvedValue([
+      {
+        id: "30000000-0000-4000-8000-000000000000",
+        encryptedCredentials: "encrypted-credentials",
+        metadata: { organizationSlug: "example" },
+      },
+    ]);
+    vi.mocked(decryptCredentials).mockReturnValue({
+      accessToken: "sentry-token",
+      expiresAt: "2099-01-01T00:00:00.000Z",
+      installationId: "40000000-0000-4000-8000-000000000000",
+      refreshToken: "sentry-refresh-token",
+    });
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(null, { status: 503 })));
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const response = await app.request("/api/integrations/sentry/check", {
+      method: "POST",
+    });
+
+    expect(await response.json()).toEqual({
+      accounts: [
+        {
+          id: "30000000-0000-4000-8000-000000000000",
+          status: "unavailable",
+        },
+      ],
+    });
+    expect(setIntegrationAccountStatus).not.toHaveBeenCalled();
   });
 
   it("starts Vercel's external installation flow with tenant state", async () => {
@@ -650,6 +818,35 @@ describe("integration callback routing", () => {
         id: "github",
         connectUrl: "/api/integrations/github/start",
         configurationUrl: "/api/integrations/github/start?mode=install",
+      }),
+    );
+  });
+
+  it("offers a fresh Sentry reconnect when an account already exists", async () => {
+    vi.stubEnv("SENTRY_APP_SLUG", "responder-test");
+    vi.stubEnv("SENTRY_CLIENT_ID", "sentry-client");
+    vi.stubEnv("SENTRY_CLIENT_SECRET", "sentry-secret");
+    vi.mocked(listOrganizationIntegrationAccounts).mockResolvedValue([
+      {
+        id: "30000000-0000-4000-8000-000000000000",
+        provider: "sentry",
+        externalAccountId: "40000000-0000-4000-8000-000000000000",
+        displayName: "example",
+        status: "error",
+        metadata: { organizationSlug: "example" },
+        updatedAt: new Date("2026-08-18T08:38:21Z"),
+        resourceCount: 2,
+      },
+    ]);
+
+    const response = await app.request("/api/integrations");
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.integrations).toContainEqual(
+      expect.objectContaining({
+        id: "sentry",
+        connectUrl: "/api/integrations/sentry/start?mode=reconnect",
       }),
     );
   });

--- a/apps/control-plane/server/integrations/routes.test.ts
+++ b/apps/control-plane/server/integrations/routes.test.ts
@@ -14,9 +14,10 @@ import {
   listOrganizationIntegrationAccounts,
   replaceIntegrationResources,
   setIntegrationAccountStatus,
+  setIntegrationAccountStatusIfCredentialsMatch,
   updateIntegrationAccountCredentials,
   upsertIntegrationAccount,
-  withLockedIntegrationAccountCredentials,
+  withIntegrationAccountCredentialLease,
 } from "../../../../packages/core/src/db/integrations.js";
 import {
   createAwsCloudFormationTemplateUrl,
@@ -62,9 +63,10 @@ vi.mock("../../../../packages/core/src/db/integrations.js", () => ({
   replaceIntegrationResources: vi.fn(),
   replaceRepositories: vi.fn(),
   setIntegrationAccountStatus: vi.fn(),
+  setIntegrationAccountStatusIfCredentialsMatch: vi.fn(),
   updateIntegrationAccountCredentials: vi.fn(),
   upsertIntegrationAccount: vi.fn(),
-  withLockedIntegrationAccountCredentials: vi.fn(),
+  withIntegrationAccountCredentialLease: vi.fn(),
 }));
 
 vi.mock("../../../../packages/core/src/integrations/aws.js", async (importOriginal) => {
@@ -128,7 +130,7 @@ function configureGitHub() {
 describe("integration callback routing", () => {
   beforeEach(() => {
     vi.mocked(getActiveTenant).mockResolvedValue(tenant);
-    vi.mocked(withLockedIntegrationAccountCredentials).mockImplementation(
+    vi.mocked(withIntegrationAccountCredentialLease).mockImplementation(
       async (input) => {
         const result = await input.operation("encrypted-credentials");
         return result.value;
@@ -210,10 +212,13 @@ describe("integration callback routing", () => {
     expect(response.status).toBe(302);
     expect(new URL(response.headers.get("location")!).searchParams.get("state"))
       .toBe("fresh-state");
-    expect(setIntegrationAccountStatus).toHaveBeenCalledWith(
-      "30000000-0000-4000-8000-000000000000",
-      "error",
-    );
+    expect(setIntegrationAccountStatusIfCredentialsMatch).toHaveBeenCalledWith({
+      encryptedCredentials: "broken-credentials",
+      integrationAccountId: "30000000-0000-4000-8000-000000000000",
+      organizationId: tenant.organizationId,
+      provider: "sentry",
+      status: "error",
+    });
   });
 
   it("checks a connected Sentry account against the live projects API", async () => {
@@ -299,10 +304,13 @@ describe("integration callback routing", () => {
         },
       ],
     });
-    expect(setIntegrationAccountStatus).toHaveBeenCalledWith(
-      "30000000-0000-4000-8000-000000000000",
-      "error",
-    );
+    expect(setIntegrationAccountStatusIfCredentialsMatch).toHaveBeenCalledWith({
+      encryptedCredentials: "encrypted-credentials",
+      integrationAccountId: "30000000-0000-4000-8000-000000000000",
+      organizationId: tenant.organizationId,
+      provider: "sentry",
+      status: "error",
+    });
   });
 
   it("does not mark a Sentry account broken during a temporary API failure", async () => {
@@ -334,7 +342,7 @@ describe("integration callback routing", () => {
         },
       ],
     });
-    expect(setIntegrationAccountStatus).not.toHaveBeenCalled();
+    expect(setIntegrationAccountStatusIfCredentialsMatch).not.toHaveBeenCalled();
   });
 
   it("starts Vercel's external installation flow with tenant state", async () => {

--- a/apps/control-plane/server/integrations/routes.test.ts
+++ b/apps/control-plane/server/integrations/routes.test.ts
@@ -16,6 +16,7 @@ import {
   setIntegrationAccountStatus,
   updateIntegrationAccountCredentials,
   upsertIntegrationAccount,
+  withLockedIntegrationAccountCredentials,
 } from "../../../../packages/core/src/db/integrations.js";
 import {
   createAwsCloudFormationTemplateUrl,
@@ -63,6 +64,7 @@ vi.mock("../../../../packages/core/src/db/integrations.js", () => ({
   setIntegrationAccountStatus: vi.fn(),
   updateIntegrationAccountCredentials: vi.fn(),
   upsertIntegrationAccount: vi.fn(),
+  withLockedIntegrationAccountCredentials: vi.fn(),
 }));
 
 vi.mock("../../../../packages/core/src/integrations/aws.js", async (importOriginal) => {
@@ -126,6 +128,12 @@ function configureGitHub() {
 describe("integration callback routing", () => {
   beforeEach(() => {
     vi.mocked(getActiveTenant).mockResolvedValue(tenant);
+    vi.mocked(withLockedIntegrationAccountCredentials).mockImplementation(
+      async (input) => {
+        const result = await input.operation("encrypted-credentials");
+        return result.value;
+      },
+    );
   });
 
   afterEach(() => {

--- a/apps/control-plane/server/integrations/routes.ts
+++ b/apps/control-plane/server/integrations/routes.ts
@@ -18,6 +18,7 @@ import {
   setIntegrationAccountStatus,
   updateIntegrationAccountCredentials,
   upsertIntegrationAccount,
+  withLockedIntegrationAccountCredentials,
 } from "../../../../packages/core/src/db/integrations.js";
 import { disableAgentsWithUnavailableRepositories } from "../../../../packages/core/src/db/agents.js";
 import {
@@ -77,6 +78,7 @@ import {
   listSentryProjects,
   refreshSentryGrant,
   SentryApiError,
+  sentryErrorNeedsReconnect,
   sentryInstallUrl,
   verifySentryInstallation,
 } from "./sentry.js";
@@ -394,7 +396,7 @@ async function retrySentrySetup(organizationId: string): Promise<{
   try {
     const credentials = await getFreshSentryCredentials({
       accountId: account.id,
-      encryptedCredentials: account.encryptedCredentials,
+      allowedStatuses: ["connected", "error", "pending"],
       organizationId,
     });
     const organizationSlug = getSentryOrganizationSlug(account.metadata);
@@ -413,42 +415,48 @@ async function retrySentrySetup(organizationId: string): Promise<{
 
 async function getFreshSentryCredentials(input: {
   accountId: string;
-  encryptedCredentials: string;
+  allowedStatuses?: Array<"connected" | "error" | "pending">;
   organizationId: string;
 }) {
-  let credentials: z.infer<typeof sentryCredentialsSchema>;
-  try {
-    credentials = sentryCredentialsSchema.parse(
-      decryptCredentials<Record<string, unknown>>(input.encryptedCredentials),
-    );
-  } catch {
-    throw new StoredSentryConnectionError();
-  }
-  const expiresAt = credentials.expiresAt
-    ? Date.parse(credentials.expiresAt)
-    : Number.POSITIVE_INFINITY;
-  if (Number.isFinite(expiresAt) && expiresAt > Date.now() + 60_000) {
-    return credentials;
-  }
-
-  const authorization = await refreshSentryGrant({
-    installationId: credentials.installationId,
-    refreshToken: credentials.refreshToken,
-  });
-  credentials = {
-    accessToken: authorization.token,
-    expiresAt: authorization.expiresAt ?? null,
-    installationId: credentials.installationId,
-    refreshToken: authorization.refreshToken,
-  };
-  const updated = await updateIntegrationAccountCredentials({
-    encryptedCredentials: encryptCredentials(credentials),
+  const credentials = await withLockedIntegrationAccountCredentials({
+    allowedStatuses: input.allowedStatuses ?? ["connected"],
     integrationAccountId: input.accountId,
     organizationId: input.organizationId,
+    operation: async (encryptedCredentials) => {
+      let current: z.infer<typeof sentryCredentialsSchema>;
+      try {
+        current = sentryCredentialsSchema.parse(
+          decryptCredentials<Record<string, unknown>>(encryptedCredentials),
+        );
+      } catch {
+        throw new StoredSentryConnectionError();
+      }
+      const expiresAt = current.expiresAt
+        ? Date.parse(current.expiresAt)
+        : Number.POSITIVE_INFINITY;
+      if (Number.isFinite(expiresAt) && expiresAt > Date.now() + 60_000) {
+        return { value: current };
+      }
+
+      const authorization = await refreshSentryGrant({
+        installationId: current.installationId,
+        refreshToken: current.refreshToken,
+      });
+      const refreshed = {
+        accessToken: authorization.token,
+        expiresAt: authorization.expiresAt ?? null,
+        installationId: current.installationId,
+        refreshToken: authorization.refreshToken,
+      };
+      return {
+        encryptedCredentials: encryptCredentials(refreshed),
+        status: "connected" as const,
+        value: refreshed,
+      };
+    },
     provider: "sentry",
-    status: "connected",
   });
-  if (!updated) throw new Error("Sentry connection was not updated");
+  if (!credentials) throw new StoredSentryConnectionError();
   return credentials;
 }
 
@@ -551,7 +559,6 @@ export const integrationRoutes = new Hono()
           }
           const credentials = await getFreshSentryCredentials({
             accountId: account.id,
-            encryptedCredentials: account.encryptedCredentials,
             organizationId: tenant.organizationId,
           });
           const organizationSlug = getSentryOrganizationSlug(account.metadata);
@@ -573,8 +580,7 @@ export const integrationRoutes = new Hono()
         } catch (error) {
           const needsReconnect =
             error instanceof StoredSentryConnectionError ||
-            (error instanceof SentryApiError &&
-              (error.httpStatus === 401 || error.httpStatus === 403));
+            sentryErrorNeedsReconnect(error);
           if (needsReconnect) {
             await setIntegrationAccountStatus(account.id, "error");
           }

--- a/apps/control-plane/server/integrations/routes.ts
+++ b/apps/control-plane/server/integrations/routes.ts
@@ -11,6 +11,7 @@ import {
   getOrganizationIntegrationAccount,
   getOrganizationIntegrationAccountByExternalId,
   getRecoverableSentryIntegrationAccount,
+  listConnectedSentryIntegrationAccounts,
   listOrganizationIntegrationAccounts,
   replaceIntegrationResources,
   replaceRepositories,
@@ -74,6 +75,8 @@ import {
 import {
   exchangeSentryGrant,
   listSentryProjects,
+  refreshSentryGrant,
+  SentryApiError,
   sentryInstallUrl,
   verifySentryInstallation,
 } from "./sentry.js";
@@ -123,8 +126,25 @@ function recoverAwsConnectionCredentials(encryptedCredentials: string) {
 }
 const sentryCredentialsSchema = z.object({
   accessToken: z.string().min(1),
+  expiresAt: z.string().nullable().optional(),
   installationId: z.uuid(),
+  refreshToken: z.string().min(1),
 });
+
+class StoredSentryConnectionError extends Error {
+  constructor() {
+    super("Stored Sentry connection is invalid");
+    this.name = "StoredSentryConnectionError";
+  }
+}
+
+function getSentryOrganizationSlug(metadata: Record<string, unknown>): string {
+  try {
+    return z.string().min(1).parse(metadata.organizationSlug);
+  } catch {
+    throw new StoredSentryConnectionError();
+  }
+}
 const datadogConnectionSchema = z.object({
   apiKey: z.string().trim().min(1).max(512),
   applicationKey: z.string().trim().min(1).max(512),
@@ -229,12 +249,16 @@ function logCallbackError(
   context?: Record<string, unknown>,
 ): void {
   const message = error instanceof Error ? error.message : "Unknown integration error";
+  const httpStatus = error instanceof SentryApiError
+    ? error.httpStatus
+    : undefined;
   if (context) {
     console.error(
       JSON.stringify({
         ...context,
         error: message,
         event: "integration_callback_failed",
+        ...(httpStatus ? { httpStatus } : {}),
         provider: provider.toLowerCase(),
       }),
     );
@@ -243,6 +267,7 @@ function logCallbackError(
       JSON.stringify({
         error: message,
         event: "integration_callback_failed",
+        ...(httpStatus ? { httpStatus } : {}),
         provider: provider.toLowerCase(),
       }),
     );
@@ -366,14 +391,13 @@ async function retrySentrySetup(organizationId: string): Promise<{
 } | null> {
   const account = await getRecoverableSentryIntegrationAccount(organizationId);
   if (!account?.encryptedCredentials) return null;
-  const credentials = sentryCredentialsSchema.parse(
-    decryptCredentials<Record<string, unknown>>(account.encryptedCredentials),
-  );
-  const organizationSlug = z
-    .string()
-    .min(1)
-    .parse(account.metadata.organizationSlug);
   try {
+    const credentials = await getFreshSentryCredentials({
+      accountId: account.id,
+      encryptedCredentials: account.encryptedCredentials,
+      organizationId,
+    });
+    const organizationSlug = getSentryOrganizationSlug(account.metadata);
     const resourceCount = await completeSentrySetup({
       accessToken: credentials.accessToken,
       accountId: account.id,
@@ -385,6 +409,47 @@ async function retrySentrySetup(organizationId: string): Promise<{
     await setIntegrationAccountStatus(account.id, "error");
     throw error;
   }
+}
+
+async function getFreshSentryCredentials(input: {
+  accountId: string;
+  encryptedCredentials: string;
+  organizationId: string;
+}) {
+  let credentials: z.infer<typeof sentryCredentialsSchema>;
+  try {
+    credentials = sentryCredentialsSchema.parse(
+      decryptCredentials<Record<string, unknown>>(input.encryptedCredentials),
+    );
+  } catch {
+    throw new StoredSentryConnectionError();
+  }
+  const expiresAt = credentials.expiresAt
+    ? Date.parse(credentials.expiresAt)
+    : Number.POSITIVE_INFINITY;
+  if (Number.isFinite(expiresAt) && expiresAt > Date.now() + 60_000) {
+    return credentials;
+  }
+
+  const authorization = await refreshSentryGrant({
+    installationId: credentials.installationId,
+    refreshToken: credentials.refreshToken,
+  });
+  credentials = {
+    accessToken: authorization.token,
+    expiresAt: authorization.expiresAt ?? null,
+    installationId: credentials.installationId,
+    refreshToken: authorization.refreshToken,
+  };
+  const updated = await updateIntegrationAccountCredentials({
+    encryptedCredentials: encryptCredentials(credentials),
+    integrationAccountId: input.accountId,
+    organizationId: input.organizationId,
+    provider: "sentry",
+    status: "connected",
+  });
+  if (!updated) throw new Error("Sentry connection was not updated");
+  return credentials;
 }
 
 export const integrationRoutes = new Hono()
@@ -450,6 +515,8 @@ export const integrationRoutes = new Hono()
                   ? "/api/integrations/custom-mcp/connect"
                 : definition.id === "github" && providerAccounts.length === 0
                   ? "/api/integrations/github/start?mode=install"
+                : definition.id === "sentry" && providerAccounts.length > 0
+                  ? "/api/integrations/sentry/start?mode=reconnect"
                   : `/api/integrations/${definition.id}/start`
               : null,
           configurationUrl:
@@ -467,6 +534,74 @@ export const integrationRoutes = new Hono()
       "content-type": "application/yaml; charset=utf-8",
     }),
   )
+  .post("/sentry/check", async (context) => {
+    const tenant = await getActiveTenant(context.req.raw.headers);
+    if (tenant.ok === false) {
+      return context.json({ error: tenant.error }, tenant.status);
+    }
+
+    const accounts = await listConnectedSentryIntegrationAccounts(
+      tenant.organizationId,
+    );
+    const checkedAccounts = await Promise.all(
+      accounts.map(async (account) => {
+        try {
+          if (!account.encryptedCredentials) {
+            throw new StoredSentryConnectionError();
+          }
+          const credentials = await getFreshSentryCredentials({
+            accountId: account.id,
+            encryptedCredentials: account.encryptedCredentials,
+            organizationId: tenant.organizationId,
+          });
+          const organizationSlug = getSentryOrganizationSlug(account.metadata);
+          const projects = await listSentryProjects(
+            credentials.accessToken,
+            organizationSlug,
+          );
+          await replaceIntegrationResources(
+            account.id,
+            "sentry_project",
+            projects,
+          );
+          await setIntegrationAccountStatus(account.id, "connected");
+          return {
+            id: account.id,
+            resourceCount: projects.length,
+            status: "working" as const,
+          };
+        } catch (error) {
+          const needsReconnect =
+            error instanceof StoredSentryConnectionError ||
+            (error instanceof SentryApiError &&
+              (error.httpStatus === 401 || error.httpStatus === 403));
+          if (needsReconnect) {
+            await setIntegrationAccountStatus(account.id, "error");
+          }
+          console.error(
+            JSON.stringify({
+              error: error instanceof Error ? error.message : "Unknown error",
+              event: "sentry_connection_check_failed",
+              ...(error instanceof SentryApiError
+                ? { httpStatus: error.httpStatus }
+                : {}),
+              integrationAccountId: account.id,
+              organizationId: tenant.organizationId,
+              status: needsReconnect ? "needs_reconnect" : "unavailable",
+            }),
+          );
+          return {
+            id: account.id,
+            status: needsReconnect
+              ? "needs_reconnect" as const
+              : "unavailable" as const,
+          };
+        }
+      }),
+    );
+
+    return context.json({ accounts: checkedAccounts });
+  })
   .get("/:provider/start", async (context) => {
     const parsedProvider = providerSchema.safeParse(context.req.param("provider"));
     if (!parsedProvider.success) {
@@ -502,7 +637,10 @@ export const integrationRoutes = new Hono()
         405,
       );
     }
-    if (parsedProvider.data === "sentry") {
+    if (
+      parsedProvider.data === "sentry" &&
+      context.req.query("mode") !== "reconnect"
+    ) {
       try {
         const retriedAccount = await retrySentrySetup(tenant.organizationId);
         if (retriedAccount) {
@@ -526,14 +664,6 @@ export const integrationRoutes = new Hono()
         }
       } catch (error) {
         logCallbackError("Sentry retry", error);
-        return context.redirect(
-          settingsRedirect(
-            context.req.query("returnTo") ?? "/settings",
-            "sentry",
-            "error",
-            "connection_failed",
-          ),
-        );
       }
     }
     if (parsedProvider.data === "linear") {

--- a/apps/control-plane/server/integrations/routes.ts
+++ b/apps/control-plane/server/integrations/routes.ts
@@ -16,9 +16,10 @@ import {
   replaceIntegrationResources,
   replaceRepositories,
   setIntegrationAccountStatus,
+  setIntegrationAccountStatusIfCredentialsMatch,
   updateIntegrationAccountCredentials,
   upsertIntegrationAccount,
-  withLockedIntegrationAccountCredentials,
+  withIntegrationAccountCredentialLease,
 } from "../../../../packages/core/src/db/integrations.js";
 import { disableAgentsWithUnavailableRepositories } from "../../../../packages/core/src/db/agents.js";
 import {
@@ -137,6 +138,13 @@ class StoredSentryConnectionError extends Error {
   constructor() {
     super("Stored Sentry connection is invalid");
     this.name = "StoredSentryConnectionError";
+  }
+}
+
+class SentryConnectionChangedError extends Error {
+  constructor() {
+    super("Sentry connection changed during refresh");
+    this.name = "SentryConnectionChangedError";
   }
 }
 
@@ -393,22 +401,35 @@ async function retrySentrySetup(organizationId: string): Promise<{
 } | null> {
   const account = await getRecoverableSentryIntegrationAccount(organizationId);
   if (!account?.encryptedCredentials) return null;
+  let expectedEncryptedCredentials = account.encryptedCredentials;
   try {
-    const credentials = await getFreshSentryCredentials({
+    const fresh = await getFreshSentryCredentials({
       accountId: account.id,
       allowedStatuses: ["connected", "error", "pending"],
       organizationId,
     });
+    expectedEncryptedCredentials = fresh.encryptedCredentials;
     const organizationSlug = getSentryOrganizationSlug(account.metadata);
     const resourceCount = await completeSentrySetup({
-      accessToken: credentials.accessToken,
+      accessToken: fresh.credentials.accessToken,
       accountId: account.id,
-      installationId: credentials.installationId,
+      installationId: fresh.credentials.installationId,
       organizationSlug,
     });
     return { accountId: account.id, resourceCount };
   } catch (error) {
-    await setIntegrationAccountStatus(account.id, "error");
+    if (
+      error instanceof StoredSentryConnectionError ||
+      sentryErrorNeedsReconnect(error)
+    ) {
+      await setIntegrationAccountStatusIfCredentialsMatch({
+        encryptedCredentials: expectedEncryptedCredentials,
+        integrationAccountId: account.id,
+        organizationId,
+        provider: "sentry",
+        status: "error",
+      });
+    }
     throw error;
   }
 }
@@ -418,7 +439,7 @@ async function getFreshSentryCredentials(input: {
   allowedStatuses?: Array<"connected" | "error" | "pending">;
   organizationId: string;
 }) {
-  const credentials = await withLockedIntegrationAccountCredentials({
+  const fresh = await withIntegrationAccountCredentialLease({
     allowedStatuses: input.allowedStatuses ?? ["connected"],
     integrationAccountId: input.accountId,
     organizationId: input.organizationId,
@@ -435,7 +456,9 @@ async function getFreshSentryCredentials(input: {
         ? Date.parse(current.expiresAt)
         : Number.POSITIVE_INFINITY;
       if (Number.isFinite(expiresAt) && expiresAt > Date.now() + 60_000) {
-        return { value: current };
+        return {
+          value: { credentials: current, encryptedCredentials },
+        };
       }
 
       const authorization = await refreshSentryGrant({
@@ -448,16 +471,25 @@ async function getFreshSentryCredentials(input: {
         installationId: current.installationId,
         refreshToken: authorization.refreshToken,
       };
+      const refreshedEncryptedCredentials = encryptCredentials(refreshed);
       return {
-        encryptedCredentials: encryptCredentials(refreshed),
+        encryptedCredentials: refreshedEncryptedCredentials,
         status: "connected" as const,
-        value: refreshed,
+        value: {
+          credentials: refreshed,
+          encryptedCredentials: refreshedEncryptedCredentials,
+        },
       };
     },
     provider: "sentry",
+    statusOnError: (error) =>
+      error instanceof StoredSentryConnectionError ||
+        sentryErrorNeedsReconnect(error)
+        ? "error"
+        : undefined,
   });
-  if (!credentials) throw new StoredSentryConnectionError();
-  return credentials;
+  if (!fresh) throw new SentryConnectionChangedError();
+  return fresh;
 }
 
 export const integrationRoutes = new Hono()
@@ -553,17 +585,19 @@ export const integrationRoutes = new Hono()
     );
     const checkedAccounts = await Promise.all(
       accounts.map(async (account) => {
+        let expectedEncryptedCredentials = account.encryptedCredentials;
         try {
           if (!account.encryptedCredentials) {
             throw new StoredSentryConnectionError();
           }
-          const credentials = await getFreshSentryCredentials({
+          const fresh = await getFreshSentryCredentials({
             accountId: account.id,
             organizationId: tenant.organizationId,
           });
+          expectedEncryptedCredentials = fresh.encryptedCredentials;
           const organizationSlug = getSentryOrganizationSlug(account.metadata);
           const projects = await listSentryProjects(
-            credentials.accessToken,
+            fresh.credentials.accessToken,
             organizationSlug,
           );
           await replaceIntegrationResources(
@@ -571,7 +605,13 @@ export const integrationRoutes = new Hono()
             "sentry_project",
             projects,
           );
-          await setIntegrationAccountStatus(account.id, "connected");
+          await setIntegrationAccountStatusIfCredentialsMatch({
+            encryptedCredentials: expectedEncryptedCredentials,
+            integrationAccountId: account.id,
+            organizationId: tenant.organizationId,
+            provider: "sentry",
+            status: "connected",
+          });
           return {
             id: account.id,
             resourceCount: projects.length,
@@ -582,7 +622,15 @@ export const integrationRoutes = new Hono()
             error instanceof StoredSentryConnectionError ||
             sentryErrorNeedsReconnect(error);
           if (needsReconnect) {
-            await setIntegrationAccountStatus(account.id, "error");
+            if (expectedEncryptedCredentials) {
+              await setIntegrationAccountStatusIfCredentialsMatch({
+                encryptedCredentials: expectedEncryptedCredentials,
+                integrationAccountId: account.id,
+                organizationId: tenant.organizationId,
+                provider: "sentry",
+                status: "error",
+              });
+            }
           }
           console.error(
             JSON.stringify({

--- a/apps/control-plane/server/integrations/routes.ts
+++ b/apps/control-plane/server/integrations/routes.ts
@@ -14,6 +14,7 @@ import {
   listConnectedSentryIntegrationAccounts,
   listOrganizationIntegrationAccounts,
   replaceIntegrationResources,
+  replaceIntegrationResourcesIfCredentialsMatch,
   replaceRepositories,
   setIntegrationAccountStatus,
   setIntegrationAccountStatusIfCredentialsMatch,
@@ -382,16 +383,30 @@ function withIntegrationAccountId(url: string, accountId: string): string {
 async function completeSentrySetup(input: {
   accessToken: string;
   accountId: string;
+  expectedEncryptedCredentials?: string;
   installationId: string;
+  organizationId?: string;
   organizationSlug: string;
 }): Promise<number> {
   const projects = await listSentryProjects(
     input.accessToken,
     input.organizationSlug,
   );
-  await replaceIntegrationResources(input.accountId, "sentry_project", projects);
   await verifySentryInstallation(input.accessToken, input.installationId);
-  await setIntegrationAccountStatus(input.accountId, "connected");
+  if (input.expectedEncryptedCredentials && input.organizationId) {
+    const updated = await replaceIntegrationResourcesIfCredentialsMatch({
+      encryptedCredentials: input.expectedEncryptedCredentials,
+      integrationAccountId: input.accountId,
+      kind: "sentry_project",
+      organizationId: input.organizationId,
+      provider: "sentry",
+      resources: projects,
+    });
+    if (!updated) throw new SentryConnectionChangedError();
+  } else {
+    await replaceIntegrationResources(input.accountId, "sentry_project", projects);
+    await setIntegrationAccountStatus(input.accountId, "connected");
+  }
   return projects.length;
 }
 
@@ -413,7 +428,9 @@ async function retrySentrySetup(organizationId: string): Promise<{
     const resourceCount = await completeSentrySetup({
       accessToken: fresh.credentials.accessToken,
       accountId: account.id,
+      expectedEncryptedCredentials,
       installationId: fresh.credentials.installationId,
+      organizationId,
       organizationSlug,
     });
     return { accountId: account.id, resourceCount };
@@ -600,18 +617,15 @@ export const integrationRoutes = new Hono()
             fresh.credentials.accessToken,
             organizationSlug,
           );
-          await replaceIntegrationResources(
-            account.id,
-            "sentry_project",
-            projects,
-          );
-          await setIntegrationAccountStatusIfCredentialsMatch({
+          const updated = await replaceIntegrationResourcesIfCredentialsMatch({
             encryptedCredentials: expectedEncryptedCredentials,
             integrationAccountId: account.id,
+            kind: "sentry_project",
             organizationId: tenant.organizationId,
             provider: "sentry",
-            status: "connected",
+            resources: projects,
           });
+          if (!updated) throw new SentryConnectionChangedError();
           return {
             id: account.id,
             resourceCount: projects.length,

--- a/apps/control-plane/server/integrations/sentry.ts
+++ b/apps/control-plane/server/integrations/sentry.ts
@@ -5,8 +5,18 @@ const sentryAuthorizationSchema = z.object({
   token: z.string().min(1),
   refreshToken: z.string().min(1),
   dateCreated: z.string().optional(),
-  expiresAt: z.string().optional(),
+  expiresAt: z.string().nullable().optional(),
 });
+
+export class SentryApiError extends Error {
+  constructor(
+    message: string,
+    readonly httpStatus: number,
+  ) {
+    super(message);
+    this.name = "SentryApiError";
+  }
+}
 
 const sentryProjectSchema = z.object({
   id: z.union([z.string(), z.number()]).transform(String),
@@ -56,7 +66,34 @@ export async function exchangeSentryGrant(input: {
     },
   );
   if (!response.ok) {
-    throw new Error(`Sentry authorization failed with HTTP ${response.status}`);
+    throw new SentryApiError("Sentry authorization failed", response.status);
+  }
+  return sentryAuthorizationSchema.parse(await response.json());
+}
+
+export async function refreshSentryGrant(input: {
+  installationId: string;
+  refreshToken: string;
+}) {
+  const { clientId, clientSecret } = sentryEnvironment();
+  const response = await fetch(
+    `https://sentry.io/api/0/sentry-app-installations/${encodeURIComponent(input.installationId)}/authorizations/`,
+    {
+      method: "POST",
+      headers: {
+        accept: "application/json",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        grant_type: "refresh_token",
+        refresh_token: input.refreshToken,
+        client_id: clientId,
+        client_secret: clientSecret,
+      }),
+    },
+  );
+  if (!response.ok) {
+    throw new SentryApiError("Unable to refresh Sentry access", response.status);
   }
   return sentryAuthorizationSchema.parse(await response.json());
 }
@@ -94,7 +131,7 @@ export async function listSentryProjects(
       },
     });
     if (!response.ok) {
-      throw new Error(`Unable to list Sentry projects (HTTP ${response.status})`);
+      throw new SentryApiError("Unable to list Sentry projects", response.status);
     }
     projects.push(...z.array(sentryProjectSchema).parse(await response.json()));
     nextUrl = nextSentryPage(response.headers.get("link"));
@@ -127,6 +164,6 @@ export async function verifySentryInstallation(
     },
   );
   if (!response.ok) {
-    throw new Error(`Unable to verify Sentry installation (HTTP ${response.status})`);
+    throw new SentryApiError("Unable to verify Sentry installation", response.status);
   }
 }

--- a/apps/control-plane/server/integrations/sentry.ts
+++ b/apps/control-plane/server/integrations/sentry.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
 
+const SENTRY_REQUEST_TIMEOUT_MS = 10_000;
+
 const sentryAuthorizationSchema = z.object({
   id: z.union([z.string(), z.number()]).transform(String),
   token: z.string().min(1),
@@ -12,10 +14,18 @@ export class SentryApiError extends Error {
   constructor(
     message: string,
     readonly httpStatus: number,
+    readonly operation: "authorization" | "installation" | "projects",
   ) {
     super(message);
     this.name = "SentryApiError";
   }
+}
+
+export function sentryErrorNeedsReconnect(error: unknown): boolean {
+  return error instanceof SentryApiError &&
+    (error.httpStatus === 401 ||
+      error.httpStatus === 403 ||
+      (error.operation === "authorization" && error.httpStatus === 400));
 }
 
 const sentryProjectSchema = z.object({
@@ -53,6 +63,7 @@ export async function exchangeSentryGrant(input: {
     `https://sentry.io/api/0/sentry-app-installations/${encodeURIComponent(input.installationId)}/authorizations/`,
     {
       method: "POST",
+      signal: AbortSignal.timeout(SENTRY_REQUEST_TIMEOUT_MS),
       headers: {
         accept: "application/json",
         "content-type": "application/json",
@@ -66,7 +77,11 @@ export async function exchangeSentryGrant(input: {
     },
   );
   if (!response.ok) {
-    throw new SentryApiError("Sentry authorization failed", response.status);
+    throw new SentryApiError(
+      "Sentry authorization failed",
+      response.status,
+      "authorization",
+    );
   }
   return sentryAuthorizationSchema.parse(await response.json());
 }
@@ -80,6 +95,7 @@ export async function refreshSentryGrant(input: {
     `https://sentry.io/api/0/sentry-app-installations/${encodeURIComponent(input.installationId)}/authorizations/`,
     {
       method: "POST",
+      signal: AbortSignal.timeout(SENTRY_REQUEST_TIMEOUT_MS),
       headers: {
         accept: "application/json",
         "content-type": "application/json",
@@ -93,7 +109,11 @@ export async function refreshSentryGrant(input: {
     },
   );
   if (!response.ok) {
-    throw new SentryApiError("Unable to refresh Sentry access", response.status);
+    throw new SentryApiError(
+      "Unable to refresh Sentry access",
+      response.status,
+      "authorization",
+    );
   }
   return sentryAuthorizationSchema.parse(await response.json());
 }
@@ -129,9 +149,14 @@ export async function listSentryProjects(
         accept: "application/json",
         authorization: `Bearer ${accessToken}`,
       },
+      signal: AbortSignal.timeout(SENTRY_REQUEST_TIMEOUT_MS),
     });
     if (!response.ok) {
-      throw new SentryApiError("Unable to list Sentry projects", response.status);
+      throw new SentryApiError(
+        "Unable to list Sentry projects",
+        response.status,
+        "projects",
+      );
     }
     projects.push(...z.array(sentryProjectSchema).parse(await response.json()));
     nextUrl = nextSentryPage(response.headers.get("link"));
@@ -156,6 +181,7 @@ export async function verifySentryInstallation(
     `https://sentry.io/api/0/sentry-app-installations/${encodeURIComponent(installationId)}/`,
     {
       method: "PUT",
+      signal: AbortSignal.timeout(SENTRY_REQUEST_TIMEOUT_MS),
       headers: {
         authorization: `Bearer ${accessToken}`,
         "content-type": "application/json",
@@ -164,6 +190,10 @@ export async function verifySentryInstallation(
     },
   );
   if (!response.ok) {
-    throw new SentryApiError("Unable to verify Sentry installation", response.status);
+    throw new SentryApiError(
+      "Unable to verify Sentry installation",
+      response.status,
+      "installation",
+    );
   }
 }

--- a/apps/control-plane/src/agents-api.ts
+++ b/apps/control-plane/src/agents-api.ts
@@ -132,6 +132,13 @@ export interface IntegrationSummary {
   state: "available" | "coming_soon" | "connected" | "setup_required";
   accountCount: number;
   resourceCount: number;
+  accounts?: Array<{
+    id: string;
+    displayName: string;
+    status: "connected" | "error" | "pending";
+    resourceCount: number;
+    updatedAt: string;
+  }>;
   connectUrl: string | null;
   configurationUrl: string | null;
 }

--- a/apps/control-plane/src/pages/settings.tsx
+++ b/apps/control-plane/src/pages/settings.tsx
@@ -122,11 +122,23 @@ export function SettingsPage() {
   useEffect(() => {
     let active = true;
     let retryTimer: number | undefined;
+    let sentryRetryTimer: number | undefined;
     let retryCount = 0;
+    let sentryCheckAttempts = 0;
     let sentryCheckStarted = false;
+
+    function retrySentryCheck() {
+      if (sentryCheckAttempts >= 2 || sentryRetryTimer !== undefined) return;
+      sentryCheckStarted = false;
+      sentryRetryTimer = window.setTimeout(() => {
+        sentryRetryTimer = undefined;
+        if (active) loadIntegrations();
+      }, 2_000);
+    }
 
     function checkSentryConnection() {
       sentryCheckStarted = true;
+      sentryCheckAttempts += 1;
       setSentryHealth("checking");
       void fetch("/api/integrations/sentry/check", { method: "POST" })
         .then(async (response) => {
@@ -136,17 +148,22 @@ export function SettingsPage() {
         .then((response) => {
           if (!active) return;
           const statuses = response.accounts.map((account) => account.status);
-          setSentryHealth(
-            statuses.includes("needs_reconnect")
-              ? "needs_reconnect"
-              : statuses.includes("unavailable") || statuses.length === 0
-                ? "unavailable"
-                : "working",
-          );
-          loadIntegrations();
+          if (statuses.includes("needs_reconnect")) {
+            setSentryHealth("needs_reconnect");
+            loadIntegrations();
+          } else if (statuses.includes("unavailable") || statuses.length === 0) {
+            setSentryHealth("unavailable");
+            retrySentryCheck();
+          } else {
+            setSentryHealth("working");
+            loadIntegrations();
+          }
         })
         .catch(() => {
-          if (active) setSentryHealth("unavailable");
+          if (active) {
+            setSentryHealth("unavailable");
+            retrySentryCheck();
+          }
         });
     }
 
@@ -191,6 +208,9 @@ export function SettingsPage() {
     return () => {
       active = false;
       if (retryTimer !== undefined) window.clearTimeout(retryTimer);
+      if (sentryRetryTimer !== undefined) {
+        window.clearTimeout(sentryRetryTimer);
+      }
     };
   }, [isFinishingSentryConnection]);
 

--- a/apps/control-plane/src/pages/settings.tsx
+++ b/apps/control-plane/src/pages/settings.tsx
@@ -37,12 +37,33 @@ interface IntegrationSummary {
   state: IntegrationState;
   accountCount: number;
   resourceCount: number;
+  accounts: Array<{
+    id: string;
+    displayName: string;
+    status: "connected" | "error" | "pending";
+    resourceCount: number;
+    updatedAt: string;
+  }>;
   connectUrl: string | null;
   configurationUrl: string | null;
 }
 
 interface IntegrationResponse {
   integrations: IntegrationSummary[];
+}
+
+type SentryHealth =
+  | "checking"
+  | "working"
+  | "needs_reconnect"
+  | "unavailable";
+
+interface SentryCheckResponse {
+  accounts: Array<{
+    id: string;
+    resourceCount?: number;
+    status: Exclude<SentryHealth, "checking">;
+  }>;
 }
 
 function connectionNotice(): {
@@ -92,6 +113,7 @@ export function SettingsPage() {
   const [integrations, setIntegrations] = useState<IntegrationSummary[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
+  const [sentryHealth, setSentryHealth] = useState<SentryHealth | null>(null);
   const [notice] = useState(connectionNotice);
   const isFinishingSentryConnection =
     new URLSearchParams(window.location.search).get("integration") === "sentry" &&
@@ -101,6 +123,32 @@ export function SettingsPage() {
     let active = true;
     let retryTimer: number | undefined;
     let retryCount = 0;
+    let sentryCheckStarted = false;
+
+    function checkSentryConnection() {
+      sentryCheckStarted = true;
+      setSentryHealth("checking");
+      void fetch("/api/integrations/sentry/check", { method: "POST" })
+        .then(async (response) => {
+          if (!response.ok) throw new Error("Unable to check Sentry");
+          return (await response.json()) as SentryCheckResponse;
+        })
+        .then((response) => {
+          if (!active) return;
+          const statuses = response.accounts.map((account) => account.status);
+          setSentryHealth(
+            statuses.includes("needs_reconnect")
+              ? "needs_reconnect"
+              : statuses.includes("unavailable") || statuses.length === 0
+                ? "unavailable"
+                : "working",
+          );
+          loadIntegrations();
+        })
+        .catch(() => {
+          if (active) setSentryHealth("unavailable");
+        });
+    }
 
     function loadIntegrations() {
       void fetch("/api/integrations")
@@ -111,10 +159,16 @@ export function SettingsPage() {
       .then((response) => {
         if (!active) return;
         setIntegrations(response.integrations);
-        const sentryConnected = response.integrations.some(
-          (integration) =>
-            integration.id === "sentry" && integration.state === "connected",
+        const sentry = response.integrations.find(
+          (integration) => integration.id === "sentry",
         );
+        const sentryConnected = sentry?.state === "connected";
+        if (sentry?.accounts.some((account) => account.status === "error")) {
+          setSentryHealth("needs_reconnect");
+        }
+        if (sentryConnected && !sentryCheckStarted) {
+          checkSentryConnection();
+        }
         if (isFinishingSentryConnection && !sentryConnected && retryCount < 8) {
           retryCount += 1;
           retryTimer = window.setTimeout(loadIntegrations, 750);
@@ -187,12 +241,20 @@ export function SettingsPage() {
           <div className="integrationRows">
             <div className="integrationRow integrationRow--featured">
               {featured.map((integration) => (
-                <IntegrationCard integration={integration} key={integration.id} />
+                <IntegrationCard
+                  integration={integration}
+                  key={integration.id}
+                  sentryHealth={sentryHealth}
+                />
               ))}
             </div>
             <div className="integrationRow">
               {secondary.map((integration) => (
-                <IntegrationCard integration={integration} key={integration.id} />
+                <IntegrationCard
+                  integration={integration}
+                  key={integration.id}
+                  sentryHealth={sentryHealth}
+                />
               ))}
             </div>
           </div>
@@ -202,7 +264,37 @@ export function SettingsPage() {
   );
 }
 
-function integrationDetail(integration: IntegrationSummary): string {
+function displayedSentryHealth(
+  integration: IntegrationSummary,
+  health: SentryHealth | null,
+): SentryHealth | null {
+  if (integration.id !== "sentry") return null;
+  if (integration.accounts.some((account) => account.status === "error")) {
+    return "needs_reconnect";
+  }
+  return health ?? (integration.state === "connected" ? "checking" : null);
+}
+
+function integrationDetail(
+  integration: IntegrationSummary,
+  sentryHealth: SentryHealth | null,
+): string {
+  const health = displayedSentryHealth(integration, sentryHealth);
+  if (health === "checking") return "Checking the connection…";
+  if (health === "working") {
+    const projectLabel = integration.resourceCount === 1 ? "project" : "projects";
+    return `Connection works · ${integration.resourceCount} ${projectLabel}`;
+  }
+  if (health === "needs_reconnect") {
+    const failedCount = Math.max(
+      1,
+      integration.accounts.filter((account) => account.status === "error").length,
+    );
+    return failedCount === 1
+      ? "1 connection failed · Select to reconnect"
+      : `${failedCount} connections failed · Select to reconnect`;
+  }
+  if (health === "unavailable") return "Could not verify the connection right now";
   if (integration.state === "connected") {
     const accountLabel = integration.accountCount === 1 ? "account" : "accounts";
     const resourceLabel = integration.resourceCount === 1 ? "resource" : "resources";
@@ -217,8 +309,15 @@ function integrationDetail(integration: IntegrationSummary): string {
   return integration.description;
 }
 
-function IntegrationCard({ integration }: { integration: IntegrationSummary }) {
+function IntegrationCard({
+  integration,
+  sentryHealth,
+}: {
+  integration: IntegrationSummary;
+  sentryHealth: SentryHealth | null;
+}) {
   const actionUrl = integrationActionUrl(integration);
+  const health = displayedSentryHealth(integration, sentryHealth);
   const canConnect = Boolean(actionUrl);
   const [isConnecting, setIsConnecting] = useState(false);
   const [choosingDatadogSite, setChoosingDatadogSite] = useState(false);
@@ -271,7 +370,15 @@ function IntegrationCard({ integration }: { integration: IntegrationSummary }) {
             decorative
             provider={integration.id}
           />
-          {integration.state === "connected" ? (
+          {health === "needs_reconnect" ? (
+            <span className="connectedBadge connectedBadge--warning">Reconnect</span>
+          ) : health === "unavailable" ? (
+            <span className="connectedBadge connectedBadge--muted">Not verified</span>
+          ) : health === "checking" ? (
+            <span className="connectedBadge connectedBadge--muted">Checking</span>
+          ) : health === "working" ? (
+            <span className="connectedBadge">Working</span>
+          ) : integration.state === "connected" ? (
             <span className="connectedBadge">Connected</span>
           ) : integration.state === "coming_soon" ? (
             <span className="connectedBadge connectedBadge--muted">Coming next</span>
@@ -279,7 +386,7 @@ function IntegrationCard({ integration }: { integration: IntegrationSummary }) {
         </span>
         <span className="integrationCard__body">
           <strong>{integration.name}</strong>
-          <small>{integrationDetail(integration)}</small>
+          <small>{integrationDetail(integration, sentryHealth)}</small>
         </span>
         <span className="integrationCard__arrow">
           {isConnecting ? (

--- a/apps/control-plane/src/styles.css
+++ b/apps/control-plane/src/styles.css
@@ -420,6 +420,12 @@ body:has(.appShell--investigation) {
   display: none;
 }
 
+.appShell--settings .connectedBadge--warning {
+  border-color: #66542d;
+  background: var(--ds-surface-base);
+  color: var(--ds-warning);
+}
+
 .appShell--settings .integrationCard__body strong {
   color: var(--ds-text-primary);
   font-size: 16px;

--- a/packages/core/src/db/integrations.test.ts
+++ b/packages/core/src/db/integrations.test.ts
@@ -7,6 +7,7 @@ import {
   createIntegrationConnectionState,
   consumeIntegrationConnectionState,
   upsertIntegrationAccount,
+  withLockedIntegrationAccountCredentials,
 } from "./integrations.js";
 import {
   integrationAccounts,
@@ -84,6 +85,49 @@ describe("integration account tenancy", () => {
     });
 
     await expect(upsertIntegrationAccount(account)).resolves.toBe("account-1");
+    expect(updateWhere).toHaveBeenCalledOnce();
+  });
+
+  it("serializes rotating credential updates with an account row lock", async () => {
+    const forUpdate = vi.fn().mockResolvedValue([
+      { encryptedCredentials: "old-credentials", status: "connected" },
+    ]);
+    const updateWhere = vi.fn().mockResolvedValue(undefined);
+    const tx = {
+      select: vi.fn(() => ({
+        from: vi.fn(() => ({
+          where: vi.fn(() => ({
+            limit: vi.fn(() => ({ for: forUpdate })),
+          })),
+        })),
+      })),
+      update: vi.fn(() => ({
+        set: vi.fn(() => ({ where: updateWhere })),
+      })),
+    };
+    vi.mocked(getDatabase).mockReturnValue({
+      transaction: vi.fn(async (operation) => operation(tx as never)),
+    } as never);
+    const operation = vi.fn().mockResolvedValue({
+      encryptedCredentials: "new-credentials",
+      status: "connected",
+      value: "refreshed",
+    });
+
+    await expect(
+      withLockedIntegrationAccountCredentials({
+        allowedStatuses: ["connected"],
+        integrationAccountId: "account-1",
+        operation,
+        organizationId: account.organizationId,
+        provider: "sentry",
+      }),
+    ).resolves.toBe("refreshed");
+
+    expect(forUpdate).toHaveBeenCalledWith("update", {
+      of: integrationAccounts,
+    });
+    expect(operation).toHaveBeenCalledWith("old-credentials");
     expect(updateWhere).toHaveBeenCalledOnce();
   });
 

--- a/packages/core/src/db/integrations.test.ts
+++ b/packages/core/src/db/integrations.test.ts
@@ -6,8 +6,9 @@ import { getDatabase } from "./client.js";
 import {
   createIntegrationConnectionState,
   consumeIntegrationConnectionState,
+  IntegrationAccountCredentialSupersededError,
   upsertIntegrationAccount,
-  withLockedIntegrationAccountCredentials,
+  withIntegrationAccountCredentialLease,
 } from "./integrations.js";
 import {
   integrationAccounts,
@@ -88,26 +89,19 @@ describe("integration account tenancy", () => {
     expect(updateWhere).toHaveBeenCalledOnce();
   });
 
-  it("serializes rotating credential updates with an account row lock", async () => {
-    const forUpdate = vi.fn().mockResolvedValue([
-      { encryptedCredentials: "old-credentials", status: "connected" },
-    ]);
-    const updateWhere = vi.fn().mockResolvedValue(undefined);
-    const tx = {
-      select: vi.fn(() => ({
-        from: vi.fn(() => ({
-          where: vi.fn(() => ({
-            limit: vi.fn(() => ({ for: forUpdate })),
-          })),
-        })),
-      })),
+  it("serializes rotating credential updates without holding a transaction", async () => {
+    const returning = vi
+      .fn()
+      .mockResolvedValueOnce([{ encryptedCredentials: "old-credentials" }])
+      .mockResolvedValueOnce([{ id: "account-1" }]);
+    const where = vi.fn(() => ({ returning }));
+    const database = {
+      transaction: vi.fn(),
       update: vi.fn(() => ({
-        set: vi.fn(() => ({ where: updateWhere })),
+        set: vi.fn(() => ({ where })),
       })),
     };
-    vi.mocked(getDatabase).mockReturnValue({
-      transaction: vi.fn(async (operation) => operation(tx as never)),
-    } as never);
+    vi.mocked(getDatabase).mockReturnValue(database as never);
     const operation = vi.fn().mockResolvedValue({
       encryptedCredentials: "new-credentials",
       status: "connected",
@@ -115,7 +109,7 @@ describe("integration account tenancy", () => {
     });
 
     await expect(
-      withLockedIntegrationAccountCredentials({
+      withIntegrationAccountCredentialLease({
         allowedStatuses: ["connected"],
         integrationAccountId: "account-1",
         operation,
@@ -124,11 +118,40 @@ describe("integration account tenancy", () => {
       }),
     ).resolves.toBe("refreshed");
 
-    expect(forUpdate).toHaveBeenCalledWith("update", {
-      of: integrationAccounts,
-    });
+    expect(database.transaction).not.toHaveBeenCalled();
+    expect(database.update).toHaveBeenCalledTimes(2);
     expect(operation).toHaveBeenCalledWith("old-credentials");
-    expect(updateWhere).toHaveBeenCalledOnce();
+    expect(where).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not overwrite a connection that changes during a failed refresh", async () => {
+    const returning = vi
+      .fn()
+      .mockResolvedValueOnce([{ encryptedCredentials: "old-credentials" }])
+      .mockResolvedValueOnce([]);
+    const set = vi.fn(() => ({
+      where: vi.fn(() => ({ returning })),
+    }));
+    vi.mocked(getDatabase).mockReturnValue({
+      update: vi.fn(() => ({ set })),
+    } as never);
+
+    await expect(
+      withIntegrationAccountCredentialLease({
+        allowedStatuses: ["connected"],
+        integrationAccountId: "account-1",
+        operation: async () => {
+          throw new Error("refresh rejected");
+        },
+        organizationId: account.organizationId,
+        provider: "sentry",
+        statusOnError: () => "error",
+      }),
+    ).rejects.toBeInstanceOf(IntegrationAccountCredentialSupersededError);
+
+    expect(set).toHaveBeenLastCalledWith(
+      expect.objectContaining({ status: "error" }),
+    );
   });
 
   it("returns a newly connected GitHub account", async () => {

--- a/packages/core/src/db/integrations.ts
+++ b/packages/core/src/db/integrations.ts
@@ -490,6 +490,79 @@ export interface SyncedIntegrationResource {
   metadata?: Record<string, unknown>;
 }
 
+export async function replaceIntegrationResourcesIfCredentialsMatch(input: {
+  encryptedCredentials: string;
+  integrationAccountId: string;
+  kind: IntegrationResourceKind;
+  organizationId: string;
+  provider: IntegrationProvider;
+  resources: SyncedIntegrationResource[];
+}): Promise<boolean> {
+  return getDatabase().transaction(async (tx) => {
+    const accounts = await tx
+      .select({ id: integrationAccounts.id })
+      .from(integrationAccounts)
+      .where(
+        and(
+          eq(integrationAccounts.id, input.integrationAccountId),
+          eq(integrationAccounts.organizationId, input.organizationId),
+          eq(integrationAccounts.provider, input.provider),
+          eq(
+            integrationAccounts.encryptedCredentials,
+            input.encryptedCredentials,
+          ),
+        ),
+      )
+      .limit(1)
+      .for("update", { of: integrationAccounts });
+    if (!accounts[0]) return false;
+
+    await tx
+      .update(integrationResources)
+      .set({ available: false, updatedAt: new Date() })
+      .where(
+        and(
+          eq(
+            integrationResources.integrationAccountId,
+            input.integrationAccountId,
+          ),
+          eq(integrationResources.kind, input.kind),
+        ),
+      );
+
+    for (const resource of input.resources) {
+      await tx
+        .insert(integrationResources)
+        .values({
+          integrationAccountId: input.integrationAccountId,
+          kind: input.kind,
+          externalId: resource.externalId,
+          displayName: resource.displayName,
+          metadata: resource.metadata ?? {},
+        })
+        .onConflictDoUpdate({
+          target: [
+            integrationResources.integrationAccountId,
+            integrationResources.kind,
+            integrationResources.externalId,
+          ],
+          set: {
+            displayName: resource.displayName,
+            available: true,
+            metadata: resource.metadata ?? {},
+            updatedAt: new Date(),
+          },
+        });
+    }
+
+    await tx
+      .update(integrationAccounts)
+      .set({ status: "connected", updatedAt: new Date() })
+      .where(eq(integrationAccounts.id, input.integrationAccountId));
+    return true;
+  });
+}
+
 export async function getSlackChannelConnection(input: {
   organizationId: string;
   integrationAccountId: string;

--- a/packages/core/src/db/integrations.ts
+++ b/packages/core/src/db/integrations.ts
@@ -253,6 +253,60 @@ export async function updateIntegrationAccountCredentials(input: {
   return updated.length > 0;
 }
 
+export async function withLockedIntegrationAccountCredentials<T>(input: {
+  allowedStatuses: Array<"connected" | "error" | "pending">;
+  integrationAccountId: string;
+  operation: (encryptedCredentials: string) => Promise<{
+    encryptedCredentials?: string;
+    status?: "connected" | "error" | "pending";
+    value: T;
+  }>;
+  organizationId: string;
+  provider: IntegrationProvider;
+}): Promise<T | null> {
+  return getDatabase().transaction(async (tx) => {
+    const rows = await tx
+      .select({
+        encryptedCredentials: integrationAccounts.encryptedCredentials,
+        status: integrationAccounts.status,
+      })
+      .from(integrationAccounts)
+      .where(
+        and(
+          eq(integrationAccounts.id, input.integrationAccountId),
+          eq(integrationAccounts.organizationId, input.organizationId),
+          eq(integrationAccounts.provider, input.provider),
+        ),
+      )
+      .limit(1)
+      .for("update", { of: integrationAccounts });
+    const account = rows[0];
+    if (
+      !account?.encryptedCredentials ||
+      !input.allowedStatuses.includes(
+        account.status as "connected" | "error" | "pending",
+      )
+    ) {
+      return null;
+    }
+
+    const result = await input.operation(account.encryptedCredentials);
+    if (result.encryptedCredentials || result.status) {
+      await tx
+        .update(integrationAccounts)
+        .set({
+          ...(result.encryptedCredentials
+            ? { encryptedCredentials: result.encryptedCredentials }
+            : {}),
+          ...(result.status ? { status: result.status } : {}),
+          updatedAt: new Date(),
+        })
+        .where(eq(integrationAccounts.id, input.integrationAccountId));
+    }
+    return result.value;
+  });
+}
+
 export async function getRecoverableSentryIntegrationAccount(
   organizationId: string,
 ) {

--- a/packages/core/src/db/integrations.ts
+++ b/packages/core/src/db/integrations.ts
@@ -277,6 +277,26 @@ export async function getRecoverableSentryIntegrationAccount(
   return rows[0] ?? null;
 }
 
+export async function listConnectedSentryIntegrationAccounts(
+  organizationId: string,
+) {
+  return getDatabase()
+    .select({
+      id: integrationAccounts.id,
+      encryptedCredentials: integrationAccounts.encryptedCredentials,
+      metadata: integrationAccounts.metadata,
+    })
+    .from(integrationAccounts)
+    .where(
+      and(
+        eq(integrationAccounts.organizationId, organizationId),
+        eq(integrationAccounts.provider, "sentry"),
+        eq(integrationAccounts.status, "connected"),
+        isNotNull(integrationAccounts.encryptedCredentials),
+      ),
+    );
+}
+
 export async function listConnectedIntegrationAccountCredentials(
   organizationId: string,
   provider: IntegrationProvider,

--- a/packages/core/src/db/integrations.ts
+++ b/packages/core/src/db/integrations.ts
@@ -1,5 +1,5 @@
-import { createHash, randomBytes } from "node:crypto";
-import { and, count, eq, gt, inArray, isNotNull, lte } from "drizzle-orm";
+import { createHash, randomBytes, randomUUID } from "node:crypto";
+import { and, count, eq, gt, inArray, isNotNull, lte, or, sql } from "drizzle-orm";
 import { getDatabase } from "./client.js";
 import {
   integrationAccounts,
@@ -253,7 +253,19 @@ export async function updateIntegrationAccountCredentials(input: {
   return updated.length > 0;
 }
 
-export async function withLockedIntegrationAccountCredentials<T>(input: {
+const CREDENTIAL_REFRESH_LEASE_KEY = "credentialRefreshLease";
+const CREDENTIAL_REFRESH_LEASE_MS = 15_000;
+const CREDENTIAL_REFRESH_WAIT_ATTEMPTS = 100;
+const CREDENTIAL_REFRESH_WAIT_MS = 100;
+
+export class IntegrationAccountCredentialSupersededError extends Error {
+  constructor() {
+    super("Integration credentials changed during refresh");
+    this.name = "IntegrationAccountCredentialSupersededError";
+  }
+}
+
+export async function withIntegrationAccountCredentialLease<T>(input: {
   allowedStatuses: Array<"connected" | "error" | "pending">;
   integrationAccountId: string;
   operation: (encryptedCredentials: string) => Promise<{
@@ -263,48 +275,149 @@ export async function withLockedIntegrationAccountCredentials<T>(input: {
   }>;
   organizationId: string;
   provider: IntegrationProvider;
+  statusOnError?: (
+    error: unknown,
+  ) => "connected" | "error" | "pending" | undefined;
 }): Promise<T | null> {
-  return getDatabase().transaction(async (tx) => {
-    const rows = await tx
-      .select({
-        encryptedCredentials: integrationAccounts.encryptedCredentials,
-        status: integrationAccounts.status,
+  const db = getDatabase();
+  const leaseId = randomUUID();
+
+  for (
+    let attempt = 0;
+    attempt < CREDENTIAL_REFRESH_WAIT_ATTEMPTS;
+    attempt += 1
+  ) {
+    const leaseStartedAt = new Date();
+    const staleBefore = new Date(
+      leaseStartedAt.getTime() - CREDENTIAL_REFRESH_LEASE_MS,
+    );
+    const rows = await db
+      .update(integrationAccounts)
+      .set({
+        metadata: sql`jsonb_set(
+          ${integrationAccounts.metadata},
+          '{credentialRefreshLease}',
+          ${JSON.stringify({ id: leaseId })}::jsonb,
+          true
+        )`,
+        updatedAt: leaseStartedAt,
       })
-      .from(integrationAccounts)
       .where(
         and(
           eq(integrationAccounts.id, input.integrationAccountId),
           eq(integrationAccounts.organizationId, input.organizationId),
           eq(integrationAccounts.provider, input.provider),
+          inArray(integrationAccounts.status, input.allowedStatuses),
+          isNotNull(integrationAccounts.encryptedCredentials),
+          or(
+            sql`${integrationAccounts.metadata} -> ${CREDENTIAL_REFRESH_LEASE_KEY} IS NULL`,
+            lte(integrationAccounts.updatedAt, staleBefore),
+          ),
         ),
       )
-      .limit(1)
-      .for("update", { of: integrationAccounts });
+      .returning({
+        encryptedCredentials: integrationAccounts.encryptedCredentials,
+      });
     const account = rows[0];
-    if (
-      !account?.encryptedCredentials ||
-      !input.allowedStatuses.includes(
-        account.status as "connected" | "error" | "pending",
-      )
-    ) {
-      return null;
+    if (!account?.encryptedCredentials) {
+      const current = await getOrganizationIntegrationAccount({
+        integrationAccountId: input.integrationAccountId,
+        organizationId: input.organizationId,
+        provider: input.provider,
+      });
+      if (
+        !current?.encryptedCredentials ||
+        !input.allowedStatuses.includes(
+          current.status as "connected" | "error" | "pending",
+        )
+      ) {
+        return null;
+      }
+      if (attempt === CREDENTIAL_REFRESH_WAIT_ATTEMPTS - 1) return null;
+      await new Promise((resolve) => {
+        setTimeout(resolve, CREDENTIAL_REFRESH_WAIT_MS);
+      });
+      continue;
     }
 
-    const result = await input.operation(account.encryptedCredentials);
-    if (result.encryptedCredentials || result.status) {
-      await tx
+    try {
+      const result = await input.operation(account.encryptedCredentials);
+      const updated = await db
         .update(integrationAccounts)
         .set({
           ...(result.encryptedCredentials
             ? { encryptedCredentials: result.encryptedCredentials }
             : {}),
           ...(result.status ? { status: result.status } : {}),
+          metadata: sql`${integrationAccounts.metadata} - ${CREDENTIAL_REFRESH_LEASE_KEY}`,
           updatedAt: new Date(),
         })
-        .where(eq(integrationAccounts.id, input.integrationAccountId));
+        .where(
+          and(
+            eq(integrationAccounts.id, input.integrationAccountId),
+            eq(integrationAccounts.organizationId, input.organizationId),
+            eq(integrationAccounts.provider, input.provider),
+            eq(
+              integrationAccounts.encryptedCredentials,
+              account.encryptedCredentials,
+            ),
+            sql`${integrationAccounts.metadata} -> ${CREDENTIAL_REFRESH_LEASE_KEY} ->> 'id' = ${leaseId}`,
+          ),
+        )
+        .returning({ id: integrationAccounts.id });
+      return updated.length > 0 ? result.value : null;
+    } catch (error) {
+      const failureStatus = input.statusOnError?.(error);
+      const released = await db
+        .update(integrationAccounts)
+        .set({
+          ...(failureStatus ? { status: failureStatus } : {}),
+          metadata: sql`${integrationAccounts.metadata} - ${CREDENTIAL_REFRESH_LEASE_KEY}`,
+          updatedAt: new Date(),
+        })
+        .where(
+          and(
+            eq(integrationAccounts.id, input.integrationAccountId),
+            eq(integrationAccounts.organizationId, input.organizationId),
+            eq(integrationAccounts.provider, input.provider),
+            eq(
+              integrationAccounts.encryptedCredentials,
+              account.encryptedCredentials,
+            ),
+            sql`${integrationAccounts.metadata} -> ${CREDENTIAL_REFRESH_LEASE_KEY} ->> 'id' = ${leaseId}`,
+          ),
+        )
+        .returning({ id: integrationAccounts.id });
+      if (released.length === 0) {
+        throw new IntegrationAccountCredentialSupersededError();
+      }
+      throw error;
     }
-    return result.value;
-  });
+  }
+
+  return null;
+}
+
+export async function setIntegrationAccountStatusIfCredentialsMatch(input: {
+  encryptedCredentials: string;
+  integrationAccountId: string;
+  organizationId: string;
+  provider: IntegrationProvider;
+  status: "connected" | "error" | "pending";
+}): Promise<boolean> {
+  const updated = await getDatabase()
+    .update(integrationAccounts)
+    .set({ status: input.status, updatedAt: new Date() })
+    .where(
+      and(
+        eq(integrationAccounts.id, input.integrationAccountId),
+        eq(integrationAccounts.organizationId, input.organizationId),
+        eq(integrationAccounts.provider, input.provider),
+        eq(integrationAccounts.encryptedCredentials, input.encryptedCredentials),
+      ),
+    )
+    .returning({ id: integrationAccounts.id });
+  return updated.length > 0;
 }
 
 export async function getRecoverableSentryIntegrationAccount(

--- a/packages/core/src/db/investigations.ts
+++ b/packages/core/src/db/investigations.ts
@@ -55,7 +55,7 @@ import {
   type AgentPrMode,
 } from "./schema.js";
 import { getInvestigationIssueDetails } from "./issues.js";
-import { withLockedIntegrationAccountCredentials } from "./integrations.js";
+import { withIntegrationAccountCredentialLease } from "./integrations.js";
 
 export interface RuntimeAgentConfig {
   id: string;
@@ -1558,7 +1558,7 @@ export async function getRuntimeSentryConnection(
     }
     try {
       const refreshedCredentials =
-        await withLockedIntegrationAccountCredentials({
+        await withIntegrationAccountCredentialLease({
           allowedStatuses: ["connected"],
           integrationAccountId: account.id,
           operation: async (encryptedCredentials) => {
@@ -1610,6 +1610,11 @@ export async function getRuntimeSentryConnection(
           },
           organizationId: config.organizationId,
           provider: "sentry",
+          statusOnError: (error) =>
+            error instanceof SentryRefreshError &&
+              [400, 401, 403].includes(error.httpStatus)
+              ? "error"
+              : undefined,
         });
       if (!refreshedCredentials) return null;
       credentials = refreshedCredentials;
@@ -1623,15 +1628,6 @@ export async function getRuntimeSentryConnection(
           integrationAccountId: account.id,
         }),
       );
-      if (
-        error instanceof SentryRefreshError &&
-        [400, 401, 403].includes(error.httpStatus)
-      ) {
-        await getDatabase()
-          .update(integrationAccounts)
-          .set({ status: "error", updatedAt: new Date() })
-          .where(eq(integrationAccounts.id, account.id));
-      }
       throw new Error("Unable to refresh Sentry access");
     }
   }

--- a/packages/core/src/db/investigations.ts
+++ b/packages/core/src/db/investigations.ts
@@ -1572,6 +1572,10 @@ export async function getRuntimeSentryConnection(
           integrationAccountId: account.id,
         }),
       );
+      await getDatabase()
+        .update(integrationAccounts)
+        .set({ status: "error", updatedAt: new Date() })
+        .where(eq(integrationAccounts.id, account.id));
       throw new Error("Unable to refresh Sentry access");
     }
     const refreshed = sentryAuthorizationSchema.parse(await response.json());
@@ -1585,6 +1589,7 @@ export async function getRuntimeSentryConnection(
       .update(integrationAccounts)
       .set({
         encryptedCredentials: encryptCredentials(credentials),
+        status: "connected",
         updatedAt: new Date(),
       })
       .where(eq(integrationAccounts.id, account.id));

--- a/packages/core/src/db/investigations.ts
+++ b/packages/core/src/db/investigations.ts
@@ -55,6 +55,7 @@ import {
   type AgentPrMode,
 } from "./schema.js";
 import { getInvestigationIssueDetails } from "./issues.js";
+import { withLockedIntegrationAccountCredentials } from "./integrations.js";
 
 export interface RuntimeAgentConfig {
   id: string;
@@ -1478,6 +1479,13 @@ const sentryAuthorizationSchema = z.object({
   expiresAt: z.string().nullable().optional(),
 });
 
+class SentryRefreshError extends Error {
+  constructor(readonly httpStatus: number) {
+    super("Unable to refresh Sentry access");
+    this.name = "SentryRefreshError";
+  }
+}
+
 const sentryTriggerConfigSchema = z.object({
   integrationAccountId: z.uuid(),
   projectIds: z.array(z.string().min(1)),
@@ -1548,51 +1556,84 @@ export async function getRuntimeSentryConnection(
     if (!clientId || !clientSecret) {
       throw new Error("Sentry App credentials are not configured");
     }
-    const response = await fetch(
-      `https://sentry.io/api/0/sentry-app-installations/${encodeURIComponent(credentials.installationId)}/authorizations/`,
-      {
-        method: "POST",
-        headers: {
-          accept: "application/json",
-          "content-type": "application/json",
-        },
-        body: JSON.stringify({
-          grant_type: "refresh_token",
-          refresh_token: credentials.refreshToken,
-          client_id: clientId,
-          client_secret: clientSecret,
-        }),
-      },
-    );
-    if (!response.ok) {
+    try {
+      const refreshedCredentials =
+        await withLockedIntegrationAccountCredentials({
+          allowedStatuses: ["connected"],
+          integrationAccountId: account.id,
+          operation: async (encryptedCredentials) => {
+            const current = sentryCredentialsSchema.parse(
+              decryptCredentials<Record<string, unknown>>(encryptedCredentials),
+            );
+            const currentExpiresAt = current.expiresAt
+              ? Date.parse(current.expiresAt)
+              : Number.POSITIVE_INFINITY;
+            if (
+              Number.isFinite(currentExpiresAt) &&
+              currentExpiresAt > Date.now() + 60_000
+            ) {
+              return { value: current };
+            }
+
+            const response = await fetch(
+              `https://sentry.io/api/0/sentry-app-installations/${encodeURIComponent(current.installationId)}/authorizations/`,
+              {
+                method: "POST",
+                headers: {
+                  accept: "application/json",
+                  "content-type": "application/json",
+                },
+                body: JSON.stringify({
+                  grant_type: "refresh_token",
+                  refresh_token: current.refreshToken,
+                  client_id: clientId,
+                  client_secret: clientSecret,
+                }),
+                signal: AbortSignal.timeout(10_000),
+              },
+            );
+            if (!response.ok) throw new SentryRefreshError(response.status);
+            const refreshed = sentryAuthorizationSchema.parse(
+              await response.json(),
+            );
+            const nextCredentials = {
+              accessToken: refreshed.token,
+              refreshToken: refreshed.refreshToken,
+              expiresAt: refreshed.expiresAt ?? null,
+              installationId: current.installationId,
+            };
+            return {
+              encryptedCredentials: encryptCredentials(nextCredentials),
+              status: "connected" as const,
+              value: nextCredentials,
+            };
+          },
+          organizationId: config.organizationId,
+          provider: "sentry",
+        });
+      if (!refreshedCredentials) return null;
+      credentials = refreshedCredentials;
+    } catch (error) {
       console.error(
         JSON.stringify({
           event: "sentry_token_refresh_failed",
-          httpStatus: response.status,
+          ...(error instanceof SentryRefreshError
+            ? { httpStatus: error.httpStatus }
+            : {}),
           integrationAccountId: account.id,
         }),
       );
-      await getDatabase()
-        .update(integrationAccounts)
-        .set({ status: "error", updatedAt: new Date() })
-        .where(eq(integrationAccounts.id, account.id));
+      if (
+        error instanceof SentryRefreshError &&
+        [400, 401, 403].includes(error.httpStatus)
+      ) {
+        await getDatabase()
+          .update(integrationAccounts)
+          .set({ status: "error", updatedAt: new Date() })
+          .where(eq(integrationAccounts.id, account.id));
+      }
       throw new Error("Unable to refresh Sentry access");
     }
-    const refreshed = sentryAuthorizationSchema.parse(await response.json());
-    credentials = {
-      accessToken: refreshed.token,
-      refreshToken: refreshed.refreshToken,
-      expiresAt: refreshed.expiresAt ?? null,
-      installationId: credentials.installationId,
-    };
-    await getDatabase()
-      .update(integrationAccounts)
-      .set({
-        encryptedCredentials: encryptCredentials(credentials),
-        status: "connected",
-        updatedAt: new Date(),
-      })
-      .where(eq(integrationAccounts.id, account.id));
   }
 
   let projectSlug: string | undefined;


### PR DESCRIPTION
## Summary

- verify connected Sentry accounts against the live projects API when Settings loads
- distinguish working, reconnect-required, and temporarily unverifiable connections
- start a fresh authorization flow when reconnecting instead of retrying stale credentials
- mark runtime token-refresh failures on the integration account so Settings reflects the failure

## Root cause

The reconnect route retried a stored pending or failed credential before starting a new authorization. An invalid old credential could therefore intercept every reconnect attempt. The Settings page also treated the stored `connected` state as proof that the credentials still worked.

## User impact

Settings now shows whether Sentry actually works. Authorization failures offer a fresh reconnect, while temporary upstream failures remain marked as unverifiable rather than broken.

## Validation

- `pnpm test`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Sentry connection health by validating against the live API, serializing token refreshes with a per-account lease, and discarding superseded health checks. Previously we retried stale credentials and treated “connected” as valid; now we classify connections as working, needs_reconnect, or unavailable, and surface failures in Settings.

- Adds POST `/api/integrations/sentry/check` to refresh tokens (per-account lease), list projects, replace `sentry_project` resources, and set status. Only updates if the encrypted credentials still match; if superseded by reconnect/refresh, returns unavailable without changing status. 401/403 and authorization 400 => needs_reconnect and the account is marked error; 5xx/network => unavailable without changing status. Sentry API calls time out and throw `SentryApiError`; logs include `httpStatus`.
- GET `/api/integrations/sentry/start?mode=reconnect` always begins a new authorization. The non-reconnect path attempts a safe retry (with leased token refresh) and falls back to fresh auth; invalid stored creds are marked error via a conditional update that only applies if the encrypted credentials still match.
- Settings shows Working/Checking/Not verified/Reconnect badges and sets `connectUrl` to the reconnect path when an account exists. Connected Sentry accounts trigger a live check on load. Integration summaries include an `accounts` array for per-account status.
- Runtime Sentry token refresh uses the same lease and marks the account error on 400/401/403. No schema changes.

**Rollout/QA**
- From Settings, verify reconnect routes to `/api/integrations/sentry/start?mode=reconnect`.
- With an expired/invalid token, loading Settings triggers `/api/integrations/sentry/check`; expect a Reconnect badge and account status=error.
- During a temporary Sentry outage, expect Not verified and no status change.
- On a successful check, resources are replaced with current projects and the badge shows Working with the project count.
- If a reconnect happens during a check, the check should return unavailable and not overwrite the new credentials.

<sup>Written for commit db85b76c0fb0b279b0836b50beefda604c200aed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/responder-oss/pull/37?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

