### PR TITLE
Track investigation creation analytics

### DIFF
--- a/apps/control-plane/server/investigations/queue.test.ts
+++ b/apps/control-plane/server/investigations/queue.test.ts
@@ -14,6 +14,7 @@ const mocks = vi.hoisted(() => ({
   getIssuePullRequestForRemediation: vi.fn(),
   getRuntimeAgentConfig: vi.fn(),
   notifyBillingLimitReached: vi.fn(),
+  prepareInvestigationRetry: vi.fn(),
   prepareWorkerQueues: vi.fn(),
   setIssuePullRequestSession: vi.fn(),
 }));
@@ -35,6 +36,7 @@ vi.mock("../../../../packages/core/src/db/investigations.js", () => ({
   discardPendingInvestigation: mocks.discardPendingInvestigation,
   failInvestigation: mocks.failInvestigation,
   getRuntimeAgentConfig: mocks.getRuntimeAgentConfig,
+  prepareInvestigationRetry: mocks.prepareInvestigationRetry,
 }));
 
 vi.mock("../../../../packages/core/src/db/pull-requests.js", () => ({
@@ -65,6 +67,7 @@ vi.mock("../../../../packages/core/src/jobs.js", async (importOriginal) => {
 import {
   closeInvestigationQueue,
   queueInvestigation,
+  queueInvestigationRetry,
   queueIssueRemediation,
 } from "./queue.js";
 
@@ -119,6 +122,12 @@ describe("investigation queue", () => {
     mocks.captureAnalyticsEvent.mockResolvedValue(undefined);
     mocks.prepareWorkerQueues.mockResolvedValue(undefined);
     mocks.notifyBillingLimitReached.mockResolvedValue(undefined);
+    mocks.prepareInvestigationRetry.mockResolvedValue({
+      config: created.config,
+      input: request,
+      investigationId: created.investigationId,
+      runtimeProfileId: created.runtimeProfileId,
+    });
     mocks.getIssuePullRequestForRemediation.mockResolvedValue(
       remediationRequest,
     );
@@ -189,6 +198,20 @@ describe("investigation queue", () => {
       created.investigationId,
     );
     expect(mocks.bossSend).not.toHaveBeenCalled();
+    expect(mocks.captureAnalyticsEvent).not.toHaveBeenCalled();
+  });
+
+  it("does not count a retry as a newly created investigation", async () => {
+    await expect(
+      queueInvestigationRetry(created.investigationId),
+    ).resolves.toEqual({
+      investigationId: created.investigationId,
+      jobId: "21212121-2121-4121-8121-212121212121",
+    });
+
+    expect(mocks.prepareInvestigationRetry).toHaveBeenCalledWith(
+      created.investigationId,
+    );
     expect(mocks.captureAnalyticsEvent).not.toHaveBeenCalled();
   });
 

--- a/apps/control-plane/server/investigations/queue.test.ts
+++ b/apps/control-plane/server/investigations/queue.test.ts
@@ -5,6 +5,7 @@ const mocks = vi.hoisted(() => ({
   bossSend: vi.fn(),
   bossStart: vi.fn(),
   bossStop: vi.fn(),
+  captureAnalyticsEvent: vi.fn(),
   claimIssuePullRequestForRemediation: vi.fn(),
   consumeInvestigation: vi.fn(),
   discardPendingInvestigation: vi.fn(),
@@ -15,6 +16,10 @@ const mocks = vi.hoisted(() => ({
   notifyBillingLimitReached: vi.fn(),
   prepareWorkerQueues: vi.fn(),
   setIssuePullRequestSession: vi.fn(),
+}));
+
+vi.mock("../../../../packages/core/src/analytics.js", () => ({
+  captureAnalyticsEvent: mocks.captureAnalyticsEvent,
 }));
 
 vi.mock("../../../../packages/core/src/billing/autumn.js", () => ({
@@ -111,6 +116,7 @@ describe("investigation queue", () => {
       nextResetAt: null,
     });
     mocks.bossStart.mockResolvedValue(undefined);
+    mocks.captureAnalyticsEvent.mockResolvedValue(undefined);
     mocks.prepareWorkerQueues.mockResolvedValue(undefined);
     mocks.notifyBillingLimitReached.mockResolvedValue(undefined);
     mocks.getIssuePullRequestForRemediation.mockResolvedValue(
@@ -136,6 +142,7 @@ describe("investigation queue", () => {
     });
     expect(mocks.consumeInvestigation).not.toHaveBeenCalled();
     expect(mocks.bossSend).not.toHaveBeenCalled();
+    expect(mocks.captureAnalyticsEvent).not.toHaveBeenCalled();
   });
 
   it("checks the monthly limit and adds a new job", async () => {
@@ -153,6 +160,19 @@ describe("investigation queue", () => {
       expect.objectContaining({ investigationId: created.investigationId }),
       { singletonKey: created.investigationId },
     );
+    expect(mocks.captureAnalyticsEvent).toHaveBeenCalledWith({
+      distinctId: `investigation:${created.investigationId}`,
+      event: "investigation created",
+      organizationId: created.config.organizationId,
+      properties: {
+        $process_person_profile: false,
+        agent_config_version_id: created.config.id,
+        agent_id: created.config.agentId,
+        investigation_id: created.investigationId,
+        is_replay: false,
+        provider: request.provider,
+      },
+    });
   });
 
   it("removes an unstarted investigation when the monthly limit is reached", async () => {
@@ -169,6 +189,7 @@ describe("investigation queue", () => {
       created.investigationId,
     );
     expect(mocks.bossSend).not.toHaveBeenCalled();
+    expect(mocks.captureAnalyticsEvent).not.toHaveBeenCalled();
   });
 
   it("fails a remediation request when the queue cannot start", async () => {

--- a/apps/control-plane/server/investigations/queue.ts
+++ b/apps/control-plane/server/investigations/queue.ts
@@ -1,5 +1,6 @@
 import { consumeInvestigation } from "../../../../packages/core/src/billing/autumn.js";
 import { notifyBillingLimitReached } from "../../../../packages/core/src/billing/notifications.js";
+import { captureAnalyticsEvent } from "../../../../packages/core/src/analytics.js";
 import {
   beginInvestigation,
   discardPendingInvestigation,
@@ -77,6 +78,20 @@ export async function queueInvestigation(
     console.error("Unable to meter investigation", error);
     throw new Error("Billing service unavailable", { cause: error });
   }
+
+  await captureAnalyticsEvent({
+    distinctId: `investigation:${result.investigationId}`,
+    event: "investigation created",
+    organizationId: result.config.organizationId,
+    properties: {
+      $process_person_profile: false,
+      agent_config_version_id: result.config.id,
+      agent_id: result.config.agentId,
+      investigation_id: result.investigationId,
+      is_replay: false,
+      provider: input.provider,
+    },
+  });
 
   try {
     const jobId = await (await getBoss()).send(

--- a/apps/worker/src/replay-requests.test.ts
+++ b/apps/worker/src/replay-requests.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { InvestigationRetryError } from "@responder/core/db/investigations";
 
 const mocks = vi.hoisted(() => ({
+  captureAnalyticsEvent: vi.fn(),
   claim: vi.fn(),
   complete: vi.fn(),
   failInvestigation: vi.fn(),
@@ -9,6 +10,10 @@ const mocks = vi.hoisted(() => ({
   markQueued: vi.fn(),
   prepare: vi.fn(),
   release: vi.fn(),
+}));
+
+vi.mock("@responder/core/analytics", () => ({
+  captureAnalyticsEvent: mocks.captureAnalyticsEvent,
 }));
 
 vi.mock("@responder/core/db/investigations", async (importOriginal) => {
@@ -64,6 +69,7 @@ const replay = {
 describe("admin replay request processor", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.captureAnalyticsEvent.mockResolvedValue(undefined);
     mocks.claim.mockResolvedValue(request);
     mocks.prepare.mockResolvedValue(replay);
     mocks.release.mockResolvedValue({ failed: false });
@@ -86,6 +92,20 @@ describe("admin replay request processor", () => {
       { singletonKey: `replay:${request.replayInvestigationId}` },
     );
     expect(mocks.markQueued).toHaveBeenCalledWith(request.id);
+    expect(mocks.captureAnalyticsEvent).toHaveBeenCalledWith({
+      distinctId: `investigation:${request.replayInvestigationId}`,
+      event: "investigation created",
+      organizationId: replay.config.organizationId,
+      properties: {
+        $process_person_profile: false,
+        agent_config_version_id: replay.config.id,
+        agent_id: replay.config.agentId,
+        investigation_id: request.replayInvestigationId,
+        is_replay: true,
+        provider: replay.input.provider,
+        source_investigation_id: request.sourceInvestigationId,
+      },
+    });
   });
 
   it("does nothing when the inbox is empty", async () => {
@@ -176,6 +196,7 @@ describe("admin replay request processor", () => {
       processNextInvestigationReplayRequest(queue),
     ).resolves.toBe(true);
     expect(mocks.markQueued).toHaveBeenCalledWith(request.id);
+    expect(mocks.captureAnalyticsEvent).not.toHaveBeenCalled();
     expect(mocks.release).not.toHaveBeenCalled();
   });
 });

--- a/apps/worker/src/replay-requests.ts
+++ b/apps/worker/src/replay-requests.ts
@@ -1,3 +1,4 @@
+import { captureAnalyticsEvent } from "@responder/core/analytics";
 import {
   claimInvestigationReplayRequest,
   completeInvestigationReplayRequest,
@@ -40,6 +41,22 @@ export async function processNextInvestigationReplayRequest(
   try {
     try {
       const replay = await prepareInvestigationReplayRequest(request);
+      if (replay.created) {
+        await captureAnalyticsEvent({
+          distinctId: `investigation:${replay.investigationId}`,
+          event: "investigation created",
+          organizationId: replay.config.organizationId,
+          properties: {
+            $process_person_profile: false,
+            agent_config_version_id: replay.config.id,
+            agent_id: replay.config.agentId,
+            investigation_id: replay.investigationId,
+            is_replay: true,
+            provider: replay.input.provider,
+            source_investigation_id: request.sourceInvestigationId,
+          },
+        });
+      }
       if (replay.replayStatus === "resolved") {
         await completeInvestigationReplayRequest(replay.investigationId);
         return true;

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -15,7 +15,7 @@ activity can be separated from other products sharing the PostHog project.
 | `integration connected` | An OAuth callback finishes and resources are synced | `provider`, `integration_account_id`, `resource_count` |
 | `agent created` | A new agent and its initial configuration are persisted | `agent_id`, `trigger_kind`, `model`, `enabled`, `pr_mode` |
 | `prompt copied` | A user clicks **Copy prompt** in Slack | `issue_id`, `issue_found`, `team_id`, `channel_id`, `surface` |
-| `investigation started` | A new or retried investigation starts its runtime session | `investigation_id`, `agent_id`, `provider`, `is_retry` |
+| `investigation created` | A new investigation or replay is persisted and accepted for processing | `investigation_id`, `agent_id`, `provider`, `is_replay`, `source_investigation_id` |
 
 Events associated with a workspace include `organization_id` and the PostHog
 `organization` group. Authenticated events use the Better Auth user ID as their

--- a/packages/core/src/analytics.test.ts
+++ b/packages/core/src/analytics.test.ts
@@ -95,12 +95,12 @@ describe("product analytics", () => {
     await expect(
       captureAnalyticsEvent({
         distinctId: "organization:organization-1",
-        event: "investigation started",
+        event: "investigation created",
         organizationId: "organization-1",
       }),
     ).resolves.toBeUndefined();
     expect(consoleError).toHaveBeenCalledWith(
-      "Unable to capture investigation started analytics event: offline",
+      "Unable to capture investigation created analytics event: offline",
     );
 
     consoleError.mockRestore();

--- a/packages/core/src/analytics.ts
+++ b/packages/core/src/analytics.ts
@@ -10,7 +10,7 @@ export interface AnalyticsEvent {
   event:
     | "agent created"
     | "integration connected"
-    | "investigation started"
+    | "investigation created"
     | "organization created"
     | "pr merged"
     | "pr opened"


### PR DESCRIPTION
## Summary
- emit an `investigation created` analytics event for newly accepted investigations
- track newly persisted replay investigations without double-counting retries
- document and test the event properties and exclusion behavior

## Validation
- `pnpm test`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emit an "investigation created" analytics event when an investigation (including replays) is persisted and accepted for processing, replacing the previous "investigation started" event. This measures creation without double-counting retries and does not affect queuing.

- Updates `packages/core` event type to `investigation created` and documents properties: `investigation_id`, `agent_id`, `agent_config_version_id`, `provider`, `is_replay`, and `source_investigation_id` (replays only); uses `distinctId=investigation:<id>` and `$process_person_profile=false`.
- Captures on creation in the control plane queue after billing passes; emits for replays only when `replay.created` is true; no capture when the monthly limit is hit, on investigation retries, or on replay retries.
- Required migration: update analytics queries/dashboards and any code referencing the old `investigation started` event to `investigation created`.

<sup>Written for commit 22ebf9ca2be31230278eafb51b3418a2329a2974. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/responder-oss/pull/45?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

