### PR TITLE
Make AWS alarm inspection reliable

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -13,6 +13,10 @@
   },
   "dependencies": {
     "@aws-crypto/sha256-js": "5.2.0",
+    "@aws-sdk/client-cloudwatch": "3.1111.0",
+    "@aws-sdk/client-cloudwatch-logs": "3.1111.0",
+    "@aws-sdk/client-lambda": "3.1111.0",
+    "@aws-sdk/client-sqs": "3.1111.0",
     "@daytona/sdk": "0.203.0",
     "@daytonaio/sdk": "npm:@daytona/sdk@0.203.0",
     "@openai/agents": "0.14.2",

--- a/apps/worker/src/aws-inspection-tools.test.ts
+++ b/apps/worker/src/aws-inspection-tools.test.ts
@@ -1,0 +1,252 @@
+import { describe, expect, it, vi } from "vitest";
+import type { RuntimeAwsConnection } from "@responder/core/db/investigations";
+import {
+  type AwsInspectionClients,
+  createAwsInspectionTools,
+} from "./aws-inspection-tools.js";
+
+const connection: RuntimeAwsConnection = {
+  accountId: "10000000-0000-4000-8000-000000000001",
+  displayName: "Production AWS",
+  externalId: "responder_abcdefghijklmnopqrstuvwxyz1234567890",
+  roleArn: "arn:aws:iam::123456789012:role/ResponderInvestigationRole",
+};
+
+function fakeClients(
+  overrides: Partial<AwsInspectionClients> = {},
+): AwsInspectionClients {
+  const empty = vi.fn().mockResolvedValue({ $metadata: {} });
+  return {
+    describeAlarmHistory: empty,
+    describeAlarms: empty,
+    getFunctionConfiguration: empty,
+    getMetricData: empty,
+    getQueryResults: empty,
+    getQueueAttributes: empty,
+    getQueueUrl: empty,
+    listEventSourceMappings: empty,
+    startQuery: empty,
+    ...overrides,
+  } as AwsInspectionClients;
+}
+
+function inspectionTool(
+  name: string,
+  clients: AwsInspectionClients,
+  connections = [connection],
+) {
+  return createAwsInspectionTools(connections, {
+    clientFactory: () => clients,
+    delay: () => Promise.resolve(),
+  }).find((candidate) => candidate.name === name)!;
+}
+
+describe("typed AWS inspection tools", () => {
+  it("reads an alarm and its history using exact SDK operations", async () => {
+    const describeAlarms = vi.fn().mockResolvedValue({
+      $metadata: {},
+      MetricAlarms: [{ AlarmName: "QueueDepthHigh", StateValue: "ALARM" }],
+    });
+    const describeAlarmHistory = vi.fn().mockResolvedValue({
+      $metadata: {},
+      AlarmHistoryItems: [{ HistorySummary: "State updated" }],
+    });
+    const tool = inspectionTool(
+      "aws_inspect_cloudwatch_alarm",
+      fakeClients({ describeAlarmHistory, describeAlarms }),
+    );
+
+    await expect(tool.invoke(
+      undefined as never,
+      JSON.stringify({
+        alarmName: "QueueDepthHigh",
+        region: "eu-west-1",
+      }),
+    )).resolves.toMatchObject({
+      accountId: "123456789012",
+      alarm: { AlarmName: "QueueDepthHigh", StateValue: "ALARM" },
+      history: [{ HistorySummary: "State updated" }],
+      region: "eu-west-1",
+    });
+    expect(describeAlarms).toHaveBeenCalledWith({
+      AlarmNames: ["QueueDepthHigh"],
+    });
+    expect(describeAlarmHistory).toHaveBeenCalledWith(
+      expect.objectContaining({ AlarmName: "QueueDepthHigh", MaxRecords: 25 }),
+    );
+  });
+
+  it("reads SQS attributes without receiving messages", async () => {
+    const getQueueUrl = vi.fn().mockResolvedValue({
+      $metadata: {},
+      QueueUrl: "https://sqs.eu-west-1.amazonaws.com/123456789012/orders-dlq",
+    });
+    const getQueueAttributes = vi.fn().mockResolvedValue({
+      $metadata: {},
+      Attributes: { ApproximateNumberOfMessages: "404" },
+    });
+    const tool = inspectionTool(
+      "aws_inspect_sqs_queue",
+      fakeClients({ getQueueAttributes, getQueueUrl }),
+    );
+
+    await expect(tool.invoke(
+      undefined as never,
+      JSON.stringify({ queueName: "orders-dlq", region: "eu-west-1" }),
+    )).resolves.toMatchObject({
+      accountId: "123456789012",
+      attributes: { ApproximateNumberOfMessages: "404" },
+      queueName: "orders-dlq",
+    });
+    expect(getQueueAttributes).toHaveBeenCalledWith(
+      expect.objectContaining({
+        QueueUrl:
+          "https://sqs.eu-west-1.amazonaws.com/123456789012/orders-dlq",
+      }),
+    );
+  });
+
+  it("reads a bounded CloudWatch metric series", async () => {
+    const getMetricData = vi.fn().mockResolvedValue({
+      $metadata: {},
+      MetricDataResults: [
+        { Id: "metric", Timestamps: [new Date("2026-08-20T12:05:00Z")], Values: [7] },
+      ],
+    });
+    const tool = inspectionTool(
+      "aws_inspect_cloudwatch_metric",
+      fakeClients({ getMetricData }),
+    );
+
+    await expect(tool.invoke(
+      undefined as never,
+      JSON.stringify({
+        dimensions: { QueueName: "orders-dlq" },
+        endTime: "2026-08-20T12:10:00Z",
+        metricName: "ApproximateNumberOfMessagesVisible",
+        namespace: "AWS/SQS",
+        region: "eu-west-1",
+        startTime: "2026-08-20T12:00:00Z",
+      }),
+    )).resolves.toMatchObject({
+      metricData: [{ Id: "metric", Values: [7] }],
+    });
+    expect(getMetricData).toHaveBeenCalledWith(
+      expect.objectContaining({
+        MetricDataQueries: [
+          expect.objectContaining({
+            Id: "metric",
+            MetricStat: expect.objectContaining({
+              Metric: expect.objectContaining({
+                Dimensions: [{ Name: "QueueName", Value: "orders-dlq" }],
+                MetricName: "ApproximateNumberOfMessagesVisible",
+                Namespace: "AWS/SQS",
+              }),
+              Period: 60,
+              Stat: "Sum",
+            }),
+          }),
+        ],
+      }),
+    );
+  });
+
+  it("omits Lambda environment variables and KMS identifiers", async () => {
+    const getFunctionConfiguration = vi.fn().mockResolvedValue({
+      $metadata: {},
+      Environment: { Variables: { API_KEY: "secret" } },
+      FunctionName: "orders-consumer",
+      KMSKeyArn: "arn:aws:kms:eu-west-1:123456789012:key/secret",
+      LastUpdateStatus: "Successful",
+    });
+    const listEventSourceMappings = vi.fn().mockResolvedValue({
+      $metadata: {},
+      EventSourceMappings: [{ State: "Enabled", UUID: "mapping-1" }],
+    });
+    const tool = inspectionTool(
+      "aws_inspect_lambda_function",
+      fakeClients({ getFunctionConfiguration, listEventSourceMappings }),
+    );
+
+    const output = await tool.invoke(
+      undefined as never,
+      JSON.stringify({
+        functionName: "orders-consumer",
+        region: "eu-west-1",
+      }),
+    );
+
+    expect(output).toMatchObject({
+      configuration: {
+        FunctionName: "orders-consumer",
+        LastUpdateStatus: "Successful",
+      },
+      eventSourceMappings: [{ State: "Enabled", UUID: "mapping-1" }],
+    });
+    expect(JSON.stringify(output)).not.toContain("API_KEY");
+    expect(JSON.stringify(output)).not.toContain("KMSKeyArn");
+  });
+
+  it("polls a bounded Logs Insights query to completion", async () => {
+    const startQuery = vi.fn().mockResolvedValue({
+      $metadata: {},
+      queryId: "query-1",
+    });
+    const getQueryResults = vi
+      .fn()
+      .mockResolvedValueOnce({ $metadata: {}, status: "Running" })
+      .mockResolvedValueOnce({
+        $metadata: {},
+        results: [[{ field: "@message", value: "failed" }]],
+        status: "Complete",
+      });
+    const delay = vi.fn().mockResolvedValue(undefined);
+    const tool = createAwsInspectionTools([connection], {
+      clientFactory: () => fakeClients({ getQueryResults, startQuery }),
+      delay,
+    }).find((candidate) => candidate.name === "aws_query_cloudwatch_logs")!;
+
+    await expect(tool.invoke(
+      undefined as never,
+      JSON.stringify({
+        endTime: "2026-08-20T12:10:00Z",
+        logGroupName: "/aws/lambda/orders-consumer",
+        queryString: "fields @message | limit 20",
+        region: "eu-west-1",
+        startTime: "2026-08-20T12:00:00Z",
+      }),
+    )).resolves.toMatchObject({
+      queryId: "query-1",
+      results: [[{ field: "@message", value: "failed" }]],
+      status: "Complete",
+    });
+    expect(delay).toHaveBeenCalledTimes(1);
+    expect(startQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        endTime: 1_787_227_800,
+        limit: 100,
+        startTime: 1_787_227_200,
+      }),
+    );
+  });
+
+  it("requires the AWS account ID when multiple accounts are connected", async () => {
+    const otherConnection: RuntimeAwsConnection = {
+      ...connection,
+      accountId: "20000000-0000-4000-8000-000000000002",
+      roleArn: "arn:aws:iam::210987654321:role/ResponderInvestigationRole",
+    };
+    const tool = inspectionTool(
+      "aws_inspect_sqs_queue",
+      fakeClients(),
+      [connection, otherConnection],
+    );
+
+    await expect(tool.invoke(
+      undefined as never,
+      JSON.stringify({ queueName: "orders-dlq", region: "eu-west-1" }),
+    )).resolves.toContain(
+      "Specify accountId when more than one AWS account is connected",
+    );
+  });
+});

--- a/apps/worker/src/aws-inspection-tools.test.ts
+++ b/apps/worker/src/aws-inspection-tools.test.ts
@@ -249,4 +249,22 @@ describe("typed AWS inspection tools", () => {
       "Specify accountId when more than one AWS account is connected",
     );
   });
+
+  it("rejects regions outside the connected commercial AWS partition", async () => {
+    const clients = fakeClients();
+    const tool = inspectionTool(
+      "aws_inspect_sqs_queue",
+      clients,
+    );
+
+    await expect(tool.invoke(
+      undefined as never,
+      JSON.stringify({ queueName: "orders-dlq", region: "cn-north-1" }),
+    )).resolves.toContain("Invalid JSON input for tool");
+    await expect(tool.invoke(
+      undefined as never,
+      JSON.stringify({ queueName: "orders-dlq", region: "us-gov-west-1" }),
+    )).resolves.toContain("Invalid JSON input for tool");
+    expect(clients.getQueueUrl).not.toHaveBeenCalled();
+  });
 });

--- a/apps/worker/src/aws-inspection-tools.ts
+++ b/apps/worker/src/aws-inspection-tools.ts
@@ -40,6 +40,7 @@ import {
 } from "@aws-sdk/client-sqs";
 import { tool } from "@openai/agents";
 import type { RuntimeAwsConnection } from "@responder/core/db/investigations";
+import { isAwsCommercialRegion } from "@responder/core/integrations/aws";
 import { z } from "zod";
 import { createRefreshingAwsCredentialsProvider } from "./aws.js";
 
@@ -164,7 +165,7 @@ const regionParameter = z
   .trim()
   .min(3)
   .max(64)
-  .regex(/^[a-z0-9-]+$/u)
+  .refine(isAwsCommercialRegion, "Region must use the commercial AWS partition")
   .describe("AWS region, for example eu-west-1");
 const timestampParameter = z.iso.datetime({ offset: true });
 

--- a/apps/worker/src/aws-inspection-tools.ts
+++ b/apps/worker/src/aws-inspection-tools.ts
@@ -1,0 +1,442 @@
+import {
+  CloudWatchClient,
+  DescribeAlarmHistoryCommand,
+  DescribeAlarmsCommand,
+  GetMetricDataCommand,
+  type DescribeAlarmHistoryCommandInput,
+  type DescribeAlarmHistoryCommandOutput,
+  type DescribeAlarmsCommandInput,
+  type DescribeAlarmsCommandOutput,
+  type GetMetricDataCommandInput,
+  type GetMetricDataCommandOutput,
+} from "@aws-sdk/client-cloudwatch";
+import {
+  CloudWatchLogsClient,
+  GetQueryResultsCommand,
+  StartQueryCommand,
+  type GetQueryResultsCommandInput,
+  type GetQueryResultsCommandOutput,
+  type StartQueryCommandInput,
+  type StartQueryCommandOutput,
+} from "@aws-sdk/client-cloudwatch-logs";
+import {
+  GetFunctionConfigurationCommand,
+  LambdaClient,
+  ListEventSourceMappingsCommand,
+  type GetFunctionConfigurationCommandInput,
+  type GetFunctionConfigurationCommandOutput,
+  type ListEventSourceMappingsCommandInput,
+  type ListEventSourceMappingsCommandOutput,
+} from "@aws-sdk/client-lambda";
+import {
+  GetQueueAttributesCommand,
+  GetQueueUrlCommand,
+  SQSClient,
+  type GetQueueAttributesCommandInput,
+  type GetQueueAttributesCommandOutput,
+  type GetQueueUrlCommandInput,
+  type GetQueueUrlCommandOutput,
+  type QueueAttributeName,
+} from "@aws-sdk/client-sqs";
+import { tool } from "@openai/agents";
+import type { RuntimeAwsConnection } from "@responder/core/db/investigations";
+import { z } from "zod";
+import { createRefreshingAwsCredentialsProvider } from "./aws.js";
+
+const MAX_LOG_QUERY_POLLS = 30;
+const LOG_QUERY_POLL_INTERVAL_MS = 1_000;
+const MAX_INSPECTION_RANGE_MS = 24 * 60 * 60 * 1_000;
+const SQS_INSPECTION_ATTRIBUTES: QueueAttributeName[] = [
+  "ApproximateNumberOfMessages",
+  "ApproximateNumberOfMessagesDelayed",
+  "ApproximateNumberOfMessagesNotVisible",
+  "CreatedTimestamp",
+  "DelaySeconds",
+  "LastModifiedTimestamp",
+  "MaximumMessageSize",
+  "MessageRetentionPeriod",
+  "QueueArn",
+  "ReceiveMessageWaitTimeSeconds",
+  "RedriveAllowPolicy",
+  "RedrivePolicy",
+  "SqsManagedSseEnabled",
+  "VisibilityTimeout",
+];
+
+export interface AwsInspectionClients {
+  describeAlarmHistory(
+    input: DescribeAlarmHistoryCommandInput,
+  ): Promise<DescribeAlarmHistoryCommandOutput>;
+  describeAlarms(
+    input: DescribeAlarmsCommandInput,
+  ): Promise<DescribeAlarmsCommandOutput>;
+  getFunctionConfiguration(
+    input: GetFunctionConfigurationCommandInput,
+  ): Promise<GetFunctionConfigurationCommandOutput>;
+  getMetricData(
+    input: GetMetricDataCommandInput,
+  ): Promise<GetMetricDataCommandOutput>;
+  getQueryResults(
+    input: GetQueryResultsCommandInput,
+  ): Promise<GetQueryResultsCommandOutput>;
+  getQueueAttributes(
+    input: GetQueueAttributesCommandInput,
+  ): Promise<GetQueueAttributesCommandOutput>;
+  getQueueUrl(input: GetQueueUrlCommandInput): Promise<GetQueueUrlCommandOutput>;
+  listEventSourceMappings(
+    input: ListEventSourceMappingsCommandInput,
+  ): Promise<ListEventSourceMappingsCommandOutput>;
+  startQuery(input: StartQueryCommandInput): Promise<StartQueryCommandOutput>;
+}
+
+export type AwsInspectionClientFactory = (
+  connection: RuntimeAwsConnection,
+  region: string,
+) => AwsInspectionClients;
+
+function sdkInspectionClients(
+  region: string,
+  credentials: ReturnType<typeof createRefreshingAwsCredentialsProvider>,
+): AwsInspectionClients {
+  const config = { credentials, maxAttempts: 3, region };
+  const cloudWatch = new CloudWatchClient(config);
+  const logs = new CloudWatchLogsClient(config);
+  const lambda = new LambdaClient(config);
+  const sqs = new SQSClient(config);
+  return {
+    describeAlarmHistory: (input) =>
+      cloudWatch.send(new DescribeAlarmHistoryCommand(input)),
+    describeAlarms: (input) =>
+      cloudWatch.send(new DescribeAlarmsCommand(input)),
+    getFunctionConfiguration: (input) =>
+      lambda.send(new GetFunctionConfigurationCommand(input)),
+    getMetricData: (input) =>
+      cloudWatch.send(new GetMetricDataCommand(input)),
+    getQueryResults: (input) =>
+      logs.send(new GetQueryResultsCommand(input)),
+    getQueueAttributes: (input) =>
+      sqs.send(new GetQueueAttributesCommand(input)),
+    getQueueUrl: (input) => sqs.send(new GetQueueUrlCommand(input)),
+    listEventSourceMappings: (input) =>
+      lambda.send(new ListEventSourceMappingsCommand(input)),
+    startQuery: (input) => logs.send(new StartQueryCommand(input)),
+  };
+}
+
+function selectedConnection(
+  connections: RuntimeAwsConnection[],
+  accountId?: string,
+): RuntimeAwsConnection {
+  if (accountId) {
+    const connection = connections.find(
+      (candidate) => awsAccountId(candidate) === accountId,
+    );
+    if (!connection) throw new Error("Choose a connected AWS account");
+    return connection;
+  }
+  if (connections.length !== 1) {
+    throw new Error(
+      "Specify accountId when more than one AWS account is connected",
+    );
+  }
+  return connections[0]!;
+}
+
+function awsAccountId(connection: RuntimeAwsConnection): string {
+  return connection.roleArn.split(":")[4] ?? "";
+}
+
+function withoutMetadata<T extends { $metadata?: unknown }>(
+  output: T,
+): Omit<T, "$metadata"> {
+  const value = { ...output };
+  delete value.$metadata;
+  return value;
+}
+
+const accountIdParameter = z
+  .string()
+  .regex(/^\d{12}$/u)
+  .optional()
+  .describe("Connected AWS account ID; required when multiple are connected");
+const regionParameter = z
+  .string()
+  .trim()
+  .min(3)
+  .max(64)
+  .regex(/^[a-z0-9-]+$/u)
+  .describe("AWS region, for example eu-west-1");
+const timestampParameter = z.iso.datetime({ offset: true });
+
+function validateInspectionRange(startTime: Date, endTime: Date): void {
+  if (endTime <= startTime) throw new Error("endTime must follow startTime");
+  if (endTime.getTime() - startTime.getTime() > MAX_INSPECTION_RANGE_MS) {
+    throw new Error("AWS inspection time range must not exceed 24 hours");
+  }
+}
+
+export function createAwsInspectionTools(
+  connections: RuntimeAwsConnection[],
+  options: {
+    clientFactory?: AwsInspectionClientFactory;
+    delay?: (milliseconds: number) => Promise<void>;
+    environment?: NodeJS.ProcessEnv;
+  } = {},
+) {
+  if (connections.length === 0) return [];
+
+  const credentials = new Map(
+    connections.map((connection) => [
+      connection.accountId,
+      createRefreshingAwsCredentialsProvider(
+        connection,
+        options.environment,
+      ),
+    ]),
+  );
+  const clientCache = new Map<string, AwsInspectionClients>();
+  const clientFactory =
+    options.clientFactory ??
+    ((connection: RuntimeAwsConnection, region: string) =>
+      sdkInspectionClients(region, credentials.get(connection.accountId)!));
+  const delay =
+    options.delay ??
+    ((milliseconds: number) =>
+      new Promise<void>((resolve) => setTimeout(resolve, milliseconds)));
+
+  function clients(accountId: string | undefined, region: string) {
+    const connection = selectedConnection(connections, accountId);
+    const key = `${connection.accountId}:${region}`;
+    let value = clientCache.get(key);
+    if (!value) {
+      value = clientFactory(connection, region);
+      clientCache.set(key, value);
+    }
+    return { clients: value, connection };
+  }
+
+  const inspectCloudWatchAlarm = tool({
+    name: "aws_inspect_cloudwatch_alarm",
+    description:
+      "Read one CloudWatch alarm and its bounded state/action history. Use this first for an AWS alarm; it returns the affected metric namespace and dimensions without requiring a script.",
+    parameters: z.object({
+      accountId: accountIdParameter,
+      alarmName: z.string().trim().min(1).max(255),
+      endTime: timestampParameter.optional(),
+      historyItems: z.number().int().min(1).max(100).default(25),
+      region: regionParameter,
+      startTime: timestampParameter.optional(),
+    }),
+    async execute(input) {
+      const { clients: aws, connection } = clients(
+        input.accountId,
+        input.region,
+      );
+      const [alarms, history] = await Promise.all([
+        aws.describeAlarms({ AlarmNames: [input.alarmName] }),
+        aws.describeAlarmHistory({
+          AlarmName: input.alarmName,
+          EndDate: input.endTime ? new Date(input.endTime) : undefined,
+          MaxRecords: input.historyItems,
+          StartDate: input.startTime ? new Date(input.startTime) : undefined,
+        }),
+      ]);
+      const alarm =
+        alarms.MetricAlarms?.[0] ??
+        alarms.CompositeAlarms?.[0] ??
+        alarms.LogAlarms?.[0];
+      if (!alarm) throw new Error("CloudWatch alarm was not found");
+      return {
+        accountId: awsAccountId(connection),
+        alarm,
+        history: history.AlarmHistoryItems ?? [],
+        nextToken: history.NextToken,
+        region: input.region,
+      };
+    },
+  });
+
+  const inspectCloudWatchMetric = tool({
+    name: "aws_inspect_cloudwatch_metric",
+    description:
+      "Read bounded CloudWatch metric datapoints for one namespace, metric, statistic, and set of dimensions. Use alarm output to supply the exact metric identity.",
+    parameters: z.object({
+      accountId: accountIdParameter,
+      dimensions: z.record(z.string().min(1), z.string()).default({}),
+      endTime: timestampParameter,
+      metricName: z.string().trim().min(1).max(255),
+      namespace: z.string().trim().min(1).max(255),
+      periodSeconds: z.number().int().min(1).max(86_400).default(60),
+      region: regionParameter,
+      startTime: timestampParameter,
+      statistic: z
+        .enum(["Average", "Maximum", "Minimum", "SampleCount", "Sum"])
+        .default("Sum"),
+    }),
+    async execute(input) {
+      const startTime = new Date(input.startTime);
+      const endTime = new Date(input.endTime);
+      validateInspectionRange(startTime, endTime);
+      const { clients: aws, connection } = clients(
+        input.accountId,
+        input.region,
+      );
+      const output = await aws.getMetricData({
+        EndTime: endTime,
+        MetricDataQueries: [
+          {
+            Id: "metric",
+            MetricStat: {
+              Metric: {
+                Dimensions: Object.entries(input.dimensions).map(
+                  ([Name, Value]) => ({ Name, Value }),
+                ),
+                MetricName: input.metricName,
+                Namespace: input.namespace,
+              },
+              Period: input.periodSeconds,
+              Stat: input.statistic,
+            },
+            ReturnData: true,
+          },
+        ],
+        ScanBy: "TimestampAscending",
+        StartTime: startTime,
+      });
+      return {
+        accountId: awsAccountId(connection),
+        metricData: output.MetricDataResults ?? [],
+        nextToken: output.NextToken,
+        region: input.region,
+      };
+    },
+  });
+
+  const inspectSqsQueue = tool({
+    name: "aws_inspect_sqs_queue",
+    description:
+      "Read one SQS queue's URL and operational attributes without receiving, deleting, or changing messages.",
+    parameters: z.object({
+      accountId: accountIdParameter,
+      queueName: z.string().trim().min(1).max(80),
+      region: regionParameter,
+    }),
+    async execute(input) {
+      const { clients: aws, connection } = clients(
+        input.accountId,
+        input.region,
+      );
+      const queue = await aws.getQueueUrl({ QueueName: input.queueName });
+      const queueUrl = queue.QueueUrl;
+      if (!queueUrl) throw new Error("SQS queue was not found");
+      const attributes = await aws.getQueueAttributes({
+        AttributeNames: SQS_INSPECTION_ATTRIBUTES,
+        QueueUrl: queueUrl,
+      });
+      return {
+        accountId: awsAccountId(connection),
+        attributes: attributes.Attributes ?? {},
+        queueName: input.queueName,
+        queueUrl,
+        region: input.region,
+      };
+    },
+  });
+
+  const inspectLambdaFunction = tool({
+    name: "aws_inspect_lambda_function",
+    description:
+      "Read a Lambda function's non-secret runtime configuration and event source mappings. Environment variables are always omitted.",
+    parameters: z.object({
+      accountId: accountIdParameter,
+      functionName: z.string().trim().min(1).max(140),
+      region: regionParameter,
+    }),
+    async execute(input) {
+      const { clients: aws, connection } = clients(
+        input.accountId,
+        input.region,
+      );
+      const [rawConfiguration, mappings] = await Promise.all([
+        aws.getFunctionConfiguration({ FunctionName: input.functionName }),
+        aws.listEventSourceMappings({
+          FunctionName: input.functionName,
+          MaxItems: 100,
+        }),
+      ]);
+      const configuration = withoutMetadata(rawConfiguration);
+      delete configuration.Environment;
+      delete configuration.KMSKeyArn;
+      return {
+        accountId: awsAccountId(connection),
+        configuration,
+        eventSourceMappings: mappings.EventSourceMappings ?? [],
+        nextMarker: mappings.NextMarker,
+        region: input.region,
+      };
+    },
+  });
+
+  const queryCloudWatchLogs = tool({
+    name: "aws_query_cloudwatch_logs",
+    description:
+      "Run one bounded CloudWatch Logs Insights query and wait up to 30 seconds for its read-only results.",
+    parameters: z.object({
+      accountId: accountIdParameter,
+      endTime: timestampParameter,
+      limit: z.number().int().min(1).max(200).default(100),
+      logGroupName: z.string().trim().min(1).max(512),
+      queryString: z.string().trim().min(1).max(10_000),
+      region: regionParameter,
+      startTime: timestampParameter,
+    }),
+    async execute(input) {
+      const startTime = new Date(input.startTime);
+      const endTime = new Date(input.endTime);
+      validateInspectionRange(startTime, endTime);
+      const { clients: aws, connection } = clients(
+        input.accountId,
+        input.region,
+      );
+      const started = await aws.startQuery({
+        endTime: Math.floor(endTime.getTime() / 1_000),
+        limit: input.limit,
+        logGroupName: input.logGroupName,
+        queryString: input.queryString,
+        startTime: Math.floor(startTime.getTime() / 1_000),
+      });
+      if (!started.queryId) throw new Error("CloudWatch Logs query did not start");
+
+      let output: GetQueryResultsCommandOutput | undefined;
+      for (let attempt = 0; attempt < MAX_LOG_QUERY_POLLS; attempt += 1) {
+        output = await aws.getQueryResults({ queryId: started.queryId });
+        if (output.status === "Complete") break;
+        if (["Cancelled", "Failed", "Timeout", "Unknown"].includes(
+          output.status ?? "Unknown",
+        )) {
+          throw new Error(`CloudWatch Logs query ${output.status ?? "failed"}`);
+        }
+        await delay(LOG_QUERY_POLL_INTERVAL_MS);
+      }
+      if (output?.status !== "Complete") {
+        throw new Error("CloudWatch Logs query did not complete within 30 seconds");
+      }
+      return {
+        accountId: awsAccountId(connection),
+        queryId: started.queryId,
+        region: input.region,
+        results: output?.results ?? [],
+        statistics: output?.statistics,
+        status: output?.status ?? "Unknown",
+      };
+    },
+  });
+
+  return [
+    inspectCloudWatchAlarm,
+    inspectCloudWatchMetric,
+    inspectSqsQueue,
+    inspectLambdaFunction,
+    queryCloudWatchLogs,
+  ];
+}

--- a/apps/worker/src/aws.test.ts
+++ b/apps/worker/src/aws.test.ts
@@ -158,4 +158,26 @@ describe("AWS alarm skill loading", () => {
       },
     ]);
   });
+
+  it("reports MCP error results instead of treating them as guide text", async () => {
+    const callTool = vi.fn().mockImplementation(
+      (_toolName: string, input: { skill_name: string }) => {
+        const result = [
+          { text: `failed to load ${input.skill_name}`, type: "text" },
+        ];
+        Object.assign(result, { isError: true });
+        return Promise.resolve(result);
+      },
+    );
+
+    const result = await loadAwsAlarmSkillContext({ callTool } as never);
+
+    expect(result.content).toBe("");
+    expect(result.failures).toEqual(
+      AWS_ALARM_SKILL_NAMES.map((skillName) => ({
+        error: `failed to load ${skillName}`,
+        skillName,
+      })),
+    );
+  });
 });

--- a/apps/worker/src/aws.test.ts
+++ b/apps/worker/src/aws.test.ts
@@ -1,7 +1,9 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
+  AWS_ALARM_SKILL_NAMES,
   awsReadOnlyToolFilter,
   createRefreshingAwsCredentialsProvider,
+  loadAwsAlarmSkillContext,
 } from "./aws.js";
 
 const connection = {
@@ -103,6 +105,57 @@ describe("AWS credential refresh", () => {
     await expect(Promise.all([first, second])).resolves.toEqual([
       credentials,
       credentials,
+    ]);
+  });
+});
+
+describe("AWS alarm skill loading", () => {
+  it("loads each service guide into the agent context", async () => {
+    const callTool = vi.fn().mockImplementation(
+      (_toolName: string, input: { skill_name: string }) =>
+        Promise.resolve([
+          {
+            text: JSON.stringify({
+              content: { skill_content: `guide for ${input.skill_name}` },
+            }),
+            type: "text",
+          },
+        ]),
+    );
+
+    const result = await loadAwsAlarmSkillContext({ callTool } as never);
+
+    expect(result.failures).toEqual([]);
+    expect(result.content).toContain("guide for aws-observability");
+    expect(result.content).toContain("guide for aws-messaging-and-streaming");
+    expect(result.content).toContain("guide for aws-serverless");
+    expect(callTool).toHaveBeenCalledTimes(AWS_ALARM_SKILL_NAMES.length);
+    expect(callTool).toHaveBeenNthCalledWith(
+      1,
+      "aws___retrieve_skill",
+      { skill_name: "aws-observability" },
+    );
+  });
+
+  it("keeps available guides when one guide fails", async () => {
+    const callTool = vi.fn().mockImplementation(
+      (_toolName: string, input: { skill_name: string }) =>
+        input.skill_name === "aws-messaging-and-streaming"
+          ? Promise.reject(new Error("temporarily unavailable"))
+          : Promise.resolve([
+              { text: `guide for ${input.skill_name}`, type: "text" },
+            ]),
+    );
+
+    const result = await loadAwsAlarmSkillContext({ callTool } as never);
+
+    expect(result.content).toContain("guide for aws-observability");
+    expect(result.content).toContain("guide for aws-serverless");
+    expect(result.failures).toEqual([
+      {
+        error: "temporarily unavailable",
+        skillName: "aws-messaging-and-streaming",
+      },
     ]);
   });
 });

--- a/apps/worker/src/aws.ts
+++ b/apps/worker/src/aws.ts
@@ -124,6 +124,21 @@ function managedSkillContent(content: unknown): string | null {
   return null;
 }
 
+function managedToolError(content: unknown): string {
+  if (!Array.isArray(content)) return "AWS skill retrieval failed";
+  const text = content.flatMap((item) =>
+    item &&
+    typeof item === "object" &&
+    "type" in item &&
+    item.type === "text" &&
+    "text" in item &&
+    typeof item.text === "string"
+      ? [item.text]
+      : []
+  ).join("\n");
+  return text || "AWS skill retrieval failed";
+}
+
 export async function loadAwsAlarmSkillContext(
   server: Pick<MCPServerStreamableHttp, "callTool">,
 ): Promise<AwsAlarmSkillContext> {
@@ -134,6 +149,7 @@ export async function loadAwsAlarmSkillContext(
           "aws___retrieve_skill",
           { skill_name: skillName },
         );
+        if (result.isError) throw new Error(managedToolError(result));
         const content = managedSkillContent(result);
         if (!content) throw new Error("AWS skill returned no readable content");
         return { content: `## ${skillName}\n\n${content}`, skillName };

--- a/apps/worker/src/aws.ts
+++ b/apps/worker/src/aws.ts
@@ -20,6 +20,17 @@ const AWS_MCP_IAM_GUARDED_TOOLS = new Set([
   "run_script",
 ]);
 
+export const AWS_ALARM_SKILL_NAMES = [
+  "aws-observability",
+  "aws-messaging-and-streaming",
+  "aws-serverless",
+] as const;
+
+export interface AwsAlarmSkillContext {
+  content: string;
+  failures: Array<{ error: string; skillName: string }>;
+}
+
 function requestQuery(url: URL): Record<string, string | string[]> {
   const query: Record<string, string | string[]> = {};
   for (const [key, value] of url.searchParams) {
@@ -82,6 +93,65 @@ export function createRefreshingAwsCredentialsProvider(
         });
     }
     return refresh;
+  };
+}
+
+function managedSkillContent(content: unknown): string | null {
+  if (!Array.isArray(content)) return null;
+  for (const item of content) {
+    if (
+      !item ||
+      typeof item !== "object" ||
+      !("type" in item) ||
+      item.type !== "text" ||
+      !("text" in item) ||
+      typeof item.text !== "string"
+    ) {
+      continue;
+    }
+    try {
+      const parsed = JSON.parse(item.text) as {
+        content?: { skill_content?: unknown };
+        skill_content?: unknown;
+      };
+      const skillContent =
+        parsed.content?.skill_content ?? parsed.skill_content;
+      if (typeof skillContent === "string") return skillContent;
+    } catch {
+      if (item.text.trim()) return item.text;
+    }
+  }
+  return null;
+}
+
+export async function loadAwsAlarmSkillContext(
+  server: Pick<MCPServerStreamableHttp, "callTool">,
+): Promise<AwsAlarmSkillContext> {
+  const loaded = await Promise.all(
+    AWS_ALARM_SKILL_NAMES.map(async (skillName) => {
+      try {
+        const result = await server.callTool(
+          "aws___retrieve_skill",
+          { skill_name: skillName },
+        );
+        const content = managedSkillContent(result);
+        if (!content) throw new Error("AWS skill returned no readable content");
+        return { content: `## ${skillName}\n\n${content}`, skillName };
+      } catch (error) {
+        return {
+          error: error instanceof Error ? error.message : String(error),
+          skillName,
+        };
+      }
+    }),
+  );
+  return {
+    content: loaded
+      .flatMap((result) => result.content ? [result.content] : [])
+      .join("\n\n"),
+    failures: loaded.flatMap((result) =>
+      result.error ? [{ error: result.error, skillName: result.skillName }] : []
+    ),
   };
 }
 

--- a/apps/worker/src/investigate.test.ts
+++ b/apps/worker/src/investigate.test.ts
@@ -249,6 +249,7 @@ describe("sandbox agent configuration", () => {
       agentPrompt: "Inspect the reported failure.",
       awsAlarmTriggered: true,
       awsAccountNames: ["AWS · 123456789012"],
+      awsSkillContext: "# AWS Observability\nInspect alarm history.",
       clickStackConnected: false,
       datadogConnected: false,
       repositories: [],
@@ -260,6 +261,11 @@ describe("sandbox agent configuration", () => {
     expect(instructions).toContain("Never request secret values");
     expect(instructions).toContain("Locate the exact CloudWatch alarm");
     expect(instructions).toContain("Treat the Slack notification as a pointer");
+    expect(instructions).toContain("aws_inspect_cloudwatch_alarm");
+    expect(instructions).toContain("top-level await instead of asyncio.run");
+    expect(instructions).toContain("exact PascalCase AWS API operation names");
+    expect(instructions).toContain("outer success status");
+    expect(instructions).toContain("# AWS Observability");
   });
 
   it("stores the exact initial message that is sent to the agent", () => {

--- a/apps/worker/src/investigate.test.ts
+++ b/apps/worker/src/investigate.test.ts
@@ -329,4 +329,12 @@ describe("sandbox agent configuration", () => {
       type: "instructions.configured",
     });
   });
+
+  it("preserves and redacts string failures", () => {
+    expect(
+      safeInvestigationError("AWS guide failed after openai-secret", {
+        OPENAI_API_KEY: "openai-secret",
+      }),
+    ).toBe("AWS guide failed after [redacted]");
+  });
 });

--- a/apps/worker/src/investigate.ts
+++ b/apps/worker/src/investigate.ts
@@ -79,7 +79,11 @@ export function safeInvestigationError(
   environment: NodeJS.ProcessEnv = process.env,
 ): string {
   let message =
-    error instanceof Error ? error.message : "Investigation agent failed";
+    error instanceof Error
+      ? error.message
+      : typeof error === "string"
+        ? error
+        : "Investigation agent failed";
   for (const name of ["OPENAI_API_KEY", "DAYTONA_API_KEY"] as const) {
     const value = environment[name];
     if (value) message = message.replaceAll(value, "[redacted]");

--- a/apps/worker/src/investigate.ts
+++ b/apps/worker/src/investigate.ts
@@ -29,7 +29,11 @@ import type {
 } from "@responder/core/db/schema";
 import type { InvestigationJob } from "@responder/core/jobs";
 import { investigationPrompt, toInvestigationInput } from "@responder/core/investigations/input";
-import { createAwsMcpServer } from "./aws.js";
+import {
+  createAwsMcpServer,
+  loadAwsAlarmSkillContext,
+} from "./aws.js";
+import { createAwsInspectionTools } from "./aws-inspection-tools.js";
 import { createDatadogMcpServer } from "./datadog.js";
 import { createCustomMcpServer, createLinearMcpServer } from "./custom-mcp.js";
 import { createClickStackMcpServer } from "./clickstack.js";
@@ -170,6 +174,7 @@ export function investigationInstructions(input: {
   agentPrompt: string;
   awsAlarmTriggered?: boolean;
   awsAccountNames?: string[];
+  awsSkillContext?: string;
   customMcpNames?: string[];
   datadogConnected: boolean;
   clickStackConnected: boolean;
@@ -210,6 +215,12 @@ export function investigationInstructions(input: {
       : null,
     input.awsAlarmTriggered && awsAccountNames.length > 0
       ? "This investigation was triggered by an AWS alarm forwarded through Slack. Locate the exact CloudWatch alarm by its normalized name and region first. Inspect its current configuration, state history, metric data, affected resource, and relevant logs around the transition. Treat the Slack notification as a pointer, not as proof of root cause."
+      : null,
+    input.awsSkillContext
+      ? `Use the following AWS investigation guides when planning service-specific inspection:\n\n${input.awsSkillContext}`
+      : null,
+    awsAccountNames.length > 0
+      ? "Prefer the typed aws_inspect_cloudwatch_alarm, aws_inspect_cloudwatch_metric, aws_query_cloudwatch_logs, aws_inspect_sqs_queue, and aws_inspect_lambda_function tools for AWS evidence. If aws___run_script is necessary, use top-level await instead of asyncio.run, use exact PascalCase AWS API operation names, and inspect every nested api_calls result. An outer success status does not mean the nested AWS calls succeeded; retry failed nested calls with corrected operation names."
       : null,
     input.datadogConnected
       ? "Use the connected Datadog tools to inspect the matching logs and surrounding service activity before concluding."
@@ -291,6 +302,9 @@ export async function runInvestigationAgent(
   onLinearTicketRequests?: (requestIds: string[]) => Promise<void>,
 ): Promise<string> {
   const investigationInput = toInvestigationInput(job.request);
+  const awsAlarmTriggered =
+    investigationInput.provider === "slack" &&
+    investigationInput.attributes?.slackAlertProvider === "aws";
   const writeTrace = async (event: InvestigationTraceEvent): Promise<void> => {
     try {
       await onTraceEvent(event);
@@ -444,6 +458,21 @@ export async function runInvestigationAgent(
         }
       }),
     );
+    let awsSkillContext = "";
+    if (awsAlarmTriggered && awsServers[0]) {
+      const loadedSkills = await loadAwsAlarmSkillContext(awsServers[0]);
+      awsSkillContext = loadedSkills.content;
+      for (const failure of loadedSkills.failures) {
+        console.error(
+          JSON.stringify({
+            error: safeInvestigationError(failure.error, environment),
+            event: "aws_investigation_skill_load_failed",
+            investigationId: job.investigationId,
+            skillName: failure.skillName,
+          }),
+        );
+      }
+    }
     session = await client.create();
     await configureDaytonaSandboxLifecycle(session, config, workspaceSecrets);
     await prepareDaytonaSandbox(session);
@@ -472,12 +501,17 @@ export async function runInvestigationAgent(
       session,
     });
     const vercelTools = createVercelTools(vercelConnections);
+    const awsInspectionTools = createAwsInspectionTools(awsConnections, {
+      environment,
+    });
     const instructions = investigationInstructions({
       agentPrompt: job.config.prompt,
-      awsAlarmTriggered:
-        investigationInput.provider === "slack" &&
-        investigationInput.attributes?.slackAlertProvider === "aws",
-      awsAccountNames: awsConnections.map((connection) => connection.displayName),
+      awsAlarmTriggered,
+      awsAccountNames: awsConnections.map(
+        (connection) =>
+          `${connection.displayName} (${connection.roleArn.split(":")[4] ?? "unknown"})`,
+      ),
+      awsSkillContext,
       customMcpNames: customMcpConnections.map((connection) => connection.displayName),
       clickStackConnected: clickStackServer !== null,
       datadogConnected: datadogServer !== null,
@@ -504,6 +538,7 @@ export async function runInvestigationAgent(
       tools: [
         issueSearchTool,
         reportTool,
+        ...awsInspectionTools,
         ...repositoryInspectionTools,
         ...upstashTools,
         ...vercelTools,

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -195,12 +195,12 @@ supports the commercial AWS partition (`arn:aws`) only.
 AWS context does not receive native EventBridge or SNS webhooks. CloudWatch
 alarms can trigger an Agent when Amazon Q Developer in chat applications
 forwards the alarm to a watched Slack channel; the selected AWS account remains
-the read-only investigation context.
-
-AWS context does not receive native EventBridge or SNS webhooks. CloudWatch
-alarms can trigger an Agent when Amazon Q Developer in chat applications
-forwards the alarm to a watched Slack channel; the selected AWS account remains
-the read-only investigation context.
+the read-only investigation context. AWS alarm investigations preload the
+CloudWatch, messaging, and serverless investigation guides. Typed read-only
+tools cover CloudWatch alarm configuration and history, metrics, Logs Insights,
+SQS queue attributes, and Lambda configuration and event source mappings. The
+managed sandboxed script runner remains available for other read-only AWS API
+calls.
 
 Production deployments should store the generic template in a private S3
 bucket and configure `AWS_INTEGRATION_TEMPLATE_BUCKET` and

--- a/packages/core/src/integrations/aws.test.ts
+++ b/packages/core/src/integrations/aws.test.ts
@@ -7,6 +7,7 @@ import {
   awsParameterizedCloudFormationTemplate,
   awsIntegrationPrincipalArn,
   awsInvestigationRoleArn,
+  isAwsCommercialRegion,
 } from "./aws.js";
 
 describe("AWS integration", () => {
@@ -18,6 +19,13 @@ describe("AWS integration", () => {
 
   it("rejects account IDs with trailing whitespace", () => {
     expect(awsAccountIdSchema.safeParse("123456789012\n").success).toBe(false);
+  });
+
+  it("recognizes only regions in the commercial AWS partition", () => {
+    expect(isAwsCommercialRegion("eu-west-3")).toBe(true);
+    expect(isAwsCommercialRegion("cn-north-1")).toBe(false);
+    expect(isAwsCommercialRegion("us-gov-west-1")).toBe(false);
+    expect(isAwsCommercialRegion("us-iso-east-1")).toBe(false);
   });
 
   it("uses the managed AIOps policy and an external-ID trust condition", () => {

--- a/packages/core/src/integrations/aws.ts
+++ b/packages/core/src/integrations/aws.ts
@@ -17,6 +17,10 @@ export const AWS_MCP_SIGNING_REGION = "us-east-1";
 const AWS_COMMERCIAL_REGION_PATTERN =
   /^(?:af|ap|ca|eu|il|me|mx|sa|us)-(?!gov-|iso)[a-z]+(?:-[a-z]+)?-\d$/;
 
+export function isAwsCommercialRegion(region: string): boolean {
+  return AWS_COMMERCIAL_REGION_PATTERN.test(region);
+}
+
 export const awsAccountIdSchema = z.string().length(12).regex(/^\d{12}$/);
 export const awsConnectionCredentialsSchema = z.object({
   accountId: awsAccountIdSchema,
@@ -86,7 +90,7 @@ export async function createAwsCloudFormationTemplateUrl(
   const bucket = environment.AWS_INTEGRATION_TEMPLATE_BUCKET?.trim();
   const key = environment.AWS_INTEGRATION_TEMPLATE_KEY?.trim();
   const region = environment.AWS_INTEGRATION_TEMPLATE_REGION?.trim();
-  if (!bucket || !key || !region || !AWS_COMMERCIAL_REGION_PATTERN.test(region)) {
+  if (!bucket || !key || !region || !isAwsCommercialRegion(region)) {
     return null;
   }
 
@@ -103,7 +107,7 @@ function isSupportedCloudFormationTemplateUrl(templateUrl: URL): boolean {
   const region = templateUrl.hostname.match(
     /^(?:[a-z0-9][a-z0-9.-]*\.)?s3[.-]([a-z0-9-]+)\.amazonaws\.com$/,
   )?.[1];
-  return region !== undefined && AWS_COMMERCIAL_REGION_PATTERN.test(region);
+  return region !== undefined && isAwsCommercialRegion(region);
 }
 
 export function awsCloudFormationQuickCreateUrl(input: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -154,6 +154,18 @@ importers:
       '@aws-crypto/sha256-js':
         specifier: 5.2.0
         version: 5.2.0
+      '@aws-sdk/client-cloudwatch':
+        specifier: 3.1111.0
+        version: 3.1111.0
+      '@aws-sdk/client-cloudwatch-logs':
+        specifier: 3.1111.0
+        version: 3.1111.0
+      '@aws-sdk/client-lambda':
+        specifier: 3.1111.0
+        version: 3.1111.0
+      '@aws-sdk/client-sqs':
+        specifier: 3.1111.0
+        version: 3.1111.0
       '@daytona/sdk':
         specifier: 0.203.0
         version: 0.203.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
@@ -260,8 +272,24 @@ packages:
     resolution: {integrity: sha512-VCpnmyHQ1IH49ni3LXnQj7DPr7rmcJmzYeiCkYdCcfgNtkvOj38cdcL9lapBWoItZWFACJPFJlymqC7/gem3Gw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/client-cloudwatch-logs@3.1111.0':
+    resolution: {integrity: sha512-IO2wKucjHIduO2z263JCMAezA5YCpFrSj4QN1u4FPZTVjUxWlE9DGGYbCuR2/1zGOp2Y3uvuk+GD0Gj7HrhpJQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-cloudwatch@3.1111.0':
+    resolution: {integrity: sha512-UNZuzAPuramSJw1DDAq5I9+2llMqmKJ6ARj472WsD9n4h7ICw8z4rEeyl4OrPSUXsUz4jRNP40AAwaPD41YwpA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-lambda@3.1111.0':
+    resolution: {integrity: sha512-jG2rB6LY2rx3XT55axgH3C0aIv1egvI0kqPYC6jfghVp82kWssU7R/1dJxXr0PnPLv4wq+WXRyLEmjyKURUjFQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/client-s3@3.1111.0':
     resolution: {integrity: sha512-VnLT6aSTN8tWl/NsXUysXNZor7wQBp9CRwufo7kt8cwGXvHLZ0S/cV1K9WFcREGboVYSo3NGQ3ZvU7LRidh2aQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-sqs@3.1111.0':
+    resolution: {integrity: sha512-xeyZhY/yL5d5mcLqtHEsdKkTdNuSGslcmIOgx402dMFji2lzRigzX8caNTdmtpTHwa47DGBoTHB3v9UgbmSnvg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/client-sts@3.1111.0':
@@ -312,6 +340,10 @@ packages:
 
   '@aws-sdk/middleware-sdk-s3@3.972.74':
     resolution: {integrity: sha512-2lzoV2z2QO5KJZYGOCnIZ1WVQgzMECvwuzr1xb034a++8QW4U4eGrmC2u4yg1xvNv4TLL/Uv5DLyuAiw0b9z7Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-sdk-sqs@3.972.41':
+    resolution: {integrity: sha512-07AbG/6LlaoC3YJ97vPgWVYFGWg3W3Bdr1ow3xjwti5u9/PjVD8+wB+qu2jDZnIvE6F7Y4ONWYCDQTPxiepdnA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/nested-clients@3.997.43':
@@ -1388,6 +1420,10 @@ packages:
     resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
     engines: {node: '>=14.0.0'}
 
+  '@smithy/middleware-compression@4.6.2':
+    resolution: {integrity: sha512-Q9d+luiRjyHT6kCL/9NyGpdZJgodh4vtvfHC6H8SqoVKrV2k9RoyI9/IloVfdCYks3/2DIi7BsYYLcda5KZS0A==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/node-http-handler@4.11.2':
     resolution: {integrity: sha512-avwAh9HM3h2lcfjvP3zYIZGf+XVgLQ91wOJ2qoFbNpW1UZeZb33aGlhTZvtkANHfcGhJroRY64525OjfgOg30g==}
     engines: {node: '>=18.0.0'}
@@ -2436,6 +2472,9 @@ packages:
 
   fflate@0.4.9:
     resolution: {integrity: sha512-zdxgIEddhfsyCaWpJ2SdXEP8ZMrKJ6+5jl4OupODcywU0IhRk6gdXuVGcPICyfx2H97hVK7xmJtRLPjkxAX8Vw==}
+
+  fflate@0.8.3:
+    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
 
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
@@ -3984,6 +4023,40 @@ snapshots:
       '@smithy/types': 4.17.2
       tslib: 2.8.1
 
+  '@aws-sdk/client-cloudwatch-logs@3.1111.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.8
+      '@aws-sdk/credential-provider-node': 3.972.80
+      '@aws-sdk/types': 3.974.4
+      '@smithy/core': 3.33.2
+      '@smithy/fetch-http-handler': 5.7.2
+      '@smithy/node-http-handler': 4.11.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/client-cloudwatch@3.1111.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.8
+      '@aws-sdk/credential-provider-node': 3.972.80
+      '@aws-sdk/types': 3.974.4
+      '@smithy/core': 3.33.2
+      '@smithy/fetch-http-handler': 5.7.2
+      '@smithy/middleware-compression': 4.6.2
+      '@smithy/node-http-handler': 4.11.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/client-lambda@3.1111.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.8
+      '@aws-sdk/credential-provider-node': 3.972.80
+      '@aws-sdk/types': 3.974.4
+      '@smithy/core': 3.33.2
+      '@smithy/fetch-http-handler': 5.7.2
+      '@smithy/node-http-handler': 4.11.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
   '@aws-sdk/client-s3@3.1111.0':
     dependencies:
       '@aws-sdk/checksums': 3.1000.28
@@ -3991,6 +4064,18 @@ snapshots:
       '@aws-sdk/credential-provider-node': 3.972.80
       '@aws-sdk/middleware-sdk-s3': 3.972.74
       '@aws-sdk/signature-v4-multi-region': 3.996.45
+      '@aws-sdk/types': 3.974.4
+      '@smithy/core': 3.33.2
+      '@smithy/fetch-http-handler': 5.7.2
+      '@smithy/node-http-handler': 4.11.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/client-sqs@3.1111.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.8
+      '@aws-sdk/credential-provider-node': 3.972.80
+      '@aws-sdk/middleware-sdk-sqs': 3.972.41
       '@aws-sdk/types': 3.974.4
       '@smithy/core': 3.33.2
       '@smithy/fetch-http-handler': 5.7.2
@@ -4119,6 +4204,13 @@ snapshots:
     dependencies:
       '@aws-sdk/core': 3.977.8
       '@aws-sdk/signature-v4-multi-region': 3.996.45
+      '@aws-sdk/types': 3.974.4
+      '@smithy/core': 3.33.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-sdk-sqs@3.972.41':
+    dependencies:
       '@aws-sdk/types': 3.974.4
       '@smithy/core': 3.33.2
       '@smithy/types': 4.17.2
@@ -5271,6 +5363,13 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  '@smithy/middleware-compression@4.6.2':
+    dependencies:
+      '@smithy/core': 3.33.2
+      '@smithy/types': 4.17.2
+      fflate: 0.8.3
+      tslib: 2.8.1
+
   '@smithy/node-http-handler@4.11.2':
     dependencies:
       '@smithy/core': 3.33.2
@@ -6262,6 +6361,8 @@ snapshots:
       picomatch: 4.0.5
 
   fflate@0.4.9: {}
+
+  fflate@0.8.3: {}
 
   file-entry-cache@8.0.0:
     dependencies:


### PR DESCRIPTION
## Summary
- add typed read-only CloudWatch alarm, metric, Logs Insights, SQS, and Lambda inspection tools
- preload observability, messaging, and serverless guides for AWS alarm investigations
- document the managed script runner contract and nested failure handling without adding a report completion gate

## Validation
- pnpm typecheck
- pnpm lint
- pnpm test (698 tests)
- hosted composition and production app build
- hosted source seal and CDK synth

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes AWS alarm investigations reliable by adding typed, read‑only inspection tools and preloading AWS guides. Before, we relied on ad‑hoc scripts; now the agent uses explicit SDK operations with guardrails for region and time windows.

- Adds tools: aws_inspect_cloudwatch_alarm (alarm and history), aws_inspect_cloudwatch_metric (≤24h metric series), aws_query_cloudwatch_logs (Logs Insights, polls ≤30s), aws_inspect_sqs_queue (URL and attributes only), and aws_inspect_lambda_function (config and event source mappings; omits environment variables and KMS identifiers).
- Enforces guardrails: require accountId when multiple AWS accounts are connected, reject non‑commercial regions, cap inspection windows to 24h for metrics and logs queries, and cache clients per account/region.
- Preloads AWS observability, messaging, and serverless guides into the agent; logs failures, redacts secrets in error messages, and proceeds with available guides.
- Registers the tools and updates instructions to prefer them; documents the script runner contract (use top‑level await, exact PascalCase AWS API operation names, and inspect nested api_calls).
- Adds `@aws-sdk/client-cloudwatch`, `@aws-sdk/client-cloudwatch-logs`, `@aws-sdk/client-sqs`, and `@aws-sdk/client-lambda`; updates docs and tests.

<sup>Written for commit f86009bcc8251162252314b5b00246fdf65de7d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/responder-oss/pull/43?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

