### PR TITLE
Show copied prompts in Slack threads

### DIFF
--- a/apps/control-plane/server/webhooks/slack-actions.test.ts
+++ b/apps/control-plane/server/webhooks/slack-actions.test.ts
@@ -1,6 +1,6 @@
 import { createHmac } from "node:crypto";
 import { Hono } from "hono";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   captureAnalyticsEvent: vi.fn(),
@@ -45,12 +45,7 @@ function signedActionRequest(payload: unknown) {
 }
 
 describe("Slack actions", () => {
-  afterEach(() => {
-    vi.clearAllMocks();
-    vi.unstubAllEnvs();
-  });
-
-  it("shows an issue prompt in the thread containing the button", async () => {
+  beforeEach(() => {
     vi.stubEnv("SLACK_SIGNING_SECRET", "slack-signing-secret");
     mocks.getIssueForSlackAction.mockResolvedValue({
       id: "07070707-0707-4707-8707-070707070707",
@@ -65,7 +60,14 @@ describe("Slack actions", () => {
     mocks.decryptCredentials.mockReturnValue({ accessToken: "xoxb-test" });
     mocks.captureAnalyticsEvent.mockResolvedValue(undefined);
     mocks.postSlackEphemeralMessage.mockResolvedValue("1785500002.000300");
+  });
 
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  it("shows an issue prompt in the thread containing the button", async () => {
     const response = await signedActionRequest({
       type: "block_actions",
       team: { id: "T123" },
@@ -90,6 +92,34 @@ describe("Slack actions", () => {
         accessToken: "xoxb-test",
         channelId: "C123",
         threadTimestamp: "1785500000.000100",
+        userId: "U123",
+      }),
+    );
+  });
+
+  it("shows an issue prompt in the channel for a top-level button", async () => {
+    const response = await signedActionRequest({
+      type: "block_actions",
+      team: { id: "T123" },
+      channel: { id: "C123" },
+      user: { id: "U123" },
+      response_url: "https://hooks.slack.com/actions/T123/B123/response-token",
+      message: {},
+      actions: [
+        {
+          action_id: "copy_issue_prompt",
+          value: "07070707-0707-4707-8707-070707070707",
+        },
+      ],
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ ok: true });
+    expect(mocks.postSlackEphemeralMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accessToken: "xoxb-test",
+        channelId: "C123",
+        threadTimestamp: undefined,
         userId: "U123",
       }),
     );

--- a/apps/control-plane/server/webhooks/slack-actions.test.ts
+++ b/apps/control-plane/server/webhooks/slack-actions.test.ts
@@ -1,0 +1,97 @@
+import { createHmac } from "node:crypto";
+import { Hono } from "hono";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  captureAnalyticsEvent: vi.fn(),
+  decryptCredentials: vi.fn(),
+  getIssueForSlackAction: vi.fn(),
+  postSlackEphemeralMessage: vi.fn(),
+}));
+
+vi.mock("@responder/core/analytics", () => ({
+  captureAnalyticsEvent: mocks.captureAnalyticsEvent,
+}));
+vi.mock("../../../../packages/core/src/credentials/encryption.js", () => ({
+  decryptCredentials: mocks.decryptCredentials,
+}));
+vi.mock("../../../../packages/core/src/db/issues.js", () => ({
+  getIssueForSlackAction: mocks.getIssueForSlackAction,
+}));
+vi.mock("../../../../packages/core/src/integrations/slack.js", async (importOriginal) => ({
+  ...(await importOriginal()),
+  postSlackEphemeralMessage: mocks.postSlackEphemeralMessage,
+}));
+
+import { slackWebhookRoutes } from "./slack.js";
+
+const app = new Hono().route("/api/webhooks/slack", slackWebhookRoutes);
+
+function signedActionRequest(payload: unknown) {
+  const body = new URLSearchParams({ payload: JSON.stringify(payload) }).toString();
+  const timestamp = Math.floor(Date.now() / 1_000).toString();
+  const signature = `v0=${createHmac("sha256", "slack-signing-secret")
+    .update(`v0:${timestamp}:${body}`)
+    .digest("hex")}`;
+  return app.request("/api/webhooks/slack/actions", {
+    method: "POST",
+    body,
+    headers: {
+      "content-type": "application/x-www-form-urlencoded",
+      "x-slack-request-timestamp": timestamp,
+      "x-slack-signature": signature,
+    },
+  });
+}
+
+describe("Slack actions", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  it("shows an issue prompt in the thread containing the button", async () => {
+    vi.stubEnv("SLACK_SIGNING_SECRET", "slack-signing-secret");
+    mocks.getIssueForSlackAction.mockResolvedValue({
+      id: "07070707-0707-4707-8707-070707070707",
+      title: "Plant API returns HTTP 500",
+      description: "The plants endpoint is failing.",
+      severity: "SEV-2",
+      remediation: "Handle missing plant records.",
+      evidence: [],
+      organizationId: "03030303-0303-4303-8303-030303030303",
+      encryptedCredentials: "encrypted-slack-token",
+    });
+    mocks.decryptCredentials.mockReturnValue({ accessToken: "xoxb-test" });
+    mocks.captureAnalyticsEvent.mockResolvedValue(undefined);
+    mocks.postSlackEphemeralMessage.mockResolvedValue("1785500002.000300");
+
+    const response = await signedActionRequest({
+      type: "block_actions",
+      team: { id: "T123" },
+      channel: { id: "C123" },
+      user: { id: "U123" },
+      response_url: "https://hooks.slack.com/actions/T123/B123/response-token",
+      message: {
+        thread_ts: "1785500000.000100",
+      },
+      actions: [
+        {
+          action_id: "copy_issue_prompt",
+          value: "07070707-0707-4707-8707-070707070707",
+        },
+      ],
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ ok: true });
+    expect(mocks.postSlackEphemeralMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accessToken: "xoxb-test",
+        channelId: "C123",
+        threadTimestamp: "1785500000.000100",
+        userId: "U123",
+      }),
+    );
+  });
+});

--- a/apps/control-plane/server/webhooks/slack.ts
+++ b/apps/control-plane/server/webhooks/slack.ts
@@ -90,6 +90,7 @@ const slackBlockActionsSchema = z.object({
     .object({
       blocks: z.array(z.unknown()).optional(),
       text: z.string().optional(),
+      thread_ts: z.string().min(1).optional(),
     })
     .optional(),
   actions: z.array(
@@ -1001,6 +1002,7 @@ export const slackWebhookRoutes = new Hono().post("/", async (context) => {
         blocks: promptResponse.blocks,
         channelId: action.data.channel.id,
         text: promptResponse.text,
+        threadTimestamp: action.data.message?.thread_ts,
         userId: action.data.user.id,
       });
       return context.json({ ok: true });

--- a/packages/core/src/integrations/slack.test.ts
+++ b/packages/core/src/integrations/slack.test.ts
@@ -183,6 +183,7 @@ describe("Slack delivery client", () => {
       blocks: [{ type: "markdown", text: "```markdown\nFix it\n```" }],
       channelId: "C123",
       text: "Investigation prompt",
+      threadTimestamp: "1785500000.000100",
       userId: "U123",
     });
 
@@ -193,6 +194,7 @@ describe("Slack delivery client", () => {
           blocks: [{ type: "markdown", text: "```markdown\nFix it\n```" }],
           channel: "C123",
           text: "Investigation prompt",
+          thread_ts: "1785500000.000100",
           user: "U123",
         }),
       }),

--- a/packages/core/src/integrations/slack.ts
+++ b/packages/core/src/integrations/slack.ts
@@ -170,12 +170,14 @@ export async function postSlackEphemeralMessage(input: {
   blocks: unknown[];
   channelId: string;
   text: string;
+  threadTimestamp?: string;
   userId: string;
 }): Promise<string | null> {
   const response = await callSlackApi(input.accessToken, "chat.postEphemeral", {
     blocks: input.blocks,
     channel: input.channelId,
     text: input.text,
+    ...(input.threadTimestamp ? { thread_ts: input.threadTimestamp } : {}),
     user: input.userId,
   });
   return response.ts ?? null;


### PR DESCRIPTION
## Summary
- carry the parent thread timestamp from Slack button actions
- post ephemeral issue prompts in the thread containing the button
- preserve channel-level behavior for buttons outside threads

## Validation
- `pnpm test`
- `pnpm typecheck`
- `pnpm lint`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows copied issue prompts as ephemeral messages in the Slack thread where the button was clicked. Previously prompts posted at the channel level only; now we thread them when a parent thread exists and keep channel-level behavior when it does not.

- Parse optional `message.thread_ts` in Slack block action payload in `apps/control-plane` and pass it as `threadTimestamp` to `postSlackEphemeralMessage`.
- `packages/core` forwards `thread_ts` to Slack’s chat.postEphemeral only when provided.
- Add tests covering threaded and top-level actions (payload shape and request signing) in `apps/control-plane` and `packages/core`.

<sup>Written for commit 1417d8027b5fcde1d2ae65fc64c3d65203042093. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/responder-oss/pull/48?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

