### PR TITLE
Make PR issue context clear and linked

### DIFF
--- a/apps/worker/src/github-pull-request.test.ts
+++ b/apps/worker/src/github-pull-request.test.ts
@@ -10,15 +10,30 @@ function commandResult(exitCode: number, output = "") {
 }
 
 describe("GitHub pull requests from Daytona", () => {
-  it("builds the same report body as the old agent", () => {
+  it("builds a simple failure explanation with deterministic issue links", () => {
     expect(
       buildPullRequestBody({
-        issue: "The route throws.",
+        failureMechanism:
+          "The page expected a value that was missing, so it stopped loading.",
+        responderIssueUrl: "https://responder.example/issues/issue-1",
+        sentryIssueUrl: "https://example.sentry.io/issues/42/",
         summary: "## Summary\nHandle the missing value.",
         testing: "## Testing\nUnit tests pass.",
       }),
     ).toBe(
-      "## Summary\nHandle the missing value.\n\n## Issue\nThe route throws.\n\n## Testing\nUnit tests pass.",
+      "## Summary\nHandle the missing value.\n\n## Issue\nThe page expected a value that was missing, so it stopped loading.\n\n[Responder issue](<https://responder.example/issues/issue-1>) · [Sentry issue](<https://example.sentry.io/issues/42/>)\n\n## Testing\nUnit tests pass.",
+    );
+  });
+
+  it("omits issue links when they are unavailable", () => {
+    expect(
+      buildPullRequestBody({
+        failureMechanism: "A missing value made the page stop loading.",
+        summary: "Handle the missing value.",
+        testing: "Unit tests pass.",
+      }),
+    ).toContain(
+      "## Issue\nA missing value made the page stop loading.\n\n## Testing",
     );
   });
 

--- a/apps/worker/src/github-pull-request.ts
+++ b/apps/worker/src/github-pull-request.ts
@@ -64,15 +64,24 @@ function pullRequestSection(heading: string, content: string): string {
 }
 
 export function buildPullRequestBody(input: {
-  issue: string;
+  failureMechanism: string;
+  responderIssueUrl?: string;
+  sentryIssueUrl?: string;
   summary: string;
   testing: string;
 }): string {
+  const issueLinks = [
+    input.responderIssueUrl
+      ? `[Responder issue](<${input.responderIssueUrl}>)`
+      : null,
+    input.sentryIssueUrl ? `[Sentry issue](<${input.sentryIssueUrl}>)` : null,
+  ].filter((link): link is string => Boolean(link));
   return [
     pullRequestSection("Summary", input.summary),
     "",
     "## Issue",
-    input.issue.trim(),
+    input.failureMechanism.trim(),
+    ...(issueLinks.length > 0 ? ["", issueLinks.join(" · ")] : []),
     "",
     pullRequestSection("Testing", input.testing),
   ].join("\n");

--- a/apps/worker/src/pull-request.test.ts
+++ b/apps/worker/src/pull-request.test.ts
@@ -54,7 +54,8 @@ describe("pull request tool", () => {
       requestId,
       issueTitle: "Broken route",
       issueDescription: "The route throws.",
-      issueEvidence: [
+      issueEvidence: [],
+      investigationEvidence: [
         {
           source: "sentry",
           title: "Broken route",
@@ -64,11 +65,11 @@ describe("pull request tool", () => {
       ],
       issueRemediation: "Handle the missing value.",
       investigationInput: {
-        provider: "sentry",
-        externalEventId: "42",
+        provider: "slack",
+        externalEventId: "thread-1",
         title: "Broken route",
         body: "The route throws.",
-        sourceUrl: "https://example.sentry.io/issues/42/",
+        sourceUrl: "https://slack.com/archives/C1/p1",
       },
       status: "creating",
     });
@@ -137,7 +138,7 @@ describe("pull request tool", () => {
       responderIssueUrl("issue 1", {
         RESPONDER_APP_URL: "https://responder.example/base",
       }),
-    ).toBe("https://responder.example/issues/issue%201");
+    ).toBe("https://responder.example/base/issues/issue%201");
     expect(responderIssueUrl("issue-1", {})).toBeUndefined();
   });
 

--- a/apps/worker/src/pull-request.test.ts
+++ b/apps/worker/src/pull-request.test.ts
@@ -6,7 +6,11 @@ import {
   markIssuePullRequestCreated,
 } from "@responder/core/db/pull-requests";
 import { createPullRequestFromSandbox } from "./github-pull-request.js";
-import { createPullRequestTool } from "./pull-request.js";
+import {
+  createPullRequestTool,
+  responderIssueUrl,
+  sentryIssueUrl,
+} from "./pull-request.js";
 
 vi.mock("@responder/core/db/investigations", () => ({
   getRuntimeRepositories: vi.fn(),
@@ -50,7 +54,22 @@ describe("pull request tool", () => {
       requestId,
       issueTitle: "Broken route",
       issueDescription: "The route throws.",
+      issueEvidence: [
+        {
+          source: "sentry",
+          title: "Broken route",
+          detail: "The route throws.",
+          url: "https://example.sentry.io/issues/42/",
+        },
+      ],
       issueRemediation: "Handle the missing value.",
+      investigationInput: {
+        provider: "sentry",
+        externalEventId: "42",
+        title: "Broken route",
+        body: "The route throws.",
+        sourceUrl: "https://example.sentry.io/issues/42/",
+      },
       status: "creating",
     });
     vi.mocked(getRuntimeRepositories).mockResolvedValue([
@@ -81,6 +100,8 @@ describe("pull request tool", () => {
         JSON.stringify({
           issueId,
           repository: "acme/service",
+          failureMechanism:
+            "A missing value made the page stop loading.",
           summary: "Handle the unchecked value.",
           testing: "Added a regression test.",
         }),
@@ -101,5 +122,56 @@ describe("pull request tool", () => {
       pullRequestNumber: 17,
       pullRequestUrl: "https://github.com/acme/service/pull/17",
     });
+    expect(createPullRequestFromSandbox).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.stringContaining(
+          "[Sentry issue](<https://example.sentry.io/issues/42/>)",
+        ),
+      }),
+      session,
+    );
+  });
+
+  it("builds a Responder issue URL only when an app origin is configured", () => {
+    expect(
+      responderIssueUrl("issue 1", {
+        RESPONDER_APP_URL: "https://responder.example/base",
+      }),
+    ).toBe("https://responder.example/issues/issue%201");
+    expect(responderIssueUrl("issue-1", {})).toBeUndefined();
+  });
+
+  it("prefers a Sentry-triggered issue URL and falls back to issue evidence", () => {
+    expect(
+      sentryIssueUrl(
+        {
+          provider: "sentry",
+          externalEventId: "42",
+          title: "Broken route",
+          body: "The route throws.",
+          sourceUrl: "https://example.sentry.io/issues/42/",
+        },
+        [],
+      ),
+    ).toBe("https://example.sentry.io/issues/42/");
+    expect(
+      sentryIssueUrl(
+        {
+          provider: "slack",
+          externalEventId: "thread-1",
+          title: "Broken route",
+          body: "The route throws.",
+          sourceUrl: "https://slack.com/archives/C1/p1",
+        },
+        [
+          {
+            source: "sentry",
+            title: "Broken route",
+            detail: "The route throws.",
+            url: "https://example.sentry.io/issues/43/",
+          },
+        ],
+      ),
+    ).toBe("https://example.sentry.io/issues/43/");
   });
 });

--- a/apps/worker/src/pull-request.ts
+++ b/apps/worker/src/pull-request.ts
@@ -10,6 +10,7 @@ import {
 } from "@responder/core/db/pull-requests";
 import type { InvestigationInput } from "@responder/core/db/schema";
 import type { IssueEvidence } from "@responder/core/investigations/report";
+import { responderIssueUrl as buildResponderIssueUrl } from "@responder/core/responder-urls";
 import { z } from "zod";
 import {
   buildPullRequestBody,
@@ -35,8 +36,7 @@ export function responderIssueUrl(
   const origin = environment.RESPONDER_APP_URL ?? environment.BETTER_AUTH_URL;
   if (!origin) return undefined;
   try {
-    const url = new URL(`/issues/${encodeURIComponent(issueId)}`, origin);
-    return ["http:", "https:"].includes(url.protocol) ? url.toString() : undefined;
+    return buildResponderIssueUrl(issueId, origin);
   } catch {
     return undefined;
   }
@@ -134,7 +134,7 @@ export function createPullRequestTool(input: {
               responderIssueUrl: responderIssueUrl(requestedPullRequest.issueId),
               sentryIssueUrl: sentryIssueUrl(
                 request.investigationInput,
-                request.issueEvidence,
+                [...request.issueEvidence, ...request.investigationEvidence],
               ),
               summary: requestedPullRequest.summary,
               testing: requestedPullRequest.testing,

--- a/apps/worker/src/pull-request.ts
+++ b/apps/worker/src/pull-request.ts
@@ -8,6 +8,8 @@ import {
   markIssuePullRequestCreated,
   markIssuePullRequestStarted,
 } from "@responder/core/db/pull-requests";
+import type { InvestigationInput } from "@responder/core/db/schema";
+import type { IssueEvidence } from "@responder/core/investigations/report";
 import { z } from "zod";
 import {
   buildPullRequestBody,
@@ -26,6 +28,43 @@ const checkedOutRepositoriesSchema = z.object({
   ),
 });
 
+export function responderIssueUrl(
+  issueId: string,
+  environment: NodeJS.ProcessEnv = process.env,
+): string | undefined {
+  const origin = environment.RESPONDER_APP_URL ?? environment.BETTER_AUTH_URL;
+  if (!origin) return undefined;
+  try {
+    const url = new URL(`/issues/${encodeURIComponent(issueId)}`, origin);
+    return ["http:", "https:"].includes(url.protocol) ? url.toString() : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function sentryIssueUrl(
+  input: InvestigationInput,
+  evidence: IssueEvidence[],
+): string | undefined {
+  const candidates = [
+    ...(input.provider === "sentry" && input.sourceUrl ? [input.sourceUrl] : []),
+    ...evidence.flatMap((item) =>
+      item.source === "sentry" && item.url ? [item.url] : [],
+    ),
+  ];
+  return candidates.find((candidate) => {
+    try {
+      const url = new URL(candidate);
+      return (
+        ["http:", "https:"].includes(url.protocol) &&
+        url.pathname.split("/").includes("issues")
+      );
+    } catch {
+      return false;
+    }
+  });
+}
+
 export function createPullRequestTool(input: {
   agentConfigVersionId: string;
   investigationId: string;
@@ -40,6 +79,14 @@ export function createPullRequestTool(input: {
     parameters: z.object({
       issueId: z.uuid(),
       repository: z.string().min(1),
+      failureMechanism: z
+        .string()
+        .trim()
+        .min(1)
+        .max(1_000)
+        .describe(
+          "In one or two very short sentences, explain what failed and why. Use extremely simple language that anyone can understand at a glance. Use no jargon, acronyms, code names, or implementation details.",
+        ),
       summary: z.string().trim().min(1).max(4_000),
       testing: z.string().trim().min(1).max(2_000),
     }),
@@ -83,7 +130,12 @@ export function createPullRequestTool(input: {
             baseBranch: checkout.branch,
             baseSha: checkout.sha,
             body: buildPullRequestBody({
-              issue: request.issueDescription,
+              failureMechanism: requestedPullRequest.failureMechanism,
+              responderIssueUrl: responderIssueUrl(requestedPullRequest.issueId),
+              sentryIssueUrl: sentryIssueUrl(
+                request.investigationInput,
+                request.issueEvidence,
+              ),
               summary: requestedPullRequest.summary,
               testing: requestedPullRequest.testing,
             }),

--- a/apps/worker/src/remediate.test.ts
+++ b/apps/worker/src/remediate.test.ts
@@ -2,6 +2,7 @@ import { MaxTurnsExceededError } from "@openai/agents";
 import { describe, expect, it } from "vitest";
 import {
   remediationApplyPatchPathInstruction,
+  remediationFailureMechanismInstruction,
   remediationMaxTurns,
   remediationRunDiagnostics,
 } from "./remediate.js";
@@ -69,6 +70,16 @@ describe("remediation agent", () => {
     expect(remediationApplyPatchPathInstruction).toContain(
       "Repository-relative paths",
     );
+  });
+
+  it("requires an extremely simple failure mechanism", () => {
+    expect(remediationFailureMechanismInstruction).toContain(
+      "what failed and why",
+    );
+    expect(remediationFailureMechanismInstruction).toContain(
+      "anyone can understand at a glance",
+    );
+    expect(remediationFailureMechanismInstruction).toContain("no jargon");
   });
 
   it("retains a safe apply_patch failure category without raw output", () => {

--- a/apps/worker/src/remediate.ts
+++ b/apps/worker/src/remediate.ts
@@ -33,6 +33,8 @@ import {
 export const remediationMaxTurns = 40;
 export const remediationApplyPatchPathInstruction =
   "When using apply_patch, use the full absolute checkout path shown above. Repository-relative paths are resolved from the workspace root and may target the wrong location.";
+export const remediationFailureMechanismInstruction =
+  "For the pull request failure mechanism, explain what failed and why in one or two very short sentences. Use extremely simple language that anyone can understand at a glance. Use no jargon, acronyms, code names, or implementation details.";
 
 export interface RemediationApplyPatchFailure {
   callId: string;
@@ -216,6 +218,7 @@ export async function runRemediationAgent(
         ),
         remediationApplyPatchPathInstruction,
         "Inspect the relevant code, make the smallest safe fix in exactly one selected repository, and run the narrowest useful checks.",
+        remediationFailureMechanismInstruction,
         `Then call create_pull_request with issue ID ${job.issue.id}. Do not finish without creating the pull request or clearly explaining why no safe code fix is possible.`,
         "Do not expose credentials or secret values. The pull request is the only allowed external change.",
         workspaceSecretUsageInstructions(workspaceSecrets),

--- a/packages/core/src/db/pull-requests.ts
+++ b/packages/core/src/db/pull-requests.ts
@@ -403,6 +403,7 @@ export async function getExecutableIssuePullRequest(input: {
       issueDescription: issues.description,
       issueEvidence: issues.evidence,
       issueRemediation: issues.remediation,
+      investigationEvidence: investigationIssues.evidence,
       investigationInput: investigations.input,
       status: issuePullRequests.status,
     })
@@ -411,6 +412,16 @@ export async function getExecutableIssuePullRequest(input: {
     .innerJoin(
       investigations,
       eq(investigations.id, issuePullRequests.investigationId),
+    )
+    .innerJoin(
+      investigationIssues,
+      and(
+        eq(investigationIssues.issueId, issuePullRequests.issueId),
+        eq(
+          investigationIssues.investigationId,
+          issuePullRequests.investigationId,
+        ),
+      ),
     )
     .where(
       and(

--- a/packages/core/src/db/pull-requests.ts
+++ b/packages/core/src/db/pull-requests.ts
@@ -401,7 +401,9 @@ export async function getExecutableIssuePullRequest(input: {
       requestId: issuePullRequests.id,
       issueTitle: issues.title,
       issueDescription: issues.description,
+      issueEvidence: issues.evidence,
       issueRemediation: issues.remediation,
+      investigationInput: investigations.input,
       status: issuePullRequests.status,
     })
     .from(issuePullRequests)

--- a/packages/core/src/integrations/slack-delivery.ts
+++ b/packages/core/src/integrations/slack-delivery.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { decryptCredentials } from "../credentials/encryption.js";
+import { responderIssueUrl } from "../responder-urls.js";
 import {
   getSlackInvestigationDeliveryContext,
   type SlackInvestigationDeliveryContext,
@@ -83,7 +84,7 @@ export function slackIssueMessage(
 ): { blocks: unknown[]; text: string } {
   const recurrence = issue.relationship === "recurrence" ? " · Recurrence" : "";
   const text = `${issue.severity} — ${issue.title}${recurrence}\n${issue.description}`;
-  const issueUrl = `${responderAppUrl()}/issues/${encodeURIComponent(issue.id)}`;
+  const issueUrl = responderIssueUrl(issue.id, responderAppUrl());
   const blockText = truncateSlackBlock(
     [
       `*${issue.severity} — ${escapeSlack(issue.title)}*${recurrence}`,

--- a/packages/core/src/integrations/slack-live-card.ts
+++ b/packages/core/src/integrations/slack-live-card.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { z } from "zod";
 import { decryptCredentials } from "../credentials/encryption.js";
+import { responderIssueUrl } from "../responder-urls.js";
 import { recordInvestigationSlackTrace } from "../db/investigations.js";
 import { getSlackInvestigationLiveContext } from "../db/issues.js";
 import {
@@ -35,22 +36,17 @@ function nonEmptyText(
   return rendered.trim().length > 0 ? rendered : fallback;
 }
 
-function investigationUrl(agentId: string, investigationId: string): string {
-  const origin = (
+function responderAppUrl(): string {
+  return (
     process.env.RESPONDER_APP_URL ??
     process.env.BETTER_AUTH_URL ??
     "http://localhost:3000"
   ).replace(/\/$/, "");
-  return `${origin}/agents/${encodeURIComponent(agentId)}/investigations/${encodeURIComponent(investigationId)}`;
 }
 
-function issueUrl(issueId: string): string {
-  const origin = (
-    process.env.RESPONDER_APP_URL ??
-    process.env.BETTER_AUTH_URL ??
-    "http://localhost:3000"
-  ).replace(/\/$/, "");
-  return `${origin}/issues/${encodeURIComponent(issueId)}`;
+function investigationUrl(agentId: string, investigationId: string): string {
+  const origin = responderAppUrl();
+  return `${origin}/agents/${encodeURIComponent(agentId)}/investigations/${encodeURIComponent(investigationId)}`;
 }
 
 function richText(value: string, preformatted = false) {
@@ -326,7 +322,7 @@ function issueLinkList(
           elements: [
             {
               type: "link",
-              url: issueUrl(issue.id),
+              url: responderIssueUrl(issue.id, responderAppUrl()),
               text: nonEmptyText(issue.title, 2_000, "Untitled issue"),
             },
           ],

--- a/packages/core/src/responder-urls.test.ts
+++ b/packages/core/src/responder-urls.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { responderIssueUrl } from "./responder-urls.js";
+
+describe("Responder URLs", () => {
+  it("preserves an application path prefix", () => {
+    expect(
+      responderIssueUrl("issue 1", "https://responder.example/app/"),
+    ).toBe("https://responder.example/app/issues/issue%201");
+  });
+
+  it("rejects non-HTTP origins", () => {
+    expect(() => responderIssueUrl("issue-1", "javascript:alert(1)"))
+      .toThrow("Responder URLs must use HTTP or HTTPS");
+  });
+});

--- a/packages/core/src/responder-urls.ts
+++ b/packages/core/src/responder-urls.ts
@@ -1,0 +1,10 @@
+export function responderIssueUrl(issueId: string, origin: string): string {
+  const url = new URL(origin);
+  if (!["http:", "https:"].includes(url.protocol)) {
+    throw new Error("Responder URLs must use HTTP or HTTPS");
+  }
+  url.pathname = `${url.pathname.replace(/\/+$/, "")}/issues/${encodeURIComponent(issueId)}`;
+  url.search = "";
+  url.hash = "";
+  return url.toString();
+}


### PR DESCRIPTION
## Summary

- require a one- or two-sentence explanation of what failed and why
- require extremely simple wording with no jargon, acronyms, code names, or implementation details
- add Responder and Sentry issue links in code whenever their URLs are available

## Why

The PR issue section currently repeats the stored issue description and has no reliable source links. This makes the failure harder to understand quickly and forces reviewers to search for the original reports.

## Impact

New remediation PRs will show a short, plain-language failure mechanism and direct links back to the source issues. Link generation does not depend on model output.

Hosted gitlink PR: https://github.com/superloglabs/responder/pull/128

Merge this public PR first. The hosted PR must point to the final public commit before it merges.

## Testing

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test` (99 files, 659 tests)
