### PR TITLE
Improve workspace secret validation

### DIFF
--- a/apps/control-plane/e2e/workspace-onboarding.spec.ts
+++ b/apps/control-plane/e2e/workspace-onboarding.spec.ts
@@ -39,7 +39,9 @@ async function mockApplicationApis(page: Page) {
     route.fulfill({ json: { agents: [] } }),
   );
   await page.route("**/api/agents/options", (route) =>
-    route.fulfill({ json: { accounts: [], resources: [], repositories: [] } }),
+    route.fulfill({
+      json: { accounts: [], resources: [], repositories: [], secrets: [] },
+    }),
   );
   await page.route("**/api/integrations", (route) =>
     route.fulfill({ json: { integrations: [] } }),
@@ -102,6 +104,77 @@ test("opens agent creation after creating a workspace", async ({ page }) => {
 
   await expect(page).toHaveURL(/\/agents\/new$/);
   await expect(page.getByRole("heading", { name: "Create agent" })).toBeVisible();
+});
+
+test("shows specific workspace secret validation issues", async ({
+  page,
+}) => {
+  await page.addInitScript(() => {
+    window.sessionStorage.setItem("responder:new-agent-step", "3");
+  });
+  await page.route("**/api/auth/**", async (route) => {
+    const path = new URL(route.request().url()).pathname;
+
+    if (path.endsWith("/get-session")) {
+      await route.fulfill({ json: sessionResponse(organization.id) });
+      return;
+    }
+
+    if (path.endsWith("/organization/list")) {
+      await route.fulfill({ json: [organization] });
+      return;
+    }
+
+    if (path.endsWith("/organization/get-full-organization")) {
+      await route.fulfill({ json: organization });
+      return;
+    }
+
+    await route.fulfill({ json: null });
+  });
+  await page.route("**/api/agents/secrets", async (route) => {
+    expect(route.request().postDataJSON()).toEqual({
+      name: "PATH",
+      value: "write-only-value",
+      allowedHosts: ["https://api.example.com/path"],
+    });
+    await route.fulfill({
+      status: 400,
+      json: {
+        error: "Invalid workspace secret",
+        issues: [
+          {
+            code: "custom",
+            path: ["name"],
+            message:
+              "PATH controls the sandbox runtime; choose a credential-specific environment variable name",
+          },
+          {
+            code: "invalid_format",
+            path: ["allowedHosts", 0],
+            message: "Use a hostname without a scheme, path, or port",
+          },
+        ],
+      },
+    });
+  });
+
+  await page.goto("/agents/new");
+  await page.getByRole("button", { name: "Add secret" }).click();
+  const dialog = page.getByRole("dialog", {
+    name: "Add a workspace secret",
+  });
+  await dialog.getByLabel("Environment variable").fill("PATH");
+  await dialog.getByLabel("Secret value").fill("write-only-value");
+  await dialog
+    .getByLabel("Allowed hosts")
+    .fill("https://api.example.com/path");
+  await dialog.getByRole("button", { name: "Store and add" }).click();
+
+  await expect(dialog).toBeVisible();
+  await expect(dialog.getByRole("alert")).toHaveText(
+    "PATH controls the sandbox runtime; choose a credential-specific environment variable name. Use a hostname without a scheme, path, or port",
+  );
 });
 
 test("keeps an invitation link open while the recipient signs in", async ({

--- a/apps/control-plane/e2e/workspace-onboarding.spec.ts
+++ b/apps/control-plane/e2e/workspace-onboarding.spec.ts
@@ -38,7 +38,7 @@ async function mockApplicationApis(page: Page) {
   await page.route("**/api/agents", (route) =>
     route.fulfill({ json: { agents: [] } }),
   );
-  await page.route("**/api/agents/options", (route) =>
+  await page.route(/\/api\/agents\/options(?:\/refresh\/slack)?$/, (route) =>
     route.fulfill({
       json: { accounts: [], resources: [], repositories: [], secrets: [] },
     }),
@@ -109,9 +109,6 @@ test("opens agent creation after creating a workspace", async ({ page }) => {
 test("shows specific workspace secret validation issues", async ({
   page,
 }) => {
-  await page.addInitScript(() => {
-    window.sessionStorage.setItem("responder:new-agent-step", "3");
-  });
   await page.route("**/api/auth/**", async (route) => {
     const path = new URL(route.request().url()).pathname;
 
@@ -132,6 +129,30 @@ test("shows specific workspace secret validation issues", async ({
 
     await route.fulfill({ json: null });
   });
+  const agentOptions = {
+    accounts: [
+      {
+        id: "slack-account-1",
+        provider: "slack",
+        displayName: "Acme Slack",
+        slackContextAvailable: true,
+      },
+    ],
+    resources: [
+      {
+        id: "slack-channel-1",
+        integrationAccountId: "slack-account-1",
+        kind: "slack_channel",
+        externalId: "C123",
+        displayName: "incidents",
+      },
+    ],
+    repositories: [],
+    secrets: [],
+  };
+  await page.route(/\/api\/agents\/options(?:\/refresh\/slack)?$/, (route) =>
+    route.fulfill({ json: agentOptions }),
+  );
   await page.route("**/api/agents/secrets", async (route) => {
     expect(route.request().postDataJSON()).toEqual({
       name: "PATH",
@@ -160,6 +181,12 @@ test("shows specific workspace secret validation issues", async ({
   });
 
   await page.goto("/agents/new");
+  await page.getByText("Alert in a Slack channel", { exact: true }).click();
+  await page.getByRole("button", { name: "Continue" }).click();
+  await page.getByRole("button", { name: "Continue" }).click();
+  await expect(
+    page.getByRole("heading", { name: "Agent context" }),
+  ).toBeVisible();
   await page.getByRole("button", { name: "Add secret" }).click();
   const dialog = page.getByRole("dialog", {
     name: "Add a workspace secret",

--- a/apps/control-plane/server/agents/routes.test.ts
+++ b/apps/control-plane/server/agents/routes.test.ts
@@ -23,7 +23,7 @@ import {
   createDaytonaWorkspaceSecret,
   deleteDaytonaWorkspaceSecret,
 } from "./daytona-secrets.js";
-import { agentRoutes } from "./routes.js";
+import { agentRoutes, workspaceSecretInputSchema } from "./routes.js";
 
 vi.mock("../../../../packages/core/src/credentials/encryption.js", () => ({
   decryptCredentials: vi.fn(),
@@ -193,6 +193,19 @@ describe("workspace secrets", () => {
     expect(response.status).toBe(400);
     expect(createDaytonaWorkspaceSecret).not.toHaveBeenCalled();
   });
+
+  it.each(["DAYTONA_API_KEY", "OPENAI_API_KEY", "RESPONDER_API_KEY"])(
+    "allows the standard credential environment variable %s",
+    (name) => {
+      expect(
+        workspaceSecretInputSchema.safeParse({
+          name,
+          value: "never-store-this",
+          allowedHosts: ["api.example.com"],
+        }).success,
+      ).toBe(true);
+    },
+  );
 
   it("does not overwrite a workspace secret or send its new value", async () => {
     vi.mocked(getActiveTenant).mockResolvedValue(tenant);

--- a/apps/control-plane/server/agents/routes.ts
+++ b/apps/control-plane/server/agents/routes.ts
@@ -29,7 +29,7 @@ import {
   createWorkspaceSecretRecord,
   findWorkspaceSecretByName,
 } from "../../../../packages/core/src/db/workspace-secrets.js";
-import { isWorkspaceSecretEnvironmentVariableName } from "../../../../packages/core/src/workspace-secret-names.js";
+import { workspaceSecretEnvironmentVariableNameReservation } from "../../../../packages/core/src/workspace-secret-names.js";
 import type { InvestigationTraceEvent } from "../../../../packages/core/src/db/schema.js";
 import {
   joinSlackChannel,
@@ -73,10 +73,12 @@ export const workspaceSecretInputSchema = z.object({
       /^[A-Z_][A-Z0-9_]*$/,
       "Use an uppercase environment variable name",
     )
-    .refine(
-      isWorkspaceSecretEnvironmentVariableName,
-      "Choose a non-system environment variable name",
-    ),
+    .superRefine((name, context) => {
+      const reservation = workspaceSecretEnvironmentVariableNameReservation(name);
+      if (reservation) {
+        context.addIssue({ code: "custom", message: reservation });
+      }
+    }),
   value: z.string().min(1, "Secret value is required").max(65_536),
   allowedHosts: z
     .array(secretHostSchema)

--- a/apps/control-plane/src/agents-api.test.ts
+++ b/apps/control-plane/src/agents-api.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { apiErrorMessage } from "./agents-api";
+
+describe("API error messages", () => {
+  it("surfaces specific validation issues instead of the generic error", () => {
+    expect(
+      apiErrorMessage(
+        {
+          error: "Invalid workspace secret",
+          issues: [
+            { message: "Choose a non-system environment variable name" },
+            { message: "Use a hostname without a scheme, path, or port" },
+          ],
+        },
+        400,
+      ),
+    ).toBe(
+      "Choose a non-system environment variable name. Use a hostname without a scheme, path, or port",
+    );
+  });
+
+  it("falls back to the top-level API error", () => {
+    expect(apiErrorMessage({ error: "Agent not found" }, 404)).toBe(
+      "Agent not found",
+    );
+  });
+});

--- a/apps/control-plane/src/agents-api.ts
+++ b/apps/control-plane/src/agents-api.ts
@@ -341,13 +341,37 @@ export interface InvestigationDetailResponse {
   traceError: string | null;
 }
 
+export function apiErrorMessage(body: unknown, status: number): string {
+  if (body && typeof body === "object") {
+    const errorBody = body as Record<string, unknown>;
+    if (Array.isArray(errorBody.issues)) {
+      const issueMessages = [
+        ...new Set(
+          errorBody.issues.flatMap((issue) => {
+            if (!issue || typeof issue !== "object") return [];
+            const message = (issue as Record<string, unknown>).message;
+            return typeof message === "string" && message.trim()
+              ? [message.trim()]
+              : [];
+          }),
+        ),
+      ];
+      if (issueMessages.length > 0) return issueMessages.join(". ");
+    }
+
+    if (typeof errorBody.error === "string" && errorBody.error.trim()) {
+      return errorBody.error;
+    }
+  }
+
+  return `Request failed (${status})`;
+}
+
 async function apiJson<T>(url: string, init?: RequestInit): Promise<T> {
   const response = await fetch(url, init);
-  const body = (await response.json().catch(() => null)) as
-    | (T & { error?: string })
-    | null;
+  const body = (await response.json().catch(() => null)) as T | null;
   if (!response.ok) {
-    throw new Error(body?.error ?? `Request failed (${response.status})`);
+    throw new Error(apiErrorMessage(body, response.status));
   }
   return body as T;
 }

--- a/apps/worker/src/sandbox.test.ts
+++ b/apps/worker/src/sandbox.test.ts
@@ -105,7 +105,7 @@ describe("Daytona sandbox cleanup", () => {
       { daytonaApiKey: "daytona-test" },
       [
         {
-          environmentVariable: "SERVICE_API_KEY",
+          environmentVariable: "DAYTONA_API_KEY",
           daytonaSecretName: "responder_secret_1",
         },
       ],
@@ -113,7 +113,7 @@ describe("Daytona sandbox cleanup", () => {
     );
 
     expect(sandbox.updateSecrets).toHaveBeenCalledWith({
-      SERVICE_API_KEY: "responder_secret_1",
+      DAYTONA_API_KEY: "responder_secret_1",
     });
     expect(calls).toEqual(["update", "stop", "start", "auto-delete"]);
   });

--- a/packages/core/src/db/workspace-secrets.test.ts
+++ b/packages/core/src/db/workspace-secrets.test.ts
@@ -2,7 +2,10 @@ import { readFileSync } from "node:fs";
 import { getTableConfig } from "drizzle-orm/pg-core";
 import { describe, expect, it } from "vitest";
 import { workspaceSecrets } from "./schema.js";
-import { isWorkspaceSecretEnvironmentVariableName } from "../workspace-secret-names.js";
+import {
+  isWorkspaceSecretEnvironmentVariableName,
+  workspaceSecretEnvironmentVariableNameReservation,
+} from "../workspace-secret-names.js";
 
 describe("workspace secret storage", () => {
   it("stores only workspace-scoped Daytona metadata, never plaintext", () => {
@@ -57,9 +60,16 @@ describe("workspace secret storage", () => {
 
 describe("workspace secret environment variable names", () => {
   it("allows application credential names", () => {
-    expect(isWorkspaceSecretEnvironmentVariableName("SERVICE_API_KEY")).toBe(
-      true,
-    );
+    for (const name of [
+      "SERVICE_API_KEY",
+      "DAYTONA_API_KEY",
+      "OPENAI_API_KEY",
+      "RESPONDER_API_KEY",
+      "GIT_TOKEN",
+      "NPM_CONFIG_TOKEN",
+    ]) {
+      expect(isWorkspaceSecretEnvironmentVariableName(name)).toBe(true);
+    }
   });
 
   it.each([
@@ -72,8 +82,15 @@ describe("workspace secret environment variable names", () => {
     "PERL5OPT",
     "RUBYOPT",
     "DYLD_INSERT_LIBRARIES",
-    "OPENAI_API_KEY",
   ])("rejects runtime control variable %s", (name) => {
     expect(isWorkspaceSecretEnvironmentVariableName(name)).toBe(false);
+  });
+
+  it("explains reserved runtime controls", () => {
+    expect(
+      workspaceSecretEnvironmentVariableNameReservation("PATH"),
+    ).toBe(
+      "PATH controls the sandbox runtime; choose a credential-specific environment variable name",
+    );
   });
 });

--- a/packages/core/src/workspace-secret-names.ts
+++ b/packages/core/src/workspace-secret-names.ts
@@ -3,7 +3,23 @@ const workspaceSecretEnvironmentVariablePattern = /^[A-Z_][A-Z0-9_]*$/;
 const reservedWorkspaceSecretEnvironmentVariables = new Set([
   "ALL_PROXY",
   "BASH_ENV",
+  "DYLD_INSERT_LIBRARIES",
   "ENV",
+  "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+  "GIT_ASKPASS",
+  "GIT_COMMON_DIR",
+  "GIT_CONFIG_COUNT",
+  "GIT_CONFIG_GLOBAL",
+  "GIT_CONFIG_NOSYSTEM",
+  "GIT_CONFIG_PARAMETERS",
+  "GIT_CONFIG_SYSTEM",
+  "GIT_DIR",
+  "GIT_EXEC_PATH",
+  "GIT_INDEX_FILE",
+  "GIT_OBJECT_DIRECTORY",
+  "GIT_SSH",
+  "GIT_SSH_COMMAND",
+  "GIT_WORK_TREE",
   "HOME",
   "HTTP_PROXY",
   "HTTPS_PROXY",
@@ -39,15 +55,13 @@ const reservedWorkspaceSecretEnvironmentVariables = new Set([
   "_JAVA_OPTIONS",
 ]);
 
-const reservedWorkspaceSecretEnvironmentVariablePrefixes = [
-  "DAYTONA_",
-  "DYLD_",
-  "GIT_",
-  "NPM_CONFIG_",
-  "OPENAI_",
-  "PNPM_",
-  "RESPONDER_",
-];
+export function workspaceSecretEnvironmentVariableNameReservation(
+  name: string,
+): string | null {
+  return reservedWorkspaceSecretEnvironmentVariables.has(name)
+    ? `${name} controls the sandbox runtime; choose a credential-specific environment variable name`
+    : null;
+}
 
 export function isWorkspaceSecretEnvironmentVariableName(
   name: string,
@@ -55,9 +69,6 @@ export function isWorkspaceSecretEnvironmentVariableName(
   return (
     name.length <= 80 &&
     workspaceSecretEnvironmentVariablePattern.test(name) &&
-    !reservedWorkspaceSecretEnvironmentVariables.has(name) &&
-    !reservedWorkspaceSecretEnvironmentVariablePrefixes.some((prefix) =>
-      name.startsWith(prefix),
-    )
+    workspaceSecretEnvironmentVariableNameReservation(name) === null
   );
 }


### PR DESCRIPTION
## Summary

- surface field-level API validation details in the agent context secret dialog
- replace broad environment-variable prefix bans with an exact runtime-control denylist
- allow standard credential names such as `DAYTONA_API_KEY` and `OPENAI_API_KEY`
- cover validation rendering and Daytona secret mounting with regression tests

## Root cause

The client discarded structured validation issues and displayed only the generic top-level API error. Secret-name validation also treated entire provider namespaces as runtime controls, even though Daytona mounts vault secrets as opaque placeholders and the privileged worker environment is separate from the sandbox.

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test` (722 tests)
- `pnpm test:e2e` (5 tests)
- `pnpm build`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves workspace secret validation and error visibility. Previously, the UI showed a generic error and the server blocked broad env var prefixes; now the UI shows field-level issues in one alert and the server denies only exact runtime-control names. Standard credential names like DAYTONA_API_KEY, OPENAI_API_KEY, and RESPONDER_API_KEY are allowed.

- Validation: replace prefix bans with explicit reservations; `workspaceSecretInputSchema` uses `superRefine` with `workspaceSecretEnvironmentVariableNameReservation` to attach per-name messages (e.g., PATH gets guidance).
- Errors: client `apiErrorMessage` aggregates `issues[].message` and falls back to the top-level `error`; unit tests added.
- E2E: exercise validation through the agent setup flow; the dialog shows concatenated messages; `/api/agents/options` mocks include `secrets: []` and support `/refresh/slack`.
- Behavior/tests: worker tests use DAYTONA_API_KEY; tests assert allowed names and reservation messaging; server exports `workspaceSecretInputSchema`.
- Rollout: no data migration; existing secrets remain valid. Monitor agents that previously relied on prefix-based rejections.

<sup>Written for commit b752670b352a3b917757d1e3892e5c0a4320a651. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/responder-oss/pull/47?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

