### PR TITLE
Investigate AWS alarms posted in Slack

### DIFF
--- a/apps/control-plane/server/index.test.ts
+++ b/apps/control-plane/server/index.test.ts
@@ -18,6 +18,7 @@ import {
   logSlackAcknowledgementFailure,
   slackCopyPromptResponse,
   slackAlertProvider,
+  slackAwsAlarm,
   slackMessageBody,
   slackPullRequestQueuedResponse,
   shouldIgnoreResolvedSlackAlert,
@@ -28,6 +29,24 @@ import {
 } from "./webhooks/sentry.js";
 import { startSlackIssueRemediation } from "./issues/remediation.js";
 import { queueInvestigation } from "./investigations/queue.js";
+
+const slackWebhookMocks = vi.hoisted(() => ({
+  findAgentsForSlackEvent: vi.fn(),
+  getSlackChannelConnection: vi.fn(),
+}));
+
+vi.mock("../../../packages/core/src/db/agents.js", async (importOriginal) => ({
+  ...(await importOriginal()),
+  findAgentsForSlackEvent: slackWebhookMocks.findAgentsForSlackEvent,
+}));
+
+vi.mock(
+  "../../../packages/core/src/db/integrations.js",
+  async (importOriginal) => ({
+    ...(await importOriginal()),
+    getSlackChannelConnection: slackWebhookMocks.getSlackChannelConnection,
+  }),
+);
 
 vi.mock("./issues/remediation.js", () => ({
   startIssueRemediation: vi.fn(),
@@ -49,6 +68,7 @@ vi.mock("./investigations/queue.js", () => ({
 
 describe("control-plane API", () => {
   afterEach(() => {
+    vi.clearAllMocks();
     vi.restoreAllMocks();
     vi.unstubAllEnvs();
     vi.unstubAllGlobals();
@@ -519,11 +539,37 @@ describe("control-plane API", () => {
       expectedProvider: "app",
       subtype: undefined,
     },
+    {
+      name: "AWS CloudWatch alarm notification",
+      body: [
+        "The alarm productUpdateWebhook-DlqAlarm changed state to ALARM: Threshold Crossed.",
+        "https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#alarmsV2:alarm/productUpdateWebhook-DlqAlarm",
+        "There are failed messages in the productUpdateWebhook dead letter queue.",
+      ].join("\n"),
+      botName: "AWS Alarm notification",
+      expectedProvider: "aws",
+      subtype: "bot_message",
+    },
+    {
+      name: "rich AWS RDS alarm card",
+      body: [
+        "🚨 CRITICAL: Freeable Memory",
+        "DB Instance: dialog-monolith-production-encrypteddatabasecluster",
+        "Condition: Freeable Memory < 500 MiB for 3 consecutive periods",
+        "Reason: Threshold Crossed: 3 datapoints were less than the threshold.",
+        "Alarm Details",
+        "https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#alarmsV2:alarm/dialog-monolith-freeable-memory",
+      ].join("\n"),
+      botName: "AWS Alarm notification",
+      expectedProvider: "aws",
+      subtype: "bot_message",
+    },
   ])("accepts the observed $name shape", (shape) => {
+    const isThreadBroadcast = shape.subtype === "thread_broadcast";
     const provider = slackAlertProvider({
       body: shape.body,
-      botAppId: shape.subtype ? undefined : "A-APP",
-      botId: shape.subtype ? undefined : "B-BOT",
+      botAppId: isThreadBroadcast ? undefined : "A-APP",
+      botId: isThreadBroadcast ? undefined : "B-BOT",
       botName: shape.botName,
       subtype: shape.subtype,
     });
@@ -537,6 +583,135 @@ describe("control-plane API", () => {
         shouldIgnoreResolvedSlackAlert(provider, shape.body, shape.botName),
       ).toBe(false);
     }
+  });
+
+  it("normalizes the exact AWS alarm identity and region", () => {
+    const body = [
+      "The alarm productUpdateWebhook-DlqAlarm changed state to ALARM: Threshold Crossed.",
+      "<https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#alarmsV2:alarm/productUpdateWebhook-DlqAlarm|see the alarm>",
+    ].join("\n");
+
+    expect(
+      slackAwsAlarm({ body, senderName: "AWS Alarm notification" }),
+    ).toEqual({
+      alarmName: "productUpdateWebhook-DlqAlarm",
+      consoleUrl:
+        "https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#alarmsV2:alarm/productUpdateWebhook-DlqAlarm",
+      region: "eu-west-1",
+      state: "ALARM",
+    });
+  });
+
+  it("queues an AWS alarm posted by an app in a watched Slack channel", async () => {
+    vi.stubEnv("SLACK_SIGNING_SECRET", "slack-signing-secret");
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    vi.spyOn(console, "info").mockImplementation(() => undefined);
+    slackWebhookMocks.findAgentsForSlackEvent.mockResolvedValueOnce([
+      {
+        agentId: "17171717-1717-4717-8717-171717171717",
+        integrationAccountId: "04040404-0404-4404-8404-040404040404",
+        organizationId: "03030303-0303-4303-8303-030303030303",
+        trigger: "slack_channel",
+      },
+    ]);
+    slackWebhookMocks.getSlackChannelConnection.mockResolvedValueOnce(null);
+    vi.mocked(queueInvestigation).mockResolvedValueOnce({
+      investigationId: "01010101-0101-4101-8101-010101010101",
+      jobId: "21212121-2121-4121-8121-212121212121",
+      kind: "queued",
+    });
+    const timestamp = Math.floor(Date.now() / 1_000).toString();
+    const body = JSON.stringify({
+      type: "event_callback",
+      team_id: "T123",
+      event_id: "EvAwsAlarm",
+      event: {
+        type: "message",
+        subtype: "bot_message",
+        bot_id: "B-AWS",
+        bot_profile: {
+          app_id: "A-AWS",
+          name: "AWS Alarm notification",
+        },
+        channel: "C123",
+        ts: "1700000005.000001",
+        text: [
+          "The alarm responder-aws-alarm-e2e-lambda-errors changed state to ALARM: Threshold Crossed.",
+          "https://eu-west-3.console.aws.amazon.com/cloudwatch/home?region=eu-west-3#alarmsV2:alarm/responder-aws-alarm-e2e-lambda-errors",
+        ].join("\n"),
+      },
+    });
+    const signature = `v0=${createHmac("sha256", "slack-signing-secret")
+      .update(`v0:${timestamp}:${body}`)
+      .digest("hex")}`;
+
+    const response = await app.request("/api/webhooks/slack", {
+      method: "POST",
+      body,
+      headers: {
+        "content-type": "application/json",
+        "x-slack-request-timestamp": timestamp,
+        "x-slack-signature": signature,
+      },
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      matchedAgents: 1,
+      ok: true,
+    });
+    expect(queueInvestigation).toHaveBeenCalledWith({
+      agentId: "17171717-1717-4717-8717-171717171717",
+      attributes: {
+        awsAlarmName: "responder-aws-alarm-e2e-lambda-errors",
+        awsAlarmRegion: "eu-west-3",
+        awsAlarmState: "ALARM",
+        awsAlarmUrl:
+          "https://eu-west-3.console.aws.amazon.com/cloudwatch/home?region=eu-west-3#alarmsV2:alarm/responder-aws-alarm-e2e-lambda-errors",
+        channelId: "C123",
+        slackAlertProvider: "aws",
+        slackEventId: "EvAwsAlarm",
+        teamId: "T123",
+        threadTimestamp: "1700000005.000001",
+        timestamp: "1700000005.000001",
+      },
+      body: expect.stringContaining("changed state to ALARM"),
+      externalEventId:
+        "EvAwsAlarm:17171717-1717-4717-8717-171717171717",
+      provider: "slack",
+      sourceUrl: "https://slack.com/archives/C123/p1700000005000001",
+      title: expect.stringContaining("responder-aws-alarm-e2e-lambda-errors"),
+    });
+  });
+
+  it("ignores AWS alarm recovery and unrelated Amazon Q messages", () => {
+    const recovery = [
+      "The alarm checkout-errors changed state to OK: Threshold Crossed.",
+      "https://eu-west-3.console.aws.amazon.com/cloudwatch/home?region=eu-west-3#alarmsV2:alarm/checkout-errors",
+    ].join("\n");
+    const provider = slackAlertProvider({
+      body: recovery,
+      botAppId: "A-AWS",
+      botId: "B-AWS",
+      botName: "AWS Alarm notification",
+    });
+
+    expect(provider).toBe("aws");
+    expect(
+      shouldIgnoreResolvedSlackAlert(
+        provider!,
+        recovery,
+        "AWS Alarm notification",
+      ),
+    ).toBe(true);
+    expect(
+      slackAlertProvider({
+        body: "AWS deployment completed successfully.",
+        botAppId: "A-AWS",
+        botId: "B-AWS",
+        botName: "Amazon Q",
+      }),
+    ).toBeNull();
   });
 
   it("ignores human messages in a watched channel", async () => {
@@ -784,6 +959,7 @@ describe("control-plane API", () => {
     const body = "✅ Alert: error rate is above its threshold";
 
     expect(shouldIgnoreResolvedSlackAlert("app", body)).toBe(true);
+    expect(shouldIgnoreResolvedSlackAlert("aws", body, "AWS")).toBe(true);
     expect(shouldIgnoreResolvedSlackAlert("datadog", body)).toBe(false);
     expect(shouldIgnoreResolvedSlackAlert("sentry", body)).toBe(false);
   });

--- a/apps/control-plane/server/webhooks/slack.ts
+++ b/apps/control-plane/server/webhooks/slack.ts
@@ -230,13 +230,95 @@ export function isSentryIssueAlert(
   );
 }
 
-type SlackAlertProvider = "app" | "datadog" | "sentry";
+type SlackAlertProvider = "app" | "aws" | "datadog" | "sentry";
+
+export type SlackAwsAlarm = {
+  alarmName?: string;
+  consoleUrl?: string;
+  region?: string;
+  state: "ALARM" | "INSUFFICIENT_DATA" | "OK";
+};
+
+function slackMessageUrls(body: string): string[] {
+  return body.match(/https:\/\/[^\s>|)]+/giu) ?? [];
+}
+
+function cloudWatchAlarmUrl(body: string): URL | null {
+  for (const candidate of slackMessageUrls(body)) {
+    try {
+      const url = new URL(candidate);
+      if (
+        /^(?:[a-z0-9-]+\.)?console\.aws\.amazon\.com$/iu.test(url.hostname) &&
+        url.pathname === "/cloudwatch/home" &&
+        /alarmsV2:alarm\//iu.test(url.hash)
+      ) {
+        return url;
+      }
+    } catch {
+      // Ignore malformed URLs extracted from message formatting.
+    }
+  }
+  return null;
+}
+
+function alarmNameFromUrl(url: URL): string | undefined {
+  try {
+    const hash = decodeURIComponent(url.hash);
+    const marker = "alarmsV2:alarm/";
+    const markerIndex = hash.toLowerCase().indexOf(marker.toLowerCase());
+    if (markerIndex === -1) return undefined;
+    const alarmName = hash.slice(markerIndex + marker.length).trim();
+    return alarmName || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function slackAwsAlarm(input: {
+  body: string;
+  senderName?: string;
+}): SlackAwsAlarm | null {
+  const senderName = input.senderName?.trim() ?? "";
+  const isAwsSender = /\b(?:amazon\s+q|aws)\b/iu.test(senderName);
+  const consoleUrl = cloudWatchAlarmUrl(input.body);
+  if (!isAwsSender && !consoleUrl) return null;
+
+  const stateMatch = input.body.match(
+    /\b(?:changed state to|state:)\s*(ALARM|OK|INSUFFICIENT_DATA)\b/iu,
+  );
+  const criticalAlarm =
+    /^(?:\s*(?:🚨|:rotating_light:)\s*)?\**CRITICAL\b/imu.test(input.body) &&
+    (/\bAlarm Details\b/iu.test(input.body) || consoleUrl !== null);
+  const state = stateMatch?.[1]?.toUpperCase() ??
+    (criticalAlarm ? "ALARM" : undefined);
+  if (state !== "ALARM" && state !== "OK" && state !== "INSUFFICIENT_DATA") {
+    return null;
+  }
+
+  const alarmNameMatch = input.body.match(
+    /\bThe alarm\s+(.+?)\s+changed state to\s+(?:ALARM|OK|INSUFFICIENT_DATA)\b/iu,
+  );
+  const region = consoleUrl?.searchParams.get("region") ??
+    consoleUrl?.hostname.match(/^([a-z0-9-]+)\.console\.aws\.amazon\.com$/iu)?.[1];
+  const alarmName = alarmNameMatch?.[1]?.trim() ||
+    (consoleUrl ? alarmNameFromUrl(consoleUrl) : undefined);
+
+  return {
+    ...(alarmName ? { alarmName } : {}),
+    ...(consoleUrl ? { consoleUrl: consoleUrl.toString() } : {}),
+    ...(region ? { region } : {}),
+    state,
+  };
+}
 
 export function shouldIgnoreResolvedSlackAlert(
   alertProvider: SlackAlertProvider,
   body: string,
   senderName?: string,
 ): boolean {
+  if (alertProvider === "aws") {
+    return slackAwsAlarm({ body, senderName })?.state !== "ALARM";
+  }
   return (
     alertProvider === "app" &&
     (isResolvedSlackAlert(body) ||
@@ -275,6 +357,9 @@ export function slackAlertProvider(input: {
   if (!isAppMessage && !isThreadBroadcast) return null;
 
   const senderName = input.botName?.trim() || input.username?.trim();
+  if (isAppMessage && slackAwsAlarm({ body: input.body, senderName })) {
+    return "aws";
+  }
   if (senderName) {
     if (/\bdatadog\b/i.test(senderName)) return "datadog";
     if (/\bsentry\b/i.test(senderName)) return "sentry";
@@ -300,6 +385,8 @@ function parseJson(value: string): unknown {
 
 async function forwardSlackEvent(input: {
   agentId: string;
+  alertProvider: SlackAlertProvider | null;
+  awsAlarm: SlackAwsAlarm | null;
   body: string;
   channelId: string;
   eventId: string;
@@ -315,6 +402,19 @@ async function forwardSlackEvent(input: {
     body: input.body,
     sourceUrl: `https://slack.com/archives/${input.channelId}/p${input.timestamp.replace(".", "")}`,
     attributes: {
+      ...(input.alertProvider
+        ? { slackAlertProvider: input.alertProvider }
+        : {}),
+      ...(input.awsAlarm?.alarmName
+        ? { awsAlarmName: input.awsAlarm.alarmName }
+        : {}),
+      ...(input.awsAlarm?.consoleUrl
+        ? { awsAlarmUrl: input.awsAlarm.consoleUrl }
+        : {}),
+      ...(input.awsAlarm?.region
+        ? { awsAlarmRegion: input.awsAlarm.region }
+        : {}),
+      ...(input.awsAlarm ? { awsAlarmState: input.awsAlarm.state } : {}),
       channelId: input.channelId,
       slackEventId: input.eventId,
       teamId: input.teamId,
@@ -645,8 +745,10 @@ export const slackWebhookRoutes = new Hono().post("/", async (context) => {
   }
 
   const body = slackMessageBody(event);
-  let alertProvider: "app" | "datadog" | "sentry" | null = null;
+  let alertProvider: SlackAlertProvider | null = null;
+  let awsAlarm: SlackAwsAlarm | null = null;
   if (event.type === "message") {
+    const senderName = event.bot_profile?.name ?? event.username;
     alertProvider = slackAlertProvider({
       body,
       botAppId: event.app_id ?? event.bot_profile?.app_id,
@@ -674,11 +776,14 @@ export const slackWebhookRoutes = new Hono().post("/", async (context) => {
         reason: "unsupported_alert_sender",
       });
     }
+    if (alertProvider === "aws") {
+      awsAlarm = slackAwsAlarm({ body, senderName });
+    }
     if (
       shouldIgnoreResolvedSlackAlert(
         alertProvider,
         body,
-        event.bot_profile?.name ?? event.username,
+        senderName,
       )
     ) {
       console.info(
@@ -733,7 +838,7 @@ export const slackWebhookRoutes = new Hono().post("/", async (context) => {
         reason: "datadog_recovery",
       });
     }
-    if (alertProvider === "app") {
+    if (alertProvider === "app" || alertProvider === "aws") {
       logAcceptedSlackAppAlert({
         botAppId: event.app_id ?? event.bot_profile?.app_id ?? null,
         botId: event.bot_id ?? null,
@@ -757,6 +862,8 @@ export const slackWebhookRoutes = new Hono().post("/", async (context) => {
     matches.map(async (match) => {
       const result = await forwardSlackEvent({
         agentId: match.agentId,
+        alertProvider,
+        awsAlarm,
         body,
         channelId: event.channel,
         eventId: callback.data.event_id,

--- a/apps/worker/src/investigate.test.ts
+++ b/apps/worker/src/investigate.test.ts
@@ -213,6 +213,7 @@ describe("sandbox agent configuration", () => {
   it("keeps AWS investigation access read-only", () => {
     const instructions = investigationInstructions({
       agentPrompt: "Inspect the reported failure.",
+      awsAlarmTriggered: true,
       awsAccountNames: ["AWS · 123456789012"],
       clickStackConnected: false,
       datadogConnected: false,
@@ -223,6 +224,8 @@ describe("sandbox agent configuration", () => {
     expect(instructions).toContain("connected read-only AWS tools");
     expect(instructions).toContain("AWS · 123456789012");
     expect(instructions).toContain("Never request secret values");
+    expect(instructions).toContain("Locate the exact CloudWatch alarm");
+    expect(instructions).toContain("Treat the Slack notification as a pointer");
   });
 
   it("stores the exact initial message that is sent to the agent", () => {

--- a/apps/worker/src/investigate.ts
+++ b/apps/worker/src/investigate.ts
@@ -155,6 +155,7 @@ export function investigationCapabilities(replay: boolean) {
 
 export function investigationInstructions(input: {
   agentPrompt: string;
+  awsAlarmTriggered?: boolean;
   awsAccountNames?: string[];
   customMcpNames?: string[];
   datadogConnected: boolean;
@@ -190,6 +191,9 @@ export function investigationInstructions(input: {
     "Investigate only the alert and context provided by Responder.",
     awsAccountNames.length > 0
       ? `Use the connected read-only AWS tools to inspect relevant infrastructure, configuration, telemetry, and service health before concluding. Connected AWS accounts: ${awsAccountNames.join(", ")}. Never request secret values.`
+      : null,
+    input.awsAlarmTriggered && awsAccountNames.length > 0
+      ? "This investigation was triggered by an AWS alarm forwarded through Slack. Locate the exact CloudWatch alarm by its normalized name and region first. Inspect its current configuration, state history, metric data, affected resource, and relevant logs around the transition. Treat the Slack notification as a pointer, not as proof of root cause."
       : null,
     input.datadogConnected
       ? "Use the connected Datadog tools to inspect the matching logs and surrounding service activity before concluding."
@@ -443,6 +447,9 @@ export async function runInvestigationAgent(
     const vercelTools = createVercelTools(vercelConnections);
     const instructions = investigationInstructions({
       agentPrompt: job.config.prompt,
+      awsAlarmTriggered:
+        investigationInput.provider === "slack" &&
+        investigationInput.attributes?.slackAlertProvider === "aws",
       awsAccountNames: awsConnections.map((connection) => connection.displayName),
       customMcpNames: customMcpConnections.map((connection) => connection.displayName),
       clickStackConnected: clickStackServer !== null,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -42,6 +42,10 @@ types. `drizzle/` contains the ordered schema history.
   that key.
 - Slack, GitHub, and Sentry webhook signatures are checked against the untouched
   request body. Retries are deduplicated with provider-specific keys.
+- App-authored CloudWatch `ALARM` notifications in watched Slack channels use
+  the existing Slack trigger. The control plane normalizes available alarm
+  identity and location fields, ignores recovery states, and the worker uses
+  only AWS accounts selected on the pinned Agent version as read-only context.
 - Remote MCP destinations must use HTTPS and resolve to public addresses.
   Redirects are revalidated and authorization is not forwarded across origins.
 - Linear context uses its read-only MCP endpoint. Ticket creation goes through

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -50,6 +50,13 @@ Enable Slack's hosted MCP server in the app's agent settings if the app is
 eligible to use it. Reconnect existing installations after changing scopes.
 Private channels require the bot to be invited.
 
+Watched channels accept app-authored CloudWatch alarm notifications from AWS
+and Amazon Q Developer in chat applications. Responder starts investigations
+only for `ALARM` notifications, normalizes the alarm name, region, state, and
+CloudWatch link when present, and ignores `OK` and `INSUFFICIENT_DATA`
+notifications. Add the matching AWS account as Agent context so the worker can
+inspect the exact alarm, metric history, affected resource, and related logs.
+
 ## Sentry
 
 Create a public Sentry integration with:
@@ -162,6 +169,11 @@ automatically refreshes temporary credentials through STS; it never asks for or
 stores customer access keys. The managed AWS MCP client exposes only tools
 explicitly annotated read-only. This integration currently supports the
 commercial AWS partition (`arn:aws`) only.
+
+AWS context does not receive native EventBridge or SNS webhooks. CloudWatch
+alarms can trigger an Agent when Amazon Q Developer in chat applications
+forwards the alarm to a watched Slack channel; the selected AWS account remains
+the read-only investigation context.
 
 Production deployments should store the generic template in a private S3
 bucket and configure `AWS_INTEGRATION_TEMPLATE_BUCKET` and

--- a/packages/core/src/investigations/input.test.ts
+++ b/packages/core/src/investigations/input.test.ts
@@ -31,6 +31,30 @@ describe("investigation input", () => {
     ).toThrow();
   });
 
+  it("renders normalized AWS alarm context for a Slack-triggered investigation", () => {
+    const prompt = investigationPrompt({
+      attributes: {
+        awsAlarmName: "responder-e2e-lambda-errors",
+        awsAlarmRegion: "eu-west-3",
+        awsAlarmState: "ALARM",
+        awsAlarmUrl:
+          "https://eu-west-3.console.aws.amazon.com/cloudwatch/home?region=eu-west-3#alarmsV2:alarm/responder-e2e-lambda-errors",
+        slackAlertProvider: "aws",
+      },
+      body: "Threshold crossed.",
+      externalEventId: "EvAwsAlarm",
+      provider: "slack",
+      sourceUrl: "https://slack.com/archives/C123/p123",
+      title: "Lambda errors",
+    });
+
+    expect(prompt).toContain("AWS alarm context:");
+    expect(prompt).toContain("Alarm: responder-e2e-lambda-errors");
+    expect(prompt).toContain("State: ALARM");
+    expect(prompt).toContain("Region: eu-west-3");
+    expect(prompt).toContain("Alarm details: https://eu-west-3.console.aws.amazon.com");
+  });
+
   it("rejects executable source links before they can be rendered", () => {
     expect(() =>
       investigationRequestSchema.parse({

--- a/packages/core/src/investigations/input.ts
+++ b/packages/core/src/investigations/input.ts
@@ -18,6 +18,34 @@ export const investigationRequestSchema = z.object({
 
 export type InvestigationRequest = z.infer<typeof investigationRequestSchema>;
 
+function stringAttribute(
+  input: InvestigationInput,
+  name: string,
+): string | null {
+  const value = input.attributes?.[name];
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function awsAlarmPromptContext(input: InvestigationInput): string[] {
+  if (
+    input.provider !== "slack" ||
+    stringAttribute(input, "slackAlertProvider") !== "aws"
+  ) {
+    return [];
+  }
+  const alarmName = stringAttribute(input, "awsAlarmName");
+  const state = stringAttribute(input, "awsAlarmState");
+  const region = stringAttribute(input, "awsAlarmRegion");
+  const alarmUrl = stringAttribute(input, "awsAlarmUrl");
+  return [
+    "AWS alarm context:",
+    alarmName ? `Alarm: ${alarmName}` : null,
+    state ? `State: ${state}` : null,
+    region ? `Region: ${region}` : null,
+    alarmUrl ? `Alarm details: ${alarmUrl}` : null,
+  ].filter((line): line is string => line !== null);
+}
+
 export function toInvestigationInput(request: InvestigationRequest): InvestigationInput {
   return {
     provider: request.provider,
@@ -30,11 +58,13 @@ export function toInvestigationInput(request: InvestigationRequest): Investigati
 }
 
 export function investigationPrompt(input: InvestigationInput): string {
+  const awsAlarmContext = awsAlarmPromptContext(input);
   return [
     `# ${input.provider} event`,
     "",
     `Title: ${input.title}`,
     input.sourceUrl ? `Source: ${input.sourceUrl}` : null,
+    ...(awsAlarmContext.length > 0 ? ["", ...awsAlarmContext] : []),
     "",
     input.body,
   ]


### PR DESCRIPTION
## Summary

- recognize CloudWatch ALARM notifications posted by AWS and Amazon Q apps in watched Slack channels
- normalize the alarm name, region, state, and console link for the investigation prompt
- guide connected AWS investigations to verify alarm history, metric data, affected resources, and logs
- ignore OK, INSUFFICIENT_DATA, and unrelated Amazon Q messages

## Testing

- `pnpm test` (668 tests)
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Investigates AWS CloudWatch alarms posted in Slack and queues investigations only for ALARM notifications. Previously we ignored these app-authored messages; now we normalize alarm identity and region and guide a read‑only AWS investigation.

- Detects `aws` as a Slack alert provider and parses AWS/Amazon Q messages via `slackAwsAlarm` (alarm name, region, state, console URL).
- Ignores `OK` and `INSUFFICIENT_DATA` notifications; accepts only `ALARM`.
- Forwards normalized alarm attributes (`awsAlarmName`, `awsAlarmRegion`, `awsAlarmState`, `awsAlarmUrl`, `slackAlertProvider`) to investigations.
- Shows normalized AWS alarm context at the top of the investigation prompt and adds focused, read‑only AWS instructions when triggered by Slack.
- Updates tests to cover provider detection, normalization, queuing, and recovery ignores; updates docs to explain behavior and constraints.

**Rollout**
- No DB changes and no new webhooks or Slack scopes.
- To enable: ensure watched Slack channels receive AWS/Amazon Q alarm posts and add the matching AWS account to the Agent version. Only `ALARM` messages will start investigations.

<sup>Written for commit 8b3ed0964d002a13ffdb5984a5b09837bf86ee1d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/responder-oss/pull/40?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

