### PR TITLE
Fix AWS metric tool schema

### DIFF
--- a/apps/worker/src/aws-inspection-tools.test.ts
+++ b/apps/worker/src/aws-inspection-tools.test.ts
@@ -118,10 +118,15 @@ describe("typed AWS inspection tools", () => {
       fakeClients({ getMetricData }),
     );
 
+    expect(tool.parameters).toMatchObject({
+      properties: { dimensions: { type: "array" } },
+      required: expect.arrayContaining(["dimensions"]),
+    });
+
     await expect(tool.invoke(
       undefined as never,
       JSON.stringify({
-        dimensions: { QueueName: "orders-dlq" },
+        dimensions: [{ name: "QueueName", value: "orders-dlq" }],
         endTime: "2026-08-20T12:10:00Z",
         metricName: "ApproximateNumberOfMessagesVisible",
         namespace: "AWS/SQS",

--- a/apps/worker/src/aws-inspection-tools.ts
+++ b/apps/worker/src/aws-inspection-tools.ts
@@ -263,7 +263,12 @@ export function createAwsInspectionTools(
       "Read bounded CloudWatch metric datapoints for one namespace, metric, statistic, and set of dimensions. Use alarm output to supply the exact metric identity.",
     parameters: z.object({
       accountId: accountIdParameter,
-      dimensions: z.record(z.string().min(1), z.string()).default({}),
+      dimensions: z.array(
+        z.object({
+          name: z.string().trim().min(1).max(255),
+          value: z.string().max(1_024),
+        }),
+      ).max(30).default([]),
       endTime: timestampParameter,
       metricName: z.string().trim().min(1).max(255),
       namespace: z.string().trim().min(1).max(255),
@@ -289,9 +294,10 @@ export function createAwsInspectionTools(
             Id: "metric",
             MetricStat: {
               Metric: {
-                Dimensions: Object.entries(input.dimensions).map(
-                  ([Name, Value]) => ({ Name, Value }),
-                ),
+                Dimensions: input.dimensions.map(({ name, value }) => ({
+                  Name: name,
+                  Value: value,
+                })),
                 MetricName: input.metricName,
                 Namespace: input.namespace,
               },


### PR DESCRIPTION
## Summary
- encode CloudWatch metric dimensions as a strict name/value array
- add a regression assertion for the generated function schema

## Validation
- pnpm typecheck
- pnpm lint
- pnpm test (702 tests)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Encodes CloudWatch metric dimensions as a strict name/value array to match the AWS API. Previously the tool accepted a record; now it requires an array of { name, value }, enforces AWS limits, updates request construction, and adds a schema regression test.

- Migration
  - Update all calls: replace `{ QueueName: "orders-dlq" }` with `[{ name: "QueueName", value: "orders-dlq" }]`.
  - Respect limits: max 30 dimensions; `name` 1–255 chars (trimmed); `value` up to 1024 chars.
  - The schema marks `dimensions` as required; pass `[]` if no dimensions are needed.

- Review notes
  - Only the parameter shape and request mapping changed; metric query semantics are unchanged.

<sup>Written for commit aaa2049254584ff31e06e70f85e74ea1cafed361. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/responder-oss/pull/44?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

