### PR TITLE
Support large repository checkouts

### DIFF
--- a/apps/worker/src/repositories.test.ts
+++ b/apps/worker/src/repositories.test.ts
@@ -1,4 +1,5 @@
 import type { DaytonaSandboxSession } from "@openai/agents-extensions/sandbox/daytona";
+import { readFile } from "node:fs/promises";
 import { describe, expect, it, vi } from "vitest";
 import {
   checkoutRuntimeRepositories,
@@ -16,9 +17,14 @@ function fakeSession() {
   } as unknown as DaytonaSandboxSession;
 }
 
+function uploadArchive() {
+  return vi.fn().mockResolvedValue(undefined);
+}
+
 describe("Daytona repository checkout", () => {
   it("downloads selected repositories without placing the GitHub token in the sandbox", async () => {
     const session = fakeSession();
+    const upload = uploadArchive();
     const fetchMock = vi
       .fn<typeof fetch>()
       .mockResolvedValueOnce(
@@ -45,6 +51,7 @@ describe("Daytona repository checkout", () => {
             private: true,
           },
         ]),
+        uploadArchive: upload,
       },
     );
 
@@ -57,7 +64,7 @@ describe("Daytona repository checkout", () => {
         workspaceBaseSha: sha,
       },
     ]);
-    expect(session.materializeEntry).toHaveBeenCalledTimes(2);
+    expect(session.materializeEntry).toHaveBeenCalledTimes(1);
     expect(session.execCommand).toHaveBeenCalledTimes(1);
     expect(JSON.stringify(vi.mocked(session.materializeEntry).mock.calls)).not.toContain(
       "github-secret",
@@ -65,6 +72,7 @@ describe("Daytona repository checkout", () => {
     expect(JSON.stringify(vi.mocked(session.execCommand).mock.calls)).not.toContain(
       "github-secret",
     );
+    expect(JSON.stringify(upload.mock.calls)).not.toContain("github-secret");
     expect(fetchMock).toHaveBeenCalledWith(
       `https://api.github.com/repos/example-org/example-repo/tarball/${sha}`,
       expect.objectContaining({
@@ -97,7 +105,6 @@ describe("Daytona repository checkout", () => {
           new Response("temporarily unavailable", { status }),
         );
       const downloadWithGit = vi.fn().mockResolvedValue({
-        archive: new Uint8Array([31, 139, 8, 0]),
         sha,
       });
 
@@ -107,6 +114,7 @@ describe("Daytona repository checkout", () => {
           downloadWithGit,
           fetch: fetchMock,
           getRepositories: vi.fn().mockResolvedValue([repository]),
+          uploadArchive: uploadArchive(),
         }),
       ).resolves.toEqual([
         expect.objectContaining({ repository: repository.fullName, sha }),
@@ -115,6 +123,8 @@ describe("Daytona repository checkout", () => {
         repository,
         "github-secret",
         sha,
+        expect.any(String),
+        5 * 1024 * 1024 * 1024,
       );
       expect(
         JSON.stringify(vi.mocked(session.materializeEntry).mock.calls),
@@ -133,7 +143,6 @@ describe("Daytona repository checkout", () => {
         private: true,
       };
       const downloadWithGit = vi.fn().mockResolvedValue({
-        archive: new Uint8Array([31, 139, 8, 0]),
         sha,
       });
 
@@ -147,6 +156,7 @@ describe("Daytona repository checkout", () => {
               new Response("temporarily unavailable", { status }),
             ),
           getRepositories: vi.fn().mockResolvedValue([repository]),
+          uploadArchive: uploadArchive(),
         }),
       ).resolves.toEqual([
         expect.objectContaining({ repository: repository.fullName, sha }),
@@ -155,6 +165,8 @@ describe("Daytona repository checkout", () => {
         repository,
         "github-secret",
         repository.defaultBranch,
+        expect.any(String),
+        5 * 1024 * 1024 * 1024,
       );
     },
   );
@@ -168,7 +180,6 @@ describe("Daytona repository checkout", () => {
       private: true,
     };
     const downloadWithGit = vi.fn().mockResolvedValue({
-      archive: new Uint8Array([31, 139, 8, 0]),
       sha,
     });
 
@@ -180,6 +191,7 @@ describe("Daytona repository checkout", () => {
           .fn<typeof fetch>()
           .mockRejectedValue(new DOMException("Timed out", "AbortError")),
         getRepositories: vi.fn().mockResolvedValue([repository]),
+        uploadArchive: uploadArchive(),
       }),
     ).resolves.toEqual([
       expect.objectContaining({ repository: repository.fullName, sha }),
@@ -188,6 +200,8 @@ describe("Daytona repository checkout", () => {
       repository,
       "github-secret",
       repository.defaultBranch,
+      expect.any(String),
+      5 * 1024 * 1024 * 1024,
     );
   });
 
@@ -200,7 +214,6 @@ describe("Daytona repository checkout", () => {
       private: true,
     };
     const downloadWithGit = vi.fn().mockResolvedValue({
-      archive: new Uint8Array([31, 139, 8, 0]),
       sha,
     });
     const fetchMock = vi
@@ -219,6 +232,7 @@ describe("Daytona repository checkout", () => {
         downloadWithGit,
         fetch: fetchMock,
         getRepositories: vi.fn().mockResolvedValue([repository]),
+        uploadArchive: uploadArchive(),
       }),
     ).resolves.toEqual([
       expect.objectContaining({ repository: repository.fullName, sha }),
@@ -227,7 +241,88 @@ describe("Daytona repository checkout", () => {
       repository,
       "github-secret",
       sha,
+      expect.any(String),
+      5 * 1024 * 1024 * 1024,
     );
+  });
+
+  it("accepts repository archives declared larger than the previous 100 MB limit", async () => {
+    const session = fakeSession();
+    let uploadedArchive: Buffer | undefined;
+    const upload = vi.fn(
+      async (_session: DaytonaSandboxSession, localPath: string) => {
+        uploadedArchive = await readFile(localPath);
+      },
+    );
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ sha }), { status: 200 }),
+      )
+      .mockResolvedValueOnce(
+        new Response(new Uint8Array([31, 139, 8, 0]), {
+          headers: { "content-length": String(101 * 1024 * 1024) },
+          status: 200,
+        }),
+      );
+
+    await expect(
+      checkoutRuntimeRepositories(session, "version-id", {
+        createInstallationToken: vi.fn().mockResolvedValue("github-secret"),
+        fetch: fetchMock,
+        getRepositories: vi.fn().mockResolvedValue([
+          {
+            defaultBranch: "main",
+            fullName: "example-org/large-repo",
+            installationId: 123,
+            private: true,
+          },
+        ]),
+        uploadArchive: upload,
+      }),
+    ).resolves.toEqual([
+      expect.objectContaining({ repository: "example-org/large-repo", sha }),
+    ]);
+    expect(upload).toHaveBeenCalledWith(
+      session,
+      expect.stringMatching(/repository\.tar\.gz$/),
+      expect.stringContaining("example-org-large-repo"),
+    );
+    expect(uploadedArchive).toEqual(Buffer.from([31, 139, 8, 0]));
+  });
+
+  it("keeps a configurable disk-safety limit for exceptionally large archives", async () => {
+    const session = fakeSession();
+    const archive = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new Uint8Array([1, 2, 3]));
+        controller.enqueue(new Uint8Array([4, 5, 6]));
+        controller.close();
+      },
+    });
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ sha }), { status: 200 }),
+      )
+      .mockResolvedValueOnce(new Response(archive, { status: 200 }));
+
+    await expect(
+      checkoutRuntimeRepositories(session, "version-id", {
+        createInstallationToken: vi.fn().mockResolvedValue("github-secret"),
+        fetch: fetchMock,
+        getRepositories: vi.fn().mockResolvedValue([
+          {
+            defaultBranch: "main",
+            fullName: "example-org/too-large-repo",
+            installationId: 123,
+            private: true,
+          },
+        ]),
+        maxArchiveBytes: 4,
+        uploadArchive: uploadArchive(),
+      }),
+    ).rejects.toThrow("GitHub repository archive exceeds the 4 bytes limit");
   });
 
   it("rejects repository names that could escape the workspace", () => {

--- a/apps/worker/src/repositories.test.ts
+++ b/apps/worker/src/repositories.test.ts
@@ -1,5 +1,7 @@
 import type { DaytonaSandboxSession } from "@openai/agents-extensions/sandbox/daytona";
-import { readFile } from "node:fs/promises";
+import { access, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import {
   checkoutRuntimeRepositories,
@@ -323,6 +325,58 @@ describe("Daytona repository checkout", () => {
         uploadArchive: uploadArchive(),
       }),
     ).rejects.toThrow("GitHub repository archive exceeds the 4 bytes limit");
+  });
+
+  it("stops Git archive generation as soon as the disk-safety limit is crossed", async () => {
+    const temporaryDirectory = await mkdtemp(
+      join(tmpdir(), "responder-git-limit-test-"),
+    );
+    const binDirectory = join(temporaryDirectory, "bin");
+    const gitPath = join(binDirectory, "git");
+    const completionMarker = join(temporaryDirectory, "archive-completed");
+    await mkdir(binDirectory);
+    await writeFile(
+      gitPath,
+      [
+        "#!/bin/sh",
+        "case \" $* \" in",
+        "  *\" rev-parse \"*) printf '%s\\n' \"$RESPONDER_TEST_GIT_SHA\" ;;",
+        "  *\" archive \"*)",
+        "    printf '12345'",
+        "    sleep 1",
+        "    : > \"$RESPONDER_TEST_GIT_COMPLETED\"",
+        "    printf '6789'",
+        "    ;;",
+        "esac",
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+    vi.stubEnv("PATH", `${binDirectory}:${process.env.PATH ?? ""}`);
+    vi.stubEnv("RESPONDER_TEST_GIT_SHA", sha);
+    vi.stubEnv("RESPONDER_TEST_GIT_COMPLETED", completionMarker);
+
+    try {
+      await expect(
+        checkoutRuntimeRepositories(fakeSession(), "version-id", {
+          createInstallationToken: vi.fn().mockResolvedValue("github-secret"),
+          fetch: vi.fn<typeof fetch>().mockRejectedValue(new Error("offline")),
+          getRepositories: vi.fn().mockResolvedValue([
+            {
+              defaultBranch: "main",
+              fullName: "example-org/git-fallback-repo",
+              installationId: 123,
+              private: true,
+            },
+          ]),
+          maxArchiveBytes: 4,
+          temporaryDirectory,
+        }),
+      ).rejects.toThrow("GitHub repository archive exceeds the 4 bytes limit");
+      await expect(access(completionMarker)).rejects.toThrow();
+    } finally {
+      vi.unstubAllEnvs();
+      await rm(temporaryDirectory, { force: true, recursive: true });
+    }
   });
 
   it("rejects repository names that could escape the workspace", () => {

--- a/apps/worker/src/repositories.ts
+++ b/apps/worker/src/repositories.ts
@@ -1,8 +1,12 @@
+import { Daytona } from "@daytona/sdk";
 import type { DaytonaSandboxSession } from "@openai/agents-extensions/sandbox/daytona";
 import { execFile } from "node:child_process";
-import { mkdtemp, mkdir, readFile, rm, stat } from "node:fs/promises";
+import { createWriteStream } from "node:fs";
+import { mkdtemp, mkdir, rm, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
+import { Readable, Transform } from "node:stream";
+import { pipeline } from "node:stream/promises";
 import { promisify } from "node:util";
 import {
   getRuntimeRepositories,
@@ -12,9 +16,47 @@ import {
   createGitHubInstallationToken,
   githubAppHeaders,
 } from "@responder/core/integrations/github";
-const maxArchiveBytes = 100 * 1024 * 1024;
+const defaultMaxArchiveBytes = 5 * 1024 * 1024 * 1024;
+const repositoryDownloadTimeoutMs = 10 * 60_000;
+const repositoryUploadTimeoutSeconds = 30 * 60;
 const workspaceRoot = "/home/daytona/workspace";
 const execFileAsync = promisify(execFile);
+
+class RepositoryArchiveLimitError extends Error {
+  constructor(limit: number) {
+    super(
+      `GitHub repository archive exceeds the ${formatByteLimit(limit)} limit`,
+    );
+    this.name = "RepositoryArchiveLimitError";
+  }
+}
+
+function formatByteLimit(bytes: number): string {
+  const gibibyte = 1024 * 1024 * 1024;
+  const mebibyte = 1024 * 1024;
+  if (bytes % gibibyte === 0) return `${bytes / gibibyte} GB`;
+  if (bytes % mebibyte === 0) return `${bytes / mebibyte} MB`;
+  return `${bytes} byte${bytes === 1 ? "" : "s"}`;
+}
+
+function repositoryArchiveLimit(
+  environment: NodeJS.ProcessEnv = process.env,
+): number {
+  const configured = environment.RESPONDER_REPOSITORY_ARCHIVE_MAX_BYTES;
+  if (!configured) return defaultMaxArchiveBytes;
+  if (!/^\d+$/.test(configured)) {
+    throw new Error(
+      "RESPONDER_REPOSITORY_ARCHIVE_MAX_BYTES must be a positive integer",
+    );
+  }
+  const limit = Number(configured);
+  if (!Number.isSafeInteger(limit) || limit <= 0) {
+    throw new Error(
+      "RESPONDER_REPOSITORY_ARCHIVE_MAX_BYTES must be a positive safe integer",
+    );
+  }
+  return limit;
+}
 
 export interface CheckedOutRepository {
   branch: string;
@@ -30,9 +72,18 @@ export interface RepositoryCheckoutDependencies {
     repository: RuntimeRepository,
     accessToken: string,
     ref: string,
-  ) => Promise<{ archive: Uint8Array; sha: string }>;
+    archivePath: string,
+    archiveLimitBytes: number,
+  ) => Promise<{ sha: string }>;
   fetch: typeof fetch;
   getRepositories: (versionId: string) => Promise<RuntimeRepository[]>;
+  maxArchiveBytes?: number;
+  temporaryDirectory?: string;
+  uploadArchive?: (
+    session: DaytonaSandboxSession,
+    localPath: string,
+    remotePath: string,
+  ) => Promise<void>;
 }
 
 const defaultDependencies: RepositoryCheckoutDependencies = {
@@ -45,14 +96,11 @@ async function downloadRepositorySnapshotWithGit(
   repository: RuntimeRepository,
   accessToken: string,
   ref: string,
-): Promise<{ archive: Uint8Array; sha: string }> {
-  const temporaryBase =
-    process.env.RESPONDER_REPOSITORY_TEMP_DIR ?? tmpdir();
-  const temporaryRoot = await mkdtemp(
-    join(temporaryBase, "responder-repository-"),
-  );
+  archivePath: string,
+  archiveLimitBytes: number,
+): Promise<{ sha: string }> {
+  const temporaryRoot = dirname(archivePath);
   const gitDirectory = join(temporaryRoot, "repository.git");
-  const archivePath = join(temporaryRoot, "repository.tar.gz");
   const gitEnvironment = {
     ...process.env,
     GIT_CONFIG_COUNT: "1",
@@ -89,7 +137,7 @@ async function downloadRepositorySnapshotWithGit(
         "origin",
         ref,
       ],
-      { env: gitEnvironment, timeout: 120_000 },
+      { env: gitEnvironment, timeout: repositoryDownloadTimeoutMs },
     );
     const { stdout } = await execFileAsync(
       "git",
@@ -110,25 +158,37 @@ async function downloadRepositorySnapshotWithGit(
         `--output=${archivePath}`,
         "FETCH_HEAD",
       ],
-      { timeout: 120_000 },
+      { timeout: repositoryDownloadTimeoutMs },
     );
     const archiveStats = await stat(archivePath);
-    if (archiveStats.size > maxArchiveBytes) {
-      throw new Error("GitHub repository archive exceeds the 100 MB limit");
+    if (archiveStats.size > archiveLimitBytes) {
+      throw new RepositoryArchiveLimitError(archiveLimitBytes);
     }
-    return { archive: new Uint8Array(await readFile(archivePath)), sha };
+    return { sha };
   } catch (error) {
-    if (
-      error instanceof Error &&
-      error.message === "GitHub repository archive exceeds the 100 MB limit"
-    ) {
-      throw error;
-    }
+    if (error instanceof RepositoryArchiveLimitError) throw error;
     throw new Error(
       `Unable to download ${repository.fullName}@${ref} using Git fallback`,
     );
+  }
+}
+
+async function uploadRepositoryArchive(
+  session: DaytonaSandboxSession,
+  localPath: string,
+  remotePath: string,
+): Promise<void> {
+  const { apiKey, apiUrl, sandboxId, target } = session.state;
+  if (!apiKey) throw new Error("Daytona API key is unavailable for file upload");
+
+  const client = new Daytona({ apiKey, apiUrl, target });
+  try {
+    const sandbox = await client.get(sandboxId);
+    await sandbox.fs.uploadFileStream(localPath, remotePath, {
+      timeout: repositoryUploadTimeoutSeconds,
+    });
   } finally {
-    await rm(temporaryRoot, { force: true, recursive: true });
+    await client[Symbol.asyncDispose]().catch(() => undefined);
   }
 }
 
@@ -181,41 +241,34 @@ async function runSandboxCommand(
   );
 }
 
-async function readResponseWithLimit(
+async function writeResponseWithLimit(
   response: Response,
-  limit = maxArchiveBytes,
-): Promise<Uint8Array> {
-  const declaredLength = Number(response.headers.get("content-length"));
+  archivePath: string,
+  limit: number,
+): Promise<void> {
+  const declaredLengthHeader = response.headers.get("content-length");
+  const declaredLength = Number(declaredLengthHeader);
   if (Number.isFinite(declaredLength) && declaredLength > limit) {
-    throw new Error("GitHub repository archive exceeds the 100 MB limit");
+    throw new RepositoryArchiveLimitError(limit);
   }
   if (!response.body) throw new Error("GitHub returned an empty archive");
 
-  const reader = response.body.getReader();
-  const chunks: Uint8Array[] = [];
   let byteLength = 0;
-  try {
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) break;
-      byteLength += value.byteLength;
+  const limiter = new Transform({
+    transform(chunk: Buffer, _encoding, callback) {
+      byteLength += chunk.byteLength;
       if (byteLength > limit) {
-        await reader.cancel();
-        throw new Error("GitHub repository archive exceeds the 100 MB limit");
+        callback(new RepositoryArchiveLimitError(limit));
+        return;
       }
-      chunks.push(value);
-    }
-  } finally {
-    reader.releaseLock();
-  }
-
-  const archive = new Uint8Array(byteLength);
-  let offset = 0;
-  for (const chunk of chunks) {
-    archive.set(chunk, offset);
-    offset += chunk.byteLength;
-  }
-  return archive;
+      callback(null, chunk);
+    },
+  });
+  await pipeline(
+    Readable.from(response.body as AsyncIterable<Uint8Array>),
+    limiter,
+    createWriteStream(archivePath, { flags: "wx" }),
+  );
 }
 
 function shouldUseGitFallback(response: Response): boolean {
@@ -232,11 +285,19 @@ async function downloadExactSnapshotWithGit(
   repository: RuntimeRepository,
   accessToken: string,
   sha: string,
+  archivePath: string,
+  archiveLimitBytes: number,
   downloadWithGit: NonNullable<
     RepositoryCheckoutDependencies["downloadWithGit"]
   >,
-): Promise<{ archive: Uint8Array; sha: string }> {
-  const fallback = await downloadWithGit(repository, accessToken, sha);
+): Promise<{ sha: string }> {
+  const fallback = await downloadWithGit(
+    repository,
+    accessToken,
+    sha,
+    archivePath,
+    archiveLimitBytes,
+  );
   if (fallback.sha !== sha) {
     throw new Error(`Git returned an unexpected commit for ${repository.fullName}`);
   }
@@ -247,10 +308,12 @@ async function fetchRepositorySnapshot(
   repository: RuntimeRepository,
   accessToken: string,
   fetchImpl: typeof fetch,
+  archivePath: string,
+  archiveLimitBytes: number,
   downloadWithGit: NonNullable<
     RepositoryCheckoutDependencies["downloadWithGit"]
   >,
-): Promise<{ archive: Uint8Array; sha: string }> {
+): Promise<{ sha: string }> {
   const headers = githubAppHeaders(accessToken);
   const branch = encodeURIComponent(repository.defaultBranch);
   let commitResponse: Response;
@@ -260,7 +323,13 @@ async function fetchRepositorySnapshot(
       { headers, signal: AbortSignal.timeout(30_000) },
     );
   } catch {
-    return downloadWithGit(repository, accessToken, repository.defaultBranch);
+    return downloadWithGit(
+      repository,
+      accessToken,
+      repository.defaultBranch,
+      archivePath,
+      archiveLimitBytes,
+    );
   }
   if (!commitResponse.ok) {
     if (shouldUseGitFallback(commitResponse)) {
@@ -269,6 +338,8 @@ async function fetchRepositorySnapshot(
         repository,
         accessToken,
         repository.defaultBranch,
+        archivePath,
+        archiveLimitBytes,
       );
     }
     throw new Error(
@@ -285,13 +356,15 @@ async function fetchRepositorySnapshot(
   try {
     archiveResponse = await fetchImpl(
       `https://api.github.com/repos/${repository.fullName}/tarball/${sha}`,
-      { headers, signal: AbortSignal.timeout(60_000) },
+      { headers, signal: AbortSignal.timeout(repositoryDownloadTimeoutMs) },
     );
   } catch {
     return downloadExactSnapshotWithGit(
       repository,
       accessToken,
       sha,
+      archivePath,
+      archiveLimitBytes,
       downloadWithGit,
     );
   }
@@ -302,12 +375,32 @@ async function fetchRepositorySnapshot(
         repository,
         accessToken,
         sha,
+        archivePath,
+        archiveLimitBytes,
         downloadWithGit,
       );
     }
     throw new Error(`Unable to download ${repository.fullName}@${sha}`);
   }
-  return { archive: await readResponseWithLimit(archiveResponse), sha };
+  try {
+    await writeResponseWithLimit(
+      archiveResponse,
+      archivePath,
+      archiveLimitBytes,
+    );
+  } catch (error) {
+    if (error instanceof RepositoryArchiveLimitError) throw error;
+    await rm(archivePath, { force: true });
+    return downloadExactSnapshotWithGit(
+      repository,
+      accessToken,
+      sha,
+      archivePath,
+      archiveLimitBytes,
+      downloadWithGit,
+    );
+  }
+  return { sha };
 }
 
 export async function checkoutRuntimeRepositories(
@@ -318,6 +411,13 @@ export async function checkoutRuntimeRepositories(
   const repositories = await dependencies.getRepositories(versionId);
   if (repositories.length === 0) return [];
 
+  const archiveLimitBytes =
+    dependencies.maxArchiveBytes ?? repositoryArchiveLimit();
+  const temporaryDirectory =
+    dependencies.temporaryDirectory ??
+    process.env.RESPONDER_REPOSITORY_TEMP_DIR ??
+    tmpdir();
+  const uploadArchive = dependencies.uploadArchive ?? uploadRepositoryArchive;
   const tokens = new Map<number, string>();
   const checkedOut: CheckedOutRepository[] = [];
   for (const repository of repositories) {
@@ -329,55 +429,62 @@ export async function checkoutRuntimeRepositories(
       tokens.set(repository.installationId, token);
     }
 
-    const snapshot = await fetchRepositorySnapshot(
-      repository,
-      token,
-      dependencies.fetch,
-      dependencies.downloadWithGit ?? downloadRepositorySnapshotWithGit,
-    );
     const [owner, name] = safeRepositoryParts(repository.fullName);
     const destination = repositoryWorkspacePath(repository.fullName);
-    const archivePath =
-      `${workspaceRoot}/.responder/archives/${owner}-${name}-${snapshot.sha}.tar.gz`;
-
-    await session.materializeEntry({
-      entry: { type: "file", content: snapshot.archive },
-      path: archivePath,
-    });
-    const workspaceBaseSha = await runSandboxCommand(
-      session,
-      [
-        "set -eu",
-        `rm -rf ${shellQuote(destination)}`,
-        `mkdir -p ${shellQuote(destination)}`,
-        [
-          `tar -xzf ${shellQuote(archivePath)}`,
-          "--no-same-owner --no-same-permissions --strip-components=1",
-          `-C ${shellQuote(destination)}`,
-        ].join(" "),
-        `rm -f ${shellQuote(archivePath)}`,
-        `git -C ${shellQuote(destination)} init -q`,
-        `git -C ${shellQuote(destination)} config user.name 'Responder Agent'`,
-        `git -C ${shellQuote(destination)} config user.email 'agent@responder.invalid'`,
-        `git -C ${shellQuote(destination)} add -A`,
-        `git -C ${shellQuote(destination)} commit -q --allow-empty -m 'Responder workspace baseline'`,
-        `git -C ${shellQuote(destination)} rev-parse HEAD`,
-      ].join("\n"),
-      `extract ${repository.fullName}`,
+    const temporaryRoot = await mkdtemp(
+      join(temporaryDirectory, "responder-repository-"),
     );
-    if (!/^[a-f0-9]{40}$/i.test(workspaceBaseSha)) {
-      throw new Error(
-        `Repository sandbox returned an invalid baseline for ${repository.fullName}`,
+    const localArchivePath = join(temporaryRoot, "repository.tar.gz");
+    try {
+      const snapshot = await fetchRepositorySnapshot(
+        repository,
+        token,
+        dependencies.fetch,
+        localArchivePath,
+        archiveLimitBytes,
+        dependencies.downloadWithGit ?? downloadRepositorySnapshotWithGit,
       );
-    }
+      const archivePath =
+        `${workspaceRoot}/.responder/archives/${owner}-${name}-${snapshot.sha}.tar.gz`;
 
-    checkedOut.push({
-      branch: repository.defaultBranch,
-      path: destination,
-      repository: repository.fullName,
-      sha: snapshot.sha,
-      workspaceBaseSha,
-    });
+      await uploadArchive(session, localArchivePath, archivePath);
+      const workspaceBaseSha = await runSandboxCommand(
+        session,
+        [
+          "set -eu",
+          `rm -rf ${shellQuote(destination)}`,
+          `mkdir -p ${shellQuote(destination)}`,
+          [
+            `tar -xzf ${shellQuote(archivePath)}`,
+            "--no-same-owner --no-same-permissions --strip-components=1",
+            `-C ${shellQuote(destination)}`,
+          ].join(" "),
+          `rm -f ${shellQuote(archivePath)}`,
+          `git -C ${shellQuote(destination)} init -q`,
+          `git -C ${shellQuote(destination)} config user.name 'Responder Agent'`,
+          `git -C ${shellQuote(destination)} config user.email 'agent@responder.invalid'`,
+          `git -C ${shellQuote(destination)} add -A`,
+          `git -C ${shellQuote(destination)} commit -q --allow-empty -m 'Responder workspace baseline'`,
+          `git -C ${shellQuote(destination)} rev-parse HEAD`,
+        ].join("\n"),
+        `extract ${repository.fullName}`,
+      );
+      if (!/^[a-f0-9]{40}$/i.test(workspaceBaseSha)) {
+        throw new Error(
+          `Repository sandbox returned an invalid baseline for ${repository.fullName}`,
+        );
+      }
+
+      checkedOut.push({
+        branch: repository.defaultBranch,
+        path: destination,
+        repository: repository.fullName,
+        sha: snapshot.sha,
+        workspaceBaseSha,
+      });
+    } finally {
+      await rm(temporaryRoot, { force: true, recursive: true });
+    }
   }
 
   await session.materializeEntry({

--- a/apps/worker/src/repositories.ts
+++ b/apps/worker/src/repositories.ts
@@ -1,8 +1,8 @@
 import { Daytona } from "@daytona/sdk";
 import type { DaytonaSandboxSession } from "@openai/agents-extensions/sandbox/daytona";
-import { execFile } from "node:child_process";
+import { execFile, spawn } from "node:child_process";
 import { createWriteStream } from "node:fs";
-import { mkdtemp, mkdir, rm, stat } from "node:fs/promises";
+import { mkdtemp, mkdir, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { Readable, Transform } from "node:stream";
@@ -58,6 +58,29 @@ function repositoryArchiveLimit(
   return limit;
 }
 
+async function writeStreamWithLimit(
+  source: Readable,
+  archivePath: string,
+  limit: number,
+): Promise<void> {
+  let byteLength = 0;
+  const limiter = new Transform({
+    transform(chunk: Buffer, _encoding, callback) {
+      byteLength += chunk.byteLength;
+      if (byteLength > limit) {
+        callback(new RepositoryArchiveLimitError(limit));
+        return;
+      }
+      callback(null, chunk);
+    },
+  });
+  await pipeline(
+    source,
+    limiter,
+    createWriteStream(archivePath, { flags: "wx" }),
+  );
+}
+
 export interface CheckedOutRepository {
   branch: string;
   path: string;
@@ -91,6 +114,52 @@ const defaultDependencies: RepositoryCheckoutDependencies = {
   fetch,
   getRepositories: getRuntimeRepositories,
 };
+
+async function writeGitArchiveWithLimit(
+  gitDirectory: string,
+  archivePath: string,
+  archiveLimitBytes: number,
+): Promise<void> {
+  const archiveProcess = spawn(
+    "git",
+    ["-C", gitDirectory, "archive", "--format=tar.gz", "FETCH_HEAD"],
+    {
+      killSignal: "SIGKILL",
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: repositoryDownloadTimeoutMs,
+    },
+  );
+  const completed = new Promise<void>((resolve, reject) => {
+    archiveProcess.once("error", reject);
+    archiveProcess.once("close", (code, signal) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+      reject(
+        new Error(
+          `Git archive exited with ${signal ? `signal ${signal}` : `code ${code ?? "unknown"}`}`,
+        ),
+      );
+    });
+  });
+  const writeArchive = writeStreamWithLimit(
+    archiveProcess.stdout,
+    archivePath,
+    archiveLimitBytes,
+  );
+
+  try {
+    await Promise.all([completed, writeArchive]);
+  } catch (error) {
+    archiveProcess.stdout.destroy();
+    if (archiveProcess.exitCode === null && archiveProcess.signalCode === null) {
+      archiveProcess.kill("SIGKILL");
+    }
+    await Promise.allSettled([completed, writeArchive]);
+    throw error;
+  }
+}
 
 async function downloadRepositorySnapshotWithGit(
   repository: RuntimeRepository,
@@ -148,22 +217,11 @@ async function downloadRepositorySnapshotWithGit(
     if (!/^[a-f0-9]{40}$/i.test(sha)) {
       throw new Error("Git returned an invalid repository commit");
     }
-    await execFileAsync(
-      "git",
-      [
-        "-C",
-        gitDirectory,
-        "archive",
-        "--format=tar.gz",
-        `--output=${archivePath}`,
-        "FETCH_HEAD",
-      ],
-      { timeout: repositoryDownloadTimeoutMs },
+    await writeGitArchiveWithLimit(
+      gitDirectory,
+      archivePath,
+      archiveLimitBytes,
     );
-    const archiveStats = await stat(archivePath);
-    if (archiveStats.size > archiveLimitBytes) {
-      throw new RepositoryArchiveLimitError(archiveLimitBytes);
-    }
     return { sha };
   } catch (error) {
     if (error instanceof RepositoryArchiveLimitError) throw error;
@@ -252,22 +310,10 @@ async function writeResponseWithLimit(
     throw new RepositoryArchiveLimitError(limit);
   }
   if (!response.body) throw new Error("GitHub returned an empty archive");
-
-  let byteLength = 0;
-  const limiter = new Transform({
-    transform(chunk: Buffer, _encoding, callback) {
-      byteLength += chunk.byteLength;
-      if (byteLength > limit) {
-        callback(new RepositoryArchiveLimitError(limit));
-        return;
-      }
-      callback(null, chunk);
-    },
-  });
-  await pipeline(
+  await writeStreamWithLimit(
     Readable.from(response.body as AsyncIterable<Uint8Array>),
-    limiter,
-    createWriteStream(archivePath, { flags: "wx" }),
+    archivePath,
+    limit,
   );
 }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -48,7 +48,9 @@ types. `drizzle/` contains the ordered schema history.
   a separate controlled tool that records a stable request before writing and
   stores the resulting Linear identifier and link.
 - Repository work runs in a separate sandbox. GitHub credentials stay outside
-  the sandbox; the service materializes only the selected repository content.
+  the sandbox; the service streams selected repository snapshots through
+  bounded worker scratch storage and into the isolated workspace without
+  buffering the complete archive in worker memory.
 - Tenant trace responses omit the initial composed runtime instructions. The
   raw stored trace retains them for an operator's private diagnostics.
 


### PR DESCRIPTION
## Summary

- stream GitHub repository archives through bounded worker scratch storage
- stream snapshot files into the isolated workspace without buffering the full archive in memory
- raise the default compressed archive ceiling from 100 MB to 5 GB and make it configurable
- extend transfer timeouts for multi-gigabyte repositories

## Root cause

Repository snapshots were accumulated in memory before workspace materialization. A hard 100 MB guard rejected larger archives before an investigation could start, and the Git fallback enforced the same limit.

## Impact

Investigations and remediations can inspect multi-gigabyte repository snapshots while GitHub credentials remain outside the sandbox. Temporary files are removed after each checkout and an operator-configurable disk safety limit remains in place.

## Validation

- pnpm typecheck
- pnpm lint
- pnpm test (661 tests)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Streams GitHub repository archives through bounded worker scratch storage and uploads them into the sandbox, raising the compressed archive limit from 100 MB to 5 GB without exposing GitHub tokens. Also bounds Git fallback archive generation so it stops as soon as the limit is crossed.

- Enforces a configurable disk limit (`RESPONDER_REPOSITORY_ARCHIVE_MAX_BYTES`, default 5 GB); rejects declared or streamed archives over the limit, stops `git archive` early, and cleans up temp files. `maxArchiveBytes` can override per call.
- Uploads archives via `Daytona` file streaming (using `@daytona/sdk`) instead of in‑memory `materializeEntry`; adds optional `uploadArchive(session, localPath, remotePath)` to override the default uploader.
- Extends timeouts for large transfers (download: 10 min; sandbox upload: 30 min).
- Changes `RepositoryCheckoutDependencies`:
  - `downloadWithGit(repository, accessToken, ref, archivePath, archiveLimitBytes) => { sha }` (writes the archive to `archivePath` and no longer returns bytes).
  - Adds optional `uploadArchive`, `maxArchiveBytes`, and `temporaryDirectory`.
- Streams extraction inside the sandbox and removes the uploaded archive afterward.

- Rollout: ensure workers have enough scratch disk or set `RESPONDER_REPOSITORY_TEMP_DIR`. Update any custom `downloadWithGit` to the new signature. If using the default uploader, provide a Daytona API key in the session; otherwise supply `uploadArchive`.

<sup>Written for commit bbd6efa6942b6af206256144c9d929e45669cc66. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/responder-oss/pull/39?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

