### PR TITLE
Rebuild the issue page as a reading column

### DIFF
--- a/apps/control-plane/src/components/evidence-list.tsx
+++ b/apps/control-plane/src/components/evidence-list.tsx
@@ -1,4 +1,22 @@
 import type { IssueEvidence } from "../agents-api";
+import {
+  evidenceSourceGlyph,
+  evidenceSourceLabel,
+} from "../pages/issue-detail-presentation";
+import { ProviderGlyph, SignalIcon } from "./icons";
+
+export function EvidenceSourceGlyph({
+  source,
+}: {
+  source: IssueEvidence["source"];
+}) {
+  const provider = evidenceSourceGlyph(source);
+  return (
+    <span className={`evidenceGlyph evidenceGlyph--${source}`}>
+      {provider ? <ProviderGlyph decorative provider={provider} /> : <SignalIcon />}
+    </span>
+  );
+}
 
 export function EvidenceList({ evidence }: { evidence: IssueEvidence[] }) {
   if (evidence.length === 0) {
@@ -7,9 +25,9 @@ export function EvidenceList({ evidence }: { evidence: IssueEvidence[] }) {
   return (
     <ul className="evidenceList">
       {evidence.map((item, index) => (
-        <li className="shadow-xl" key={`${item.source}-${item.title}-${index}`}>
-          <span>{item.source}</span>
-          <div>
+        <li key={`${item.source}-${item.title}-${index}`}>
+          <EvidenceSourceGlyph source={item.source} />
+          <div className="evidenceItem__body">
             <strong>{item.title}</strong>
             <p>{item.detail}</p>
             {item.url ? (
@@ -23,6 +41,9 @@ export function EvidenceList({ evidence }: { evidence: IssueEvidence[] }) {
               </code>
             ) : null}
           </div>
+          <span className="evidenceItem__source">
+            {evidenceSourceLabel(item.source)}
+          </span>
         </li>
       ))}
     </ul>

--- a/apps/control-plane/src/components/icons.tsx
+++ b/apps/control-plane/src/components/icons.tsx
@@ -395,3 +395,96 @@ export function CogIcon(props: IconProps) {
     </svg>
   );
 }
+
+export function SeverityIcon({
+  filled = 3,
+  ...props
+}: IconProps & { filled?: number }) {
+  return (
+    <svg
+      aria-hidden="true"
+      fill="none"
+      height="12"
+      viewBox="0 0 16 16"
+      width="12"
+      {...props}
+    >
+      {[
+        { x: 2.4, y: 9.4, height: 4.2 },
+        { x: 6.6, y: 6.2, height: 7.4 },
+        { x: 10.8, y: 3, height: 10.6 },
+      ].map((bar, index) => (
+        <rect
+          fill="currentColor"
+          fillOpacity={index < filled ? 1 : 0.28}
+          height={bar.height}
+          key={bar.x}
+          rx="0.8"
+          width="2.8"
+          x={bar.x}
+          y={bar.y}
+        />
+      ))}
+    </svg>
+  );
+}
+
+export function StatusDotIcon(props: IconProps) {
+  return (
+    <svg
+      aria-hidden="true"
+      fill="none"
+      height="14"
+      viewBox="0 0 16 16"
+      width="14"
+      {...props}
+    >
+      <circle cx="8" cy="8" r="5.6" stroke="currentColor" strokeWidth="1.4" />
+      <path
+        d="M8 8V4.9"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeWidth="1.4"
+      />
+    </svg>
+  );
+}
+
+export function PullRequestIcon(props: IconProps) {
+  return (
+    <svg
+      aria-hidden="true"
+      fill="none"
+      height="14"
+      viewBox="0 0 16 16"
+      width="14"
+      {...props}
+    >
+      <circle cx="4.4" cy="4" r="1.9" stroke="currentColor" strokeWidth="1.4" />
+      <circle cx="4.4" cy="12" r="1.9" stroke="currentColor" strokeWidth="1.4" />
+      <circle cx="11.6" cy="6.2" r="1.9" stroke="currentColor" strokeWidth="1.4" />
+      <path
+        d="M4.4 5.9v4.2M11.6 8.1v.6c0 1.5-1.2 2.7-2.7 2.7H6.3"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeWidth="1.4"
+      />
+    </svg>
+  );
+}
+
+export function SignalIcon(props: IconProps) {
+  return (
+    <svg
+      aria-hidden="true"
+      fill="none"
+      height="12"
+      viewBox="0 0 16 16"
+      width="12"
+      {...props}
+    >
+      <circle cx="8" cy="8" r="5.5" stroke="currentColor" strokeWidth="1.3" />
+      <circle cx="8" cy="8" fill="currentColor" r="1.8" />
+    </svg>
+  );
+}

--- a/apps/control-plane/src/components/screen-skeletons.tsx
+++ b/apps/control-plane/src/components/screen-skeletons.tsx
@@ -128,39 +128,47 @@ export function AgentDetailSkeleton() {
 export function IssueDetailSkeleton() {
   return (
     <LoadingRegion className="screenSkeleton screenSkeleton--issue" label="Loading issue…">
-      <section className="issueDetailHeading screenSkeleton__detailHeading">
-        <div className="screenSkeleton__headingCopy">
-          <Skeleton className="screenSkeleton__back" style={{ width: "104px" }} />
-          <Skeleton className="screenSkeleton__badge" style={{ width: "54px" }} />
-          <Skeleton className="screenSkeleton__title" style={{ width: "min(560px, 72vw)" }} />
-          <Skeleton style={{ width: "210px" }} />
-        </div>
-        <div className="screenSkeleton__actions">
-          <Skeleton className="screenSkeleton__button screenSkeleton__button--small" />
-          <Skeleton className="screenSkeleton__button screenSkeleton__button--small" />
-        </div>
-      </section>
+      <div className="issueDetail">
+        <div className="issueDetail__main screenSkeleton__detailHeading">
+          <div className="issueHeader">
+            <Skeleton className="screenSkeleton__back" style={{ width: "72px" }} />
+            <Skeleton className="screenSkeleton__badge" style={{ width: "260px" }} />
+            <Skeleton className="screenSkeleton__title" style={{ width: "min(560px, 72vw)" }} />
+          </div>
 
-      <div className="issueDetailContent">
-        <section className="issueDefinition screenSkeleton__issueDefinition">
-          {["68%", "82%", "74%"].map((width, index) => (
-            <article className="issueDefinitionCard screenSkeleton__contentCard" key={index}>
-              <Skeleton className="screenSkeleton__cardTitle" style={{ width: index === 2 ? "82px" : "116px" }} />
-              <Skeleton style={{ width }} />
-              <Skeleton style={{ width: index === 2 ? "62%" : "92%" }} />
-              <Skeleton style={{ width: "48%" }} />
-            </article>
-          ))}
-        </section>
-        <section className="issueInvestigations screenSkeleton__linkedItems">
-          <Skeleton className="screenSkeleton__cardTitle" style={{ width: "112px" }} />
-          {Array.from({ length: 3 }, (_, index) => (
-            <div className="screenSkeleton__linkedRow" key={index}>
-              <Skeleton style={{ width: `${64 + index * 7}%` }} />
-              <Skeleton style={{ width: "46%" }} />
+          <div className="issueProse">
+            {["94%", "88%", "62%"].map((width) => (
+              <Skeleton key={width} style={{ width }} />
+            ))}
+          </div>
+
+          <div className="issueCallout">
+            <Skeleton className="screenSkeleton__cardTitle" style={{ width: "104px" }} />
+            <Skeleton style={{ width: "90%" }} />
+            <Skeleton style={{ width: "54%" }} />
+          </div>
+
+          {["82px", "112px"].map((titleWidth, section) => (
+            <div className="issueSection screenSkeleton__linkedItems" key={titleWidth}>
+              <Skeleton className="screenSkeleton__cardTitle" style={{ width: titleWidth }} />
+              {Array.from({ length: 3 }, (_, index) => (
+                <div className="screenSkeleton__linkedRow" key={index}>
+                  <Skeleton style={{ width: `${52 + ((index + section) % 3) * 12}%` }} />
+                </div>
+              ))}
             </div>
           ))}
-        </section>
+        </div>
+
+        <div className="issueRail">
+          <div className="issueRail__group">
+            {["68px", "128px", "104px", "96px"].map((width) => (
+              <div className="issueRail__row" key={width}>
+                <Skeleton style={{ width }} />
+              </div>
+            ))}
+          </div>
+        </div>
       </div>
     </LoadingRegion>
   );

--- a/apps/control-plane/src/components/screen-skeletons.tsx
+++ b/apps/control-plane/src/components/screen-skeletons.tsx
@@ -168,6 +168,13 @@ export function IssueDetailSkeleton() {
               </div>
             ))}
           </div>
+          {/* Copy prompt and Archive always render; Create pull request depends
+              on the repository, which is not known until the issue loads. */}
+          <div className="issueRail__actions">
+            {[0, 1].map((index) => (
+              <Skeleton className="screenSkeleton__railAction" key={index} />
+            ))}
+          </div>
         </div>
       </div>
     </LoadingRegion>

--- a/apps/control-plane/src/pages/issue-detail-presentation.test.ts
+++ b/apps/control-plane/src/pages/issue-detail-presentation.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { IssueDetailResponse, IssueEvidence } from "../agents-api";
 import {
   evidenceSourceGlyph,
+  rowStatusLabel,
   evidenceSourceLabel,
   investigationCountLabel,
   investigationStatusTone,
@@ -168,5 +169,20 @@ describe("issueParagraphs", () => {
 
   it("keeps single newlines inside a paragraph", () => {
     expect(issueParagraphs("One\ntwo")).toEqual(["One\ntwo"]);
+  });
+});
+
+describe("rowStatusLabel", () => {
+  it("names every investigation status", () => {
+    expect(rowStatusLabel("pending")).toBe("Pending");
+    expect(rowStatusLabel("investigating")).toBe("Investigating");
+    expect(rowStatusLabel("resolved")).toBe("Resolved");
+    expect(rowStatusLabel("failed")).toBe("Failed");
+  });
+
+  it("names every pull request and Linear ticket status", () => {
+    expect(rowStatusLabel("queued")).toBe("Queued");
+    expect(rowStatusLabel("creating")).toBe("Creating");
+    expect(rowStatusLabel("created")).toBe("Created");
   });
 });

--- a/apps/control-plane/src/pages/issue-detail-presentation.test.ts
+++ b/apps/control-plane/src/pages/issue-detail-presentation.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from "vitest";
+import type { IssueDetailResponse, IssueEvidence } from "../agents-api";
+import {
+  evidenceSourceGlyph,
+  evidenceSourceLabel,
+  investigationCountLabel,
+  investigationStatusTone,
+  issueIdentifiedAt,
+  issueParagraphs,
+  issueRowDate,
+  originatingAgentName,
+  primaryEvidenceSource,
+  relationshipLabel,
+} from "./issue-detail-presentation";
+
+type Investigation = IssueDetailResponse["investigations"][number];
+
+function evidence(source: IssueEvidence["source"]): IssueEvidence {
+  return { source, title: "title", detail: "detail" };
+}
+
+function investigation(overrides: Partial<Investigation>): Investigation {
+  return {
+    id: "investigation-1",
+    agentId: "agent-1",
+    agentName: "Payments",
+    title: "Investigation",
+    status: "resolved",
+    relationship: "recurrence",
+    evidence: [],
+    createdAt: "2026-05-20T01:25:00.000Z",
+    completedAt: null,
+    ...overrides,
+  };
+}
+
+describe("issueIdentifiedAt", () => {
+  it("joins the day and the time of day", () => {
+    expect(issueIdentifiedAt("2026-05-20T13:25:00.000Z", "en-US")).toMatch(
+      /^May \d{1,2}, 2026 · \d{1,2}:\d{2}\s?(AM|PM)$/,
+    );
+  });
+
+  it("falls back to a dash when the issue has no timestamp", () => {
+    expect(issueIdentifiedAt(null)).toBe("—");
+  });
+});
+
+describe("issueRowDate", () => {
+  it("drops the year so linked rows stay in their column", () => {
+    expect(issueRowDate("2026-05-20T13:25:00.000Z", "en-US")).toBe("May 20");
+  });
+});
+
+describe("investigationCountLabel", () => {
+  it("reads naturally for none, one, and many", () => {
+    expect(investigationCountLabel(0)).toBe("No linked investigations");
+    expect(investigationCountLabel(1)).toBe("Seen in 1 investigation");
+    expect(investigationCountLabel(4)).toBe("Seen in 4 investigations");
+  });
+});
+
+describe("relationshipLabel", () => {
+  it("names the first sighting and later ones", () => {
+    expect(relationshipLabel("new")).toBe("First identified");
+    expect(relationshipLabel("recurrence")).toBe("Recurrence");
+  });
+});
+
+describe("investigationStatusTone", () => {
+  it("maps every investigation status to a dot colour", () => {
+    expect(investigationStatusTone("pending")).toBe("pending");
+    expect(investigationStatusTone("investigating")).toBe("active");
+    expect(investigationStatusTone("resolved")).toBe("resolved");
+    expect(investigationStatusTone("failed")).toBe("failed");
+  });
+});
+
+describe("evidenceSourceLabel", () => {
+  it("uses the product names people recognise", () => {
+    expect(evidenceSourceLabel("sentry")).toBe("Sentry");
+    expect(evidenceSourceLabel("github")).toBe("GitHub");
+    expect(evidenceSourceLabel("vercel")).toBe("Vercel");
+  });
+
+  it("shortens the names that would crowd the column", () => {
+    expect(evidenceSourceLabel("clickstack")).toBe("ClickStack");
+  });
+
+  it("names the sources that have no provider behind them", () => {
+    expect(evidenceSourceLabel("alert")).toBe("Alert");
+    expect(evidenceSourceLabel("other")).toBe("Other");
+  });
+});
+
+describe("evidenceSourceGlyph", () => {
+  it("uses the provider logo when the source is a provider", () => {
+    expect(evidenceSourceGlyph("sentry")).toBe("sentry");
+    expect(evidenceSourceGlyph("aws")).toBe("aws");
+    expect(evidenceSourceGlyph("langfuse")).toBe("langfuse");
+  });
+
+  it("has no logo for sources that are not providers", () => {
+    expect(evidenceSourceGlyph("alert")).toBeNull();
+    expect(evidenceSourceGlyph("other")).toBeNull();
+  });
+});
+
+describe("primaryEvidenceSource", () => {
+  it("returns nothing when there is no evidence", () => {
+    expect(primaryEvidenceSource([])).toBeNull();
+  });
+
+  it("picks the source that appears most often", () => {
+    expect(
+      primaryEvidenceSource([
+        evidence("github"),
+        evidence("sentry"),
+        evidence("sentry"),
+      ]),
+    ).toBe("sentry");
+  });
+
+  it("keeps the first source on a tie", () => {
+    expect(
+      primaryEvidenceSource([evidence("datadog"), evidence("sentry")]),
+    ).toBe("datadog");
+  });
+});
+
+describe("originatingAgentName", () => {
+  it("returns nothing without investigations", () => {
+    expect(originatingAgentName([])).toBeNull();
+  });
+
+  it("prefers the investigation that first identified the issue", () => {
+    expect(
+      originatingAgentName([
+        investigation({ agentName: "Checkout web" }),
+        investigation({ agentName: "Payments", relationship: "new" }),
+      ]),
+    ).toBe("Payments");
+  });
+
+  it("falls back to the earliest investigation", () => {
+    expect(
+      originatingAgentName([
+        investigation({
+          agentName: "Checkout web",
+          createdAt: "2026-05-22T00:00:00.000Z",
+        }),
+        investigation({
+          agentName: "Ingest pipeline",
+          createdAt: "2026-05-20T00:00:00.000Z",
+        }),
+      ]),
+    ).toBe("Ingest pipeline");
+  });
+});
+
+describe("issueParagraphs", () => {
+  it("splits on blank lines and trims the leftovers", () => {
+    expect(issueParagraphs("First line.\n\n  Second line.  \n\n\n")).toEqual([
+      "First line.",
+      "Second line.",
+    ]);
+  });
+
+  it("keeps single newlines inside a paragraph", () => {
+    expect(issueParagraphs("One\ntwo")).toEqual(["One\ntwo"]);
+  });
+});

--- a/apps/control-plane/src/pages/issue-detail-presentation.ts
+++ b/apps/control-plane/src/pages/issue-detail-presentation.ts
@@ -1,0 +1,108 @@
+import type { IssueDetailResponse, IssueEvidence } from "../agents-api";
+import {
+  providerDisplayName,
+  providerGlyphs,
+  type ProviderGlyphId,
+} from "../components/provider-glyphs";
+
+type Investigation = IssueDetailResponse["investigations"][number];
+type EvidenceSource = IssueEvidence["source"];
+
+/** Labels that read better here than the shared provider name. */
+const evidenceSourceLabelOverrides: Partial<Record<EvidenceSource, string>> = {
+  alert: "Alert",
+  clickstack: "ClickStack",
+  other: "Other",
+};
+
+/** "May 20, 2026 · 1:25 AM" — the identified-at stamp under the title. */
+export function issueIdentifiedAt(value: string | null, locale?: string): string {
+  if (!value) return "—";
+  const date = new Date(value);
+  const day = new Intl.DateTimeFormat(locale, { dateStyle: "medium" }).format(date);
+  const time = new Intl.DateTimeFormat(locale, { timeStyle: "short" }).format(date);
+  return `${day} · ${time}`;
+}
+
+/** "May 20" — the trailing date on a linked row. */
+export function issueRowDate(value: string, locale?: string): string {
+  return new Intl.DateTimeFormat(locale, {
+    day: "numeric",
+    month: "short",
+  }).format(new Date(value));
+}
+
+export function investigationCountLabel(count: number): string {
+  if (count === 0) return "No linked investigations";
+  if (count === 1) return "Seen in 1 investigation";
+  return `Seen in ${count} investigations`;
+}
+
+export function relationshipLabel(
+  relationship: Investigation["relationship"],
+): string {
+  return relationship === "new" ? "First identified" : "Recurrence";
+}
+
+/** Drives the colour of the status dot on an investigation row. */
+export function investigationStatusTone(
+  status: Investigation["status"],
+): "pending" | "active" | "resolved" | "failed" {
+  if (status === "resolved") return "resolved";
+  if (status === "failed") return "failed";
+  if (status === "investigating") return "active";
+  return "pending";
+}
+
+export function evidenceSourceGlyph(
+  source: EvidenceSource,
+): ProviderGlyphId | null {
+  return source in providerGlyphs ? (source as ProviderGlyphId) : null;
+}
+
+export function evidenceSourceLabel(source: EvidenceSource): string {
+  return evidenceSourceLabelOverrides[source] ?? providerDisplayName(source);
+}
+
+/**
+ * The source that carries the issue, used for the Source property. Picks the
+ * most common one and falls back to the first on a tie so the value is stable.
+ */
+export function primaryEvidenceSource(
+  evidence: IssueEvidence[],
+): EvidenceSource | null {
+  if (evidence.length === 0) return null;
+  const counts = new Map<EvidenceSource, number>();
+  for (const item of evidence) {
+    counts.set(item.source, (counts.get(item.source) ?? 0) + 1);
+  }
+  let best = evidence[0].source;
+  for (const item of evidence) {
+    if ((counts.get(item.source) ?? 0) > (counts.get(best) ?? 0)) {
+      best = item.source;
+    }
+  }
+  return best;
+}
+
+/** The agent that first identified the issue, used for the Agent property. */
+export function originatingAgentName(
+  investigations: Investigation[],
+): string | null {
+  if (investigations.length === 0) return null;
+  const first =
+    investigations.find((investigation) => investigation.relationship === "new") ??
+    [...investigations].sort(
+      (left, right) =>
+        new Date(left.createdAt).getTime() - new Date(right.createdAt).getTime(),
+    )[0];
+  return first?.agentName ?? null;
+}
+
+/** Splits a stored description into the paragraphs the layout renders. */
+export function issueParagraphs(description: string): string[] {
+  return description
+    .split(/\n\s*\n/)
+    .map((paragraph) => paragraph.trim())
+    .filter((paragraph) => paragraph.length > 0);
+}

--- a/apps/control-plane/src/pages/issue-detail-presentation.ts
+++ b/apps/control-plane/src/pages/issue-detail-presentation.ts
@@ -7,6 +7,10 @@ import {
 
 type Investigation = IssueDetailResponse["investigations"][number];
 type EvidenceSource = IssueEvidence["source"];
+type RowStatus =
+  | Investigation["status"]
+  | IssueDetailResponse["pullRequestState"]["requests"][number]["status"]
+  | IssueDetailResponse["linearTicketState"]["requests"][number]["status"];
 
 /** Labels that read better here than the shared provider name. */
 const evidenceSourceLabelOverrides: Partial<Record<EvidenceSource, string>> = {
@@ -52,6 +56,14 @@ export function investigationStatusTone(
   if (status === "failed") return "failed";
   if (status === "investigating") return "active";
   return "pending";
+}
+
+/**
+ * The accessible name of a row's status dot. Colour alone carries the status
+ * visually, so the dot needs a label for anyone who cannot see it.
+ */
+export function rowStatusLabel(status: RowStatus): string {
+  return `${status.charAt(0).toUpperCase()}${status.slice(1)}`;
 }
 
 export function evidenceSourceGlyph(

--- a/apps/control-plane/src/pages/issue-detail.tsx
+++ b/apps/control-plane/src/pages/issue-detail.tsx
@@ -8,18 +8,37 @@ import {
   type IssueDetailResponse,
 } from "../agents-api";
 import { AppShell } from "../components/app-shell";
-import { EvidenceList } from "../components/evidence-list";
-import { ArrowIcon } from "../components/icons";
+import { EvidenceList, EvidenceSourceGlyph } from "../components/evidence-list";
+import {
+  ArrowIcon,
+  ProviderGlyph,
+  PullRequestIcon,
+  SeverityIcon,
+  StatusDotIcon,
+} from "../components/icons";
 import { IssueDetailSkeleton } from "../components/screen-skeletons";
 import { copyToClipboard } from "../copy-to-clipboard";
 import { Button } from "../design-system";
 import { useDocumentTitle } from "../use-document-title";
+import {
+  evidenceSourceLabel,
+  investigationCountLabel,
+  investigationStatusTone,
+  issueIdentifiedAt,
+  issueParagraphs,
+  issueRowDate,
+  originatingAgentName,
+  primaryEvidenceSource,
+  relationshipLabel,
+} from "./issue-detail-presentation";
+
+const severityBars = { "SEV-1": 3, "SEV-2": 2, "SEV-3": 1 } as const;
 
 function formatDate(value: string | null): string {
   if (!value) return "—";
   return new Intl.DateTimeFormat(undefined, {
     dateStyle: "medium",
-    timeStyle: "medium",
+    timeStyle: "short",
   }).format(new Date(value));
 }
 
@@ -61,8 +80,7 @@ export function IssueDetailPage() {
     ) ?? false;
   const hasActiveLinearTicket =
     detail?.linearTicketState.requests.some((request) =>
-      request.status === "pending" ||
-      request.status === "creating",
+      request.status === "pending" || request.status === "creating",
     ) ?? false;
 
   useEffect(() => {
@@ -102,6 +120,10 @@ export function IssueDetailPage() {
   }
 
   const { issue, investigations } = detail;
+  const pullRequests = detail.pullRequestState.requests;
+  const linearTickets = detail.linearTicketState.requests;
+  const agentName = originatingAgentName(investigations);
+  const source = primaryEvidenceSource(issue.evidence);
 
   async function toggleArchived() {
     if (!issueId || archivePending) return;
@@ -157,190 +179,218 @@ export function IssueDetailPage() {
 
   return (
     <AppShell active="issues" density="compact">
-      <section className="issueDetailHeading">
-        <div>
-          <Link className="backLink" to="/issues">
-            ← Back to issues
-          </Link>
-          <div className="issueTitleStack">
-            <div className="issueTitleBadges">
+      <div className="issueDetail">
+        <div className="issueDetail__main">
+          <header className="issueHeader">
+            <Link className="issueHeader__back" to="/issues">
+              ← Issues
+            </Link>
+            <div className="issueHeader__meta">
               <span className="issueSeverityBadge">{issue.severity}</span>
               {issue.archivedAt ? (
                 <span className="archivedBadge">Archived</span>
               ) : null}
+              <span>Identified {issueIdentifiedAt(issue.createdAt)}</span>
+              <span aria-hidden="true" className="issueHeader__separator">
+                ·
+              </span>
+              <span>{investigationCountLabel(investigations.length)}</span>
             </div>
-            <div className="issueTitleBlock">
-              <h1>{issue.title}</h1>
-              <p>
-                Identified {formatDate(issue.createdAt)}
-                {issue.archivedAt
-                  ? ` · Archived ${formatDate(issue.archivedAt)}`
-                  : ""}
-              </p>
-            </div>
+            <h1>{issue.title}</h1>
+          </header>
+
+          {error ? <p className="formError">{error}</p> : null}
+
+          <div className="issueProse">
+            {issueParagraphs(issue.description).map((paragraph, index) => (
+              <p key={index}>{paragraph}</p>
+            ))}
           </div>
-        </div>
-        <div className="buttonGroup">
-          <Button
-            aria-live="polite"
-            onClick={() => void copyPrompt()}
-            size="small"
-            variant="secondary"
-          >
-            {promptCopied ? "Copied" : "Copy prompt"}
-          </Button>
-          <Button
-            disabled={archivePending}
-            loading={archivePending}
-            onClick={() => void toggleArchived()}
-            size="small"
-            variant={issue.archivedAt ? "secondary" : "danger"}
-          >
-            {archivePending
-              ? "Saving…"
-              : issue.archivedAt
-                ? "Unarchive"
-                : "Archive"}
-          </Button>
-          {detail.pullRequestState.canCreate ? (
-            <Button
-              loading={pullRequestPending}
-              onClick={() => void createPullRequest()}
-              size="small"
-              variant="primary"
-            >
-              {pullRequestPending ? "Starting…" : "Create pull request"}
-            </Button>
-          ) : null}
-        </div>
-      </section>
 
-      {error ? <p className="formError">{error}</p> : null}
-
-      <div className="issueDetailContent">
-        <section className="issueDefinition">
-          <article className="issueDefinitionCard">
-            <h2>Description</h2>
-            <p>{issue.description}</p>
-          </article>
-          <article className="issueDefinitionCard">
+          <section className="issueCallout">
             <h2>Remediation</h2>
             <p>{issue.remediation}</p>
-          </article>
-          <article className="issueDefinitionCard issueDefinitionCard--evidence">
-            <h2>Evidence</h2>
-            <EvidenceList evidence={issue.evidence} />
-          </article>
-        </section>
+          </section>
 
-        <section className="issueInvestigations">
-          <header>
-            <h2>Investigations</h2>
-          </header>
-          {investigations.length === 0 ? (
-            <p className="inlineEmpty">No linked investigations.</p>
-          ) : (
-            <div className="issueInvestigationList">
-              {investigations.map((investigation) => (
+          <section className="issueSection">
+            <h2 className="issueSection__title">Evidence</h2>
+            <EvidenceList evidence={issue.evidence} />
+          </section>
+
+          <section className="issueSection">
+            <h2 className="issueSection__title">Investigations</h2>
+            {investigations.length === 0 ? (
+              <p className="inlineEmpty">No linked investigations.</p>
+            ) : (
+              investigations.map((investigation) => (
                 <Link
-                  className="issueInvestigationRow shadow-xl"
+                  className="issueLine"
                   key={investigation.id}
                   to={`/agents/${investigation.agentId}/investigations/${investigation.id}`}
                 >
-                  <span>
-                    <strong>{investigation.title}</strong>
-                    <small>
-                      {investigation.agentName} ·{" "}
-                      {investigation.relationship === "new"
-                        ? "First identified"
-                        : "Recurrence"}{" "}
-                      · {formatDate(investigation.createdAt)}
-                    </small>
+                  <span
+                    className={`issueLine__status issueLine__status--${investigationStatusTone(investigation.status)}`}
+                  >
+                    <StatusDotIcon />
                   </span>
-                  <span className="issueRow__arrow">
+                  <span className="issueLine__title">{investigation.title}</span>
+                  <span className="issueLine__note">
+                    {relationshipLabel(investigation.relationship)}
+                  </span>
+                  <span className="issueLine__spacer" />
+                  <span className="issueLine__date">
+                    {issueRowDate(investigation.createdAt)}
+                  </span>
+                  <span className="issueLine__chevron">
                     <ArrowIcon />
                   </span>
                 </Link>
+              ))
+            )}
+          </section>
+
+          {pullRequests.length > 0 ? (
+            <section className="issueSection">
+              <h2 className="issueSection__title">Pull requests</h2>
+              {pullRequests.map((request) => (
+                <div className="issueLine issueLine--stacked" key={request.id}>
+                  <span
+                    className={`issueLine__status issueLine__status--${
+                      request.status === "created"
+                        ? "resolved"
+                        : request.status === "failed"
+                          ? "failed"
+                          : "pending"
+                    }`}
+                  >
+                    <PullRequestIcon />
+                  </span>
+                  <span className="issueLine__body">
+                    <strong>
+                      {request.status === "created"
+                        ? `#${request.pullRequestNumber} in ${request.repositoryFullName}`
+                        : request.status === "failed"
+                          ? "Pull request failed"
+                          : "Creating pull request…"}
+                    </strong>
+                    <small>
+                      {request.failureReason ?? formatDate(request.createdAt)}
+                    </small>
+                  </span>
+                  {request.pullRequestUrl ? (
+                    <a
+                      className="issueLine__action"
+                      href={request.pullRequestUrl}
+                      rel="noreferrer"
+                      target="_blank"
+                    >
+                      Open pull request
+                    </a>
+                  ) : null}
+                </div>
               ))}
-            </div>
-          )}
-          {detail.pullRequestState.requests.length > 0 ? (
-            <div className="issuePullRequests">
-              <header>
-                <h2>Pull requests</h2>
-              </header>
-              <div className="issueInvestigationList">
-                {detail.pullRequestState.requests.map((request) => (
-                  <div
-                    className="issueInvestigationRow shadow-xl"
-                    key={request.id}
-                  >
-                    <span>
-                      <strong>
-                        {request.status === "created"
-                          ? `#${request.pullRequestNumber} in ${request.repositoryFullName}`
-                          : request.status === "failed"
-                            ? "Pull request failed"
-                            : "Creating pull request…"}
-                      </strong>
-                      <small>
-                        {request.failureReason ?? formatDate(request.createdAt)}
-                      </small>
-                    </span>
-                    {request.pullRequestUrl ? (
-                      <a
-                        className="button button--secondary button--small"
-                        href={request.pullRequestUrl}
-                        rel="noreferrer"
-                        target="_blank"
-                      >
-                        Open pull request
-                      </a>
-                    ) : null}
-                  </div>
-                ))}
-              </div>
-            </div>
+            </section>
           ) : null}
-          {detail.linearTicketState.requests.length > 0 ? (
-            <div className="issuePullRequests">
-              <header>
-                <h2>Linear tickets</h2>
-              </header>
-              <div className="issueInvestigationList">
-                {detail.linearTicketState.requests.map((request) => (
-                  <div
-                    className="issueInvestigationRow shadow-xl"
-                    key={request.id}
+
+          {linearTickets.length > 0 ? (
+            <section className="issueSection">
+              <h2 className="issueSection__title">Linear tickets</h2>
+              {linearTickets.map((request) => (
+                <div className="issueLine issueLine--stacked" key={request.id}>
+                  <span
+                    className={`issueLine__status${
+                      request.status === "failed"
+                        ? " issueLine__status--failed"
+                        : ""
+                    }`}
                   >
-                    <span>
-                      <strong>
-                        {request.status === "created"
-                          ? request.linearIdentifier ?? request.linearIssueId
-                          : request.status === "failed"
-                            ? "Linear ticket failed"
-                            : "Creating Linear ticket…"}
-                      </strong>
-                      <small>
-                        {request.failureReason ?? formatDate(request.createdAt)}
-                      </small>
-                    </span>
-                    {request.linearIssueUrl ? (
-                      <a
-                        className="button button--secondary button--small"
-                        href={request.linearIssueUrl}
-                        rel="noreferrer"
-                        target="_blank"
-                      >
-                        Open Linear ticket
-                      </a>
-                    ) : null}
-                  </div>
-                ))}
-              </div>
-            </div>
+                    <ProviderGlyph decorative provider="linear" />
+                  </span>
+                  <span className="issueLine__body">
+                    <strong>
+                      {request.status === "created"
+                        ? (request.linearIdentifier ?? request.linearIssueId)
+                        : request.status === "failed"
+                          ? "Linear ticket failed"
+                          : "Creating Linear ticket…"}
+                    </strong>
+                    <small>
+                      {request.failureReason ?? formatDate(request.createdAt)}
+                    </small>
+                  </span>
+                  {request.linearIssueUrl ? (
+                    <a
+                      className="issueLine__action"
+                      href={request.linearIssueUrl}
+                      rel="noreferrer"
+                      target="_blank"
+                    >
+                      Open Linear ticket
+                    </a>
+                  ) : null}
+                </div>
+              ))}
+            </section>
           ) : null}
-        </section>
+        </div>
+
+        <aside className="issueRail">
+          <div className="issueRail__group">
+            <h2 className="issueRail__title">Properties</h2>
+            <div className="issueRail__row">
+              <span className="issueRail__label">Severity</span>
+              <span className="issueRail__icon issueRail__icon--severity">
+                <SeverityIcon filled={severityBars[issue.severity]} />
+              </span>
+              <span className="issueRail__value">{issue.severity}</span>
+            </div>
+            <div className="issueRail__row">
+              <span className="issueRail__label">Agent</span>
+              <span className="issueRail__value">{agentName ?? "—"}</span>
+            </div>
+            <div className="issueRail__row">
+              <span className="issueRail__label">Source</span>
+              {source ? <EvidenceSourceGlyph source={source} /> : null}
+              <span className="issueRail__value">
+                {source ? evidenceSourceLabel(source) : "—"}
+              </span>
+            </div>
+          </div>
+
+          <div className="issueRail__actions">
+            {detail.pullRequestState.canCreate ? (
+              <Button
+                loading={pullRequestPending}
+                onClick={() => void createPullRequest()}
+                size="small"
+                variant="primary"
+              >
+                {pullRequestPending ? "Starting…" : "Create pull request"}
+              </Button>
+            ) : null}
+            <Button
+              aria-live="polite"
+              onClick={() => void copyPrompt()}
+              size="small"
+              variant="secondary"
+            >
+              {promptCopied ? "Copied" : "Copy prompt"}
+            </Button>
+            <Button
+              disabled={archivePending}
+              loading={archivePending}
+              onClick={() => void toggleArchived()}
+              size="small"
+              variant={issue.archivedAt ? "secondary" : "danger"}
+            >
+              {archivePending
+                ? "Saving…"
+                : issue.archivedAt
+                  ? "Unarchive"
+                  : "Archive"}
+            </Button>
+          </div>
+        </aside>
       </div>
     </AppShell>
   );

--- a/apps/control-plane/src/pages/issue-detail.tsx
+++ b/apps/control-plane/src/pages/issue-detail.tsx
@@ -30,6 +30,7 @@ import {
   originatingAgentName,
   primaryEvidenceSource,
   relationshipLabel,
+  rowStatusLabel,
 } from "./issue-detail-presentation";
 
 const severityBars = { "SEV-1": 3, "SEV-2": 2, "SEV-3": 1 } as const;
@@ -229,7 +230,9 @@ export function IssueDetailPage() {
                   to={`/agents/${investigation.agentId}/investigations/${investigation.id}`}
                 >
                   <span
+                    aria-label={rowStatusLabel(investigation.status)}
                     className={`issueLine__status issueLine__status--${investigationStatusTone(investigation.status)}`}
+                    role="img"
                   >
                     <StatusDotIcon />
                   </span>
@@ -255,6 +258,7 @@ export function IssueDetailPage() {
               {pullRequests.map((request) => (
                 <div className="issueLine issueLine--stacked" key={request.id}>
                   <span
+                    aria-label={rowStatusLabel(request.status)}
                     className={`issueLine__status issueLine__status--${
                       request.status === "created"
                         ? "resolved"
@@ -262,6 +266,7 @@ export function IssueDetailPage() {
                           ? "failed"
                           : "pending"
                     }`}
+                    role="img"
                   >
                     <PullRequestIcon />
                   </span>
@@ -298,11 +303,13 @@ export function IssueDetailPage() {
               {linearTickets.map((request) => (
                 <div className="issueLine issueLine--stacked" key={request.id}>
                   <span
+                    aria-label={rowStatusLabel(request.status)}
                     className={`issueLine__status${
                       request.status === "failed"
                         ? " issueLine__status--failed"
                         : ""
                     }`}
+                    role="img"
                   >
                     <ProviderGlyph decorative provider="linear" />
                   </span>

--- a/apps/control-plane/src/styles.css
+++ b/apps/control-plane/src/styles.css
@@ -3527,26 +3527,18 @@ button:disabled {
   margin-bottom: 5px;
 }
 
-.screenSkeleton__linkedItems {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-}
-
 .screenSkeleton__linkedItems > .screenSkeleton__cardTitle {
-  margin-bottom: 12px;
+  margin-bottom: 4px;
 }
 
 .screenSkeleton__linkedRow {
-  min-height: 72px;
-  padding: 14px;
+  min-height: 44px;
+  padding: 0 10px;
   display: flex;
   flex-direction: column;
   justify-content: center;
   gap: 9px;
-  border: 1px solid var(--ds-border-default);
-  border-radius: var(--ds-radius-medium);
-  background: var(--ds-surface-raised);
+  border-radius: 6px;
 }
 
 .screenSkeleton--investigation > div[aria-hidden="true"] {
@@ -6483,212 +6475,478 @@ body:has(.appShell--create) {
   color: var(--dim);
 }
 
-.issueDetailHeading {
-  min-height: 152px;
-  padding: 8px 0 28px;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 24px;
-}
-
-.issueDetailHeading > div {
-  min-width: 0;
-}
-
-.issueDetailHeading h1 {
-  max-width: 900px;
-  margin: 0;
-  font-size: 33px;
-  font-weight: 500;
-  line-height: 45px;
-  letter-spacing: normal;
-}
-
-.issueTitleBlock {
-  min-width: 0;
-  display: flex;
-  flex-direction: column;
-}
-
-.issueTitleStack {
-  min-width: 0;
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 8px;
-}
-
-.issueTitleBadges {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.issueDetailHeading p {
-  margin: 6px 0 0;
-  color: var(--ds-text-muted);
-  font-size: 10px;
-  line-height: 16px;
-}
-
-.issueSeverityBadge {
-  padding: 3px 8px;
-  border: 1px solid #514525;
-  border-radius: var(--ds-radius-pill);
-  background: #1b170c;
-  color: var(--ds-warning);
-  font-size: 11px;
-  font-weight: 500;
-  line-height: 16px;
-  letter-spacing: 0.04em;
-}
-
-.issueDetailContent {
-  display: grid;
-  align-items: start;
-  grid-template-columns: minmax(0, 800px) minmax(360px, 1fr);
-  gap: 24px;
-}
-
-.issueDefinition {
-  min-width: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-}
-
-.issueDefinitionCard {
-  padding: 28px;
-  border-radius: var(--ds-radius-large);
-  background: var(--ds-surface-base);
-}
-
-.issueDefinitionCard h2,
-.investigationIssue__remediation > span {
-  margin: 0 0 8px;
-  color: var(--ds-text-primary);
-  font-size: 16px;
-  font-weight: 500;
-  line-height: 24px;
-  letter-spacing: -0.012em;
-}
-
-.issueDefinitionCard > p {
-  max-width: 720px;
-  margin: 0;
-  color: var(--ds-text-secondary);
-  font-size: 14px;
-  line-height: 20px;
-  white-space: pre-wrap;
-}
-
-.issueInvestigations {
-  min-width: 0;
-  padding: 28px;
-  border-radius: var(--ds-radius-large);
-  background: var(--ds-surface-base);
-}
-
-.issueInvestigations > header {
-  min-height: 40px;
+.issueDetail {
+  --issueText: #f7f8f8;
+  --issueBody: #c7c9ce;
+  --issueMuted: #8a8f98;
+  --issueDim: #62666d;
+  --issueFaint: #3e4045;
+  --issueHairline: #212224;
+  --issueRailValue: #e8e9eb;
+  padding-top: 18px;
   display: flex;
   align-items: flex-start;
+  gap: 0;
 }
 
-.issuePullRequests {
-  margin-top: 24px;
-}
-
-.issuePullRequests > header {
-  min-height: 40px;
+.issueDetail__main {
+  min-width: 0;
+  padding-right: 44px;
+  padding-bottom: 64px;
+  flex: 1 1 auto;
   display: flex;
-  align-items: flex-start;
+  flex-direction: column;
+  gap: 28px;
 }
 
-.issuePullRequests .issueInvestigationRow {
-  grid-template-columns: minmax(0, 1fr) auto;
-}
-
-.issueInvestigations h2 {
-  margin: 0;
-  color: var(--ds-text-primary);
-  font-size: 16px;
-  font-weight: 500;
-  line-height: 24px;
-  letter-spacing: -0.012em;
-}
-
-.issueInvestigationList {
+.issueHeader {
   display: flex;
   flex-direction: column;
   gap: 10px;
 }
 
-.issueInvestigationRow {
-  position: relative;
-  min-height: 72px;
-  padding: 12px 14px;
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) 24px;
+.issueHeader__back {
+  margin-bottom: 2px;
+  display: inline-flex;
+  align-self: flex-start;
+  color: var(--issueDim);
+  font-size: 13px;
+  line-height: 16px;
+}
+
+.issueHeader__back:hover {
+  color: var(--issueText);
+}
+
+.issueHeader__meta {
+  display: flex;
   align-items: center;
-  gap: 12px;
-  border: 1px solid var(--ds-border-default);
-  border-radius: var(--ds-radius-medium);
-  background: var(--ds-surface-raised);
-  transition:
-    border-color var(--ds-duration-fast) var(--ds-ease-standard),
-    background var(--ds-duration-fast) var(--ds-ease-standard);
+  flex-wrap: wrap;
+  gap: 8px;
+  color: var(--issueDim);
+  font-size: 12px;
+  line-height: 16px;
 }
 
-.issueInvestigationRow::after,
-.evidenceList li::after {
-  position: absolute;
-  inset: -1px;
-  border-radius: inherit;
-  box-shadow:
-    rgb(255 255 255 / 2%) 0 0 0 0.5px inset,
-    var(--ds-border-top) 0 0.5px 0 inset;
-  content: "";
-  pointer-events: none;
+.issueHeader__separator {
+  color: var(--issueFaint);
 }
 
-a.issueInvestigationRow:hover {
-  border-color: var(--ds-border-strong);
-  background: var(--ds-surface-hover);
+.issueSeverityBadge {
+  height: 20px;
+  padding: 0 8px;
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  border-radius: 4px;
+  background: #3a2f1c;
+  color: #e9a23b;
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 14px;
+  letter-spacing: 0.02em;
 }
 
-a.issueInvestigationRow:focus-visible {
-  outline: 2px solid var(--ds-text-primary);
-  outline-offset: 2px;
+.issueHeader h1 {
+  margin: 0;
+  color: var(--issueText);
+  font-size: 26px;
+  font-weight: 600;
+  line-height: 34px;
+  letter-spacing: -0.012em;
 }
 
-.issueInvestigationRow > span:first-child {
-  min-width: 0;
+.issueProse {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 12px;
 }
 
-.issueInvestigationRow strong,
-.issueInvestigationRow small {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+.issueProse p {
+  margin: 0;
+  color: var(--issueBody);
+  font-size: 15px;
+  line-height: 24px;
+  white-space: pre-wrap;
 }
 
-.issueInvestigationRow strong {
-  color: var(--ds-text-primary);
-  font-size: 12px;
+.issueCallout {
+  padding: 16px 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  border: 1px solid var(--issueHairline);
+  border-radius: 8px;
+  background: #161617;
+}
+
+.issueCallout h2 {
+  margin: 0;
+  color: var(--issueText);
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 16px;
+}
+
+.issueCallout p {
+  margin: 0;
+  color: #b4b7bd;
+  font-size: 14.5px;
+  line-height: 23px;
+  white-space: pre-wrap;
+}
+
+.issueSection {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.issueSection__title {
+  margin: 0;
+  padding-bottom: 8px;
+  color: var(--issueText);
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 16px;
+}
+
+.issueSection .inlineEmpty {
+  padding-left: 10px;
+}
+
+.evidenceList {
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  list-style: none;
+}
+
+.evidenceList li {
+  padding: 12px 10px;
+  display: flex;
+  align-items: flex-start;
+  gap: 14px;
+  border-radius: 6px;
+}
+
+.evidenceGlyph {
+  width: 20px;
+  height: 20px;
+  margin-top: 1px;
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 5px;
+  background: #232427;
+  color: #9da3ae;
+}
+
+.evidenceGlyph .providerGlyph,
+.evidenceGlyph .providerGlyph > svg {
+  width: 12px;
+  height: 12px;
+  font-size: 6px;
+}
+
+.evidenceGlyph--sentry {
+  background: #2a1e2e;
+  color: #c88be0;
+}
+
+.evidenceGlyph--datadog {
+  background: #1e2e3a;
+  color: #7fbee8;
+}
+
+.evidenceGlyph--clickstack {
+  background: #232427;
+}
+
+.evidenceItem__body {
+  min-width: 0;
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 3px;
+}
+
+.evidenceItem__body strong {
+  color: var(--issueText);
+  font-size: 14px;
   font-weight: 500;
   line-height: 18px;
 }
 
-.issueInvestigationRow small,
-.issueInvestigationRow time {
-  color: var(--ds-text-muted);
-  font-size: 9px;
-  line-height: 15px;
+.evidenceItem__body p {
+  margin: 0;
+  color: var(--issueMuted);
+  font-size: 13.5px;
+  line-height: 21px;
+}
+
+.evidenceItem__body a {
+  margin-top: 2px;
+  color: #7e8cde;
+  font-size: 12.5px;
+  line-height: 16px;
+}
+
+.evidenceItem__body a:hover {
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+.evidenceItem__body code {
+  margin-top: 2px;
+  color: #6e7480;
+  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 12px;
+  line-height: 16px;
+}
+
+.evidenceItem__source {
+  width: 64px;
+  flex: 0 0 auto;
+  display: flex;
+  justify-content: flex-end;
+  color: var(--issueDim);
+  font-size: 12px;
+  line-height: 16px;
+}
+
+.issueLine {
+  min-height: 44px;
+  padding: 0 10px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  border-radius: 6px;
+  color: inherit;
+  transition: background var(--ds-duration-fast) var(--ds-ease-standard);
+}
+
+.issueLine--stacked {
+  min-height: 48px;
+}
+
+a.issueLine:hover {
+  background: #161617;
+}
+
+a.issueLine:focus-visible {
+  outline: 2px solid var(--ds-text-primary);
+  outline-offset: -2px;
+}
+
+.issueLine__status {
+  width: 16px;
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--issueMuted);
+}
+
+.issueLine__status .providerGlyph,
+.issueLine__status .providerGlyph > svg {
+  width: 14px;
+  height: 14px;
+  font-size: 7px;
+}
+
+.issueLine__status--active {
+  color: #e9a23b;
+}
+
+.issueLine__status--resolved {
+  color: #4cb782;
+}
+
+.issueLine__status--failed {
+  color: var(--ds-danger);
+}
+
+.issueLine__title {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--issueText);
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 18px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.issueLine__note {
+  padding-left: 10px;
+  flex: 0 0 auto;
+  color: var(--issueDim);
+  font-size: 13px;
+  line-height: 16px;
+}
+
+.issueLine__spacer {
+  flex: 1 1 auto;
+}
+
+.issueLine__date {
+  width: 76px;
+  flex: 0 0 auto;
+  display: flex;
+  justify-content: flex-end;
+  color: var(--issueDim);
+  font-size: 12.5px;
+  line-height: 16px;
+}
+
+.issueLine__chevron {
+  width: 14px;
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  color: #4a4d53;
+}
+
+.issueLine__chevron svg {
+  width: 12px;
+  height: 12px;
+}
+
+.issueLine__body {
+  min-width: 0;
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.issueLine__body strong {
+  overflow: hidden;
+  color: var(--issueText);
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 18px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.issueLine__body small {
+  color: var(--issueDim);
+  font-size: 12.5px;
+  line-height: 16px;
+}
+
+.issueLine__action {
+  height: 26px;
+  padding: 0 10px;
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid #292a2e;
+  border-radius: 6px;
+  background: #1a1a1c;
+  color: #c7c9ce;
+  font-size: 12.5px;
+  font-weight: 500;
+  line-height: 16px;
+}
+
+.issueLine__action:hover {
+  border-color: #3a3b40;
+  background: #232326;
+  color: var(--issueText);
+}
+
+.issueRail {
+  width: 230px;
+  padding: 24px 28px;
+  flex: 0 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.issueRail__group {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.issueRail__title {
+  height: 30px;
+  margin: 0;
+  padding: 0 6px;
+  display: flex;
+  align-items: center;
+  color: rgb(232 233 235 / 80%);
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 18px;
+}
+
+.issueRail__row {
+  min-height: 30px;
+  padding: 0 6px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  border-radius: 5px;
+}
+
+.issueRail__label {
+  width: 64px;
+  flex: 0 0 auto;
+  color: var(--issueDim);
+  font-size: 12.5px;
+  line-height: 16px;
+}
+
+.issueRail__icon {
+  width: 14px;
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.issueRail__icon--severity {
+  color: #e9a23b;
+}
+
+.issueRail__row .evidenceGlyph {
+  width: 14px;
+  height: 14px;
+  margin-top: 0;
+  border-radius: 4px;
+}
+
+.issueRail__value {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--issueRailValue);
+  font-size: 12.5px;
+  font-weight: 500;
+  line-height: 16px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.issueRail__actions {
+  padding-top: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  border-top: 1px solid var(--issueHairline);
+}
+
+.issueRail__actions .dsButton {
+  width: 100%;
 }
 
 .investigationIssues {
@@ -6734,60 +6992,6 @@ a.issueInvestigationRow:focus-visible {
 
 .investigationIssue__remediation > p {
   white-space: pre-wrap;
-}
-
-.evidenceList {
-  margin: 10px 0 0;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  list-style: none;
-}
-
-.evidenceList li {
-  position: relative;
-  min-height: 72px;
-  padding: 12px;
-  display: grid;
-  grid-template-columns: 70px minmax(0, 1fr);
-  gap: 12px;
-  border: 1px solid var(--ds-border-default);
-  border-radius: var(--ds-radius-medium);
-  background: var(--ds-surface-raised);
-}
-
-.evidenceList li > span {
-  color: var(--ds-text-muted);
-  font-size: 10px;
-  font-weight: 600;
-  line-height: 14px;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-
-.evidenceList strong {
-  color: var(--ds-text-primary);
-  font-size: 12px;
-  font-weight: 500;
-  line-height: 16px;
-}
-
-.evidenceList p {
-  margin: 2px 0 0 !important;
-  color: var(--ds-text-muted) !important;
-  font-size: 11px;
-  line-height: 14px !important;
-}
-
-.evidenceList a,
-.evidenceList code {
-  margin-top: 2px;
-  display: inline-flex;
-  color: var(--ds-text-secondary);
-  font-family: var(--ds-font-sans);
-  font-size: 10px;
-  line-height: 12px;
 }
 
 @media (max-width: 900px) {
@@ -6845,8 +7049,20 @@ a.issueInvestigationRow:focus-visible {
     grid-template-columns: 1fr;
   }
 
-  .issueDetailContent {
-    grid-template-columns: 1fr;
+  .issueDetail {
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .issueDetail__main {
+    padding-right: 0;
+    padding-bottom: 8px;
+  }
+
+  .issueRail {
+    width: 100%;
+    padding: 20px 0 0;
+    border-top: 1px solid var(--issueHairline);
   }
 
   .investigationDetailContent {
@@ -7053,8 +7269,7 @@ a.issueInvestigationRow:focus-visible {
 
   .pageHeading,
   .detailHeading,
-  .investigationDetailHeading,
-  .issueDetailHeading {
+  .investigationDetailHeading {
     align-items: flex-start;
     flex-direction: column;
     gap: 22px;
@@ -7100,29 +7315,14 @@ a.issueInvestigationRow:focus-visible {
     width: 100%;
   }
 
-  .issueDetailHeading {
-    min-height: auto;
-    padding-block: 8px 20px;
-  }
-
-  .issueDetailHeading h1 {
-    font-size: 27px;
-    line-height: 35px;
-  }
-
-  .issueDetailHeading p {
-    margin-left: 0;
+  .issueHeader h1 {
+    font-size: 23px;
+    line-height: 30px;
   }
 
   .titleWithBadge {
     align-items: flex-start;
     flex-wrap: wrap;
-  }
-
-  .issueDefinitionCard,
-  .issueInvestigations {
-    padding: 20px;
-    border-radius: 24px;
   }
 
   .buttonGroup .button,
@@ -7165,8 +7365,18 @@ a.issueInvestigationRow:focus-visible {
   }
 
   .evidenceList li {
-    grid-template-columns: 1fr;
-    gap: 6px;
+    flex-wrap: wrap;
+    gap: 10px;
+  }
+
+  .evidenceItem__source {
+    width: auto;
+    padding-left: 34px;
+  }
+
+  .issueLine__note,
+  .issueLine__date {
+    display: none;
   }
 
   .traceTimeline summary {

--- a/apps/control-plane/src/styles.css
+++ b/apps/control-plane/src/styles.css
@@ -3527,6 +3527,12 @@ button:disabled {
   margin-bottom: 5px;
 }
 
+.screenSkeleton__railAction.dsSkeleton {
+  width: 100%;
+  height: 36px;
+  border-radius: var(--ds-radius-pill);
+}
+
 .screenSkeleton__linkedItems > .screenSkeleton__cardTitle {
   margin-bottom: 4px;
 }


### PR DESCRIPTION
Rebuilds the issue detail page around a single reading column with a properties rail, replacing the nested card grid.

## What changed

- **Layout.** One reading column beside a 230px properties rail. Evidence, investigations, pull requests, and Linear tickets are flat hairline rows rather than bordered cards.
- **Actions.** Copy prompt, Archive, and Create pull request move into the rail, under Severity / Agent / Source.
- **Evidence rows.** Each row leads with a tinted source chip built from `ProviderGlyph`, so newly added providers get their logo without another lookup table. Sources with no provider behind them (`alert`, `other`) fall back to a neutral glyph.
- **New `issue-detail-presentation` module.** Holds the derived values the layout needs — identified-at stamp, investigation count, relationship label, status tone, evidence source label and glyph, and the description paragraph split. Covered by unit tests so the edge cases do not need a browser.
- **Loading skeleton** now matches the new shape.

## Notes

- Source labels come from the shared `providerDisplayName`, overridden only where the shared name crowds the column (`ClickStack`) or where there is no provider (`Alert`, `Other`).
- Investigation status drives the row dot colour: amber investigating, grey pending, green resolved, red failed.
- The Linear row shows the Linear glyph untinted, because tinting a brand mark green at 14px made it unreadable. Failed tickets still get the red tint and the row title already carries the state.

## Validation

`pnpm typecheck`, `pnpm lint`, `pnpm test` (107 files, 743 tests), and `pnpm build` all pass. Verified in a local stack against a seeded issue covering every section, including an evidence source with no provider logo.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rebuilds the issue page into a single reading column with a 230px properties rail, replacing the nested card grid. Rows replace cards for evidence, investigations, pull requests, and Linear tickets; page actions move into the rail. Adds accessible status labels for row dots.

- Evidence rows lead with a tinted provider glyph via `ProviderGlyph` (fallback `SignalIcon`); source labels reuse `providerDisplayName` with small overrides (ClickStack, Alert, Other).
- Presentation logic lives in `issue-detail-presentation` (identified-at stamp, row date, investigation count/relationship/status tone, evidence source label/glyph, description paragraph split, primary source, originating agent). Covered by unit tests.
- Accessibility: row status dots now expose an aria-label via shared `rowStatusLabel` across investigations, pull requests, and Linear tickets.
- UI updates: status dot tones (pending/active/resolved/failed), severity bars, Linear glyph left untinted, row dates drop the year, identified-at uses short time.
- Loading: skeleton matches the new structure and reserves the two always-present rail actions so the rail width does not shift.
- No API changes or migrations required.

<sup>Written for commit cd92f76d39f37869740f0fa14157946a682085e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/responder-oss/pull/50?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

