### PR TITLE
Persist agent secret selections

### DIFF
--- a/apps/control-plane/src/pages/agent-create-draft.test.ts
+++ b/apps/control-plane/src/pages/agent-create-draft.test.ts
@@ -20,7 +20,7 @@ describe("agent draft persistence", () => {
     const workspaceSecretRecordIds = workspaceSecretRecordIdsForDraft(
       OPTIONS,
       {
-        workspaceSecretRecordIds: ["secret-1", "deleted-secret"],
+        workspaceSecretNames: ["STATUS_API_TOKEN", "DELETED_API_TOKEN"],
       },
       {},
     );
@@ -29,8 +29,8 @@ describe("agent draft persistence", () => {
     } as CreateDraft;
 
     expect(workspaceSecretRecordIds).toEqual(["secret-1"]);
-    expect(draftForSessionStorage(draft).workspaceSecretRecordIds).toEqual([
-      "secret-1",
+    expect(draftForSessionStorage(draft, OPTIONS).workspaceSecretNames).toEqual([
+      "STATUS_API_TOKEN",
     ]);
   });
 });

--- a/apps/control-plane/src/pages/agent-create-draft.test.ts
+++ b/apps/control-plane/src/pages/agent-create-draft.test.ts
@@ -12,6 +12,11 @@ const OPTIONS = {
       name: "STATUS_API_TOKEN",
       allowedHosts: ["status.example.com"],
     },
+    {
+      id: "secret-2",
+      name: "STATUS_API_TOKEN",
+      allowedHosts: ["other.example.com"],
+    },
   ],
 };
 
@@ -32,5 +37,22 @@ describe("agent draft persistence", () => {
     expect(draftForSessionStorage(draft, OPTIONS).workspaceSecretNames).toEqual([
       "STATUS_API_TOKEN",
     ]);
+  });
+
+  it("restores and migrates a valid ID from a legacy session draft", () => {
+    const workspaceSecretRecordIds = workspaceSecretRecordIdsForDraft(
+      OPTIONS,
+      { workspaceSecretRecordIds: ["secret-1", "deleted-secret"] },
+      {},
+    );
+    const draft = { workspaceSecretRecordIds } as CreateDraft;
+
+    expect(workspaceSecretRecordIds).toEqual(["secret-1"]);
+    expect(draftForSessionStorage(draft, OPTIONS)).toMatchObject({
+      workspaceSecretNames: ["STATUS_API_TOKEN"],
+    });
+    expect(draftForSessionStorage(draft, OPTIONS)).not.toHaveProperty(
+      "workspaceSecretRecordIds",
+    );
   });
 });

--- a/apps/control-plane/src/pages/agent-create-draft.test.ts
+++ b/apps/control-plane/src/pages/agent-create-draft.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import {
+  draftForSessionStorage,
+  workspaceSecretRecordIdsForDraft,
+  type CreateDraft,
+} from "./agent-create-draft";
+
+const OPTIONS = {
+  secrets: [
+    {
+      id: "secret-1",
+      name: "STATUS_API_TOKEN",
+      allowedHosts: ["status.example.com"],
+    },
+  ],
+};
+
+describe("agent draft persistence", () => {
+  it("restores valid workspace secret selections and persists them again", () => {
+    const workspaceSecretRecordIds = workspaceSecretRecordIdsForDraft(
+      OPTIONS,
+      {
+        workspaceSecretRecordIds: ["secret-1", "deleted-secret"],
+      },
+      {},
+    );
+    const draft = {
+      workspaceSecretRecordIds,
+    } as CreateDraft;
+
+    expect(workspaceSecretRecordIds).toEqual(["secret-1"]);
+    expect(draftForSessionStorage(draft).workspaceSecretRecordIds).toEqual([
+      "secret-1",
+    ]);
+  });
+});

--- a/apps/control-plane/src/pages/agent-create-draft.ts
+++ b/apps/control-plane/src/pages/agent-create-draft.ts
@@ -23,11 +23,17 @@ export interface CreateDraft {
   instructions: string;
 }
 
-export type SavedCreateDraft = Partial<CreateDraft> & {
+export type SavedCreateDraft = Partial<
+  Omit<CreateDraft, "workspaceSecretRecordIds">
+> & {
   postScope?: "all" | "selected";
+  workspaceSecretNames?: string[];
 };
 
-export function draftForSessionStorage(draft: CreateDraft): SavedCreateDraft {
+export function draftForSessionStorage(
+  draft: CreateDraft,
+  options: Pick<AgentOptions, "secrets">,
+): SavedCreateDraft {
   return {
     inputKind: draft.inputKind,
     sentryAccountId: draft.sentryAccountId,
@@ -41,7 +47,9 @@ export function draftForSessionStorage(draft: CreateDraft): SavedCreateDraft {
     prMode: draft.prMode,
     contextAccountIds: draft.contextAccountIds,
     contextResourceIds: draft.contextResourceIds,
-    workspaceSecretRecordIds: draft.workspaceSecretRecordIds,
+    workspaceSecretNames: options.secrets
+      .filter((secret) => draft.workspaceSecretRecordIds.includes(secret.id))
+      .map((secret) => secret.name),
     createLinearTickets: draft.createLinearTickets,
     linearIssueTemplate: draft.linearIssueTemplate,
     instructions: draft.instructions,
@@ -53,10 +61,13 @@ export function workspaceSecretRecordIdsForDraft(
   saved: SavedCreateDraft,
   configured: Partial<CreateDraft>,
 ): string[] {
-  const selectedIds =
-    saved.workspaceSecretRecordIds ?? configured.workspaceSecretRecordIds;
+  if (saved.workspaceSecretNames) {
+    return options.secrets
+      .filter((secret) => saved.workspaceSecretNames?.includes(secret.name))
+      .map((secret) => secret.id);
+  }
 
-  return selectedIds?.filter((id) =>
+  return configured.workspaceSecretRecordIds?.filter((id) =>
     options.secrets.some((secret) => secret.id === id),
   ) ?? [];
 }

--- a/apps/control-plane/src/pages/agent-create-draft.ts
+++ b/apps/control-plane/src/pages/agent-create-draft.ts
@@ -27,6 +27,7 @@ export type SavedCreateDraft = Partial<
   Omit<CreateDraft, "workspaceSecretRecordIds">
 > & {
   postScope?: "all" | "selected";
+  workspaceSecretRecordIds?: string[];
   workspaceSecretNames?: string[];
 };
 
@@ -62,9 +63,16 @@ export function workspaceSecretRecordIdsForDraft(
   configured: Partial<CreateDraft>,
 ): string[] {
   if (saved.workspaceSecretNames) {
-    return options.secrets
-      .filter((secret) => saved.workspaceSecretNames?.includes(secret.name))
-      .map((secret) => secret.id);
+    return [...new Set(saved.workspaceSecretNames)].flatMap((name) => {
+      const secret = options.secrets.find((candidate) => candidate.name === name);
+      return secret ? [secret.id] : [];
+    });
+  }
+
+  if (saved.workspaceSecretRecordIds) {
+    return saved.workspaceSecretRecordIds.filter((id) =>
+      options.secrets.some((secret) => secret.id === id),
+    );
   }
 
   return configured.workspaceSecretRecordIds?.filter((id) =>

--- a/apps/control-plane/src/pages/agent-create-draft.ts
+++ b/apps/control-plane/src/pages/agent-create-draft.ts
@@ -1,0 +1,62 @@
+import type { AgentOptions, AgentPrMode } from "../agents-api";
+
+export type InputKind = "sentry_issue" | "slack_channel";
+export type OutputMode = "thread" | "output_channel";
+export type Severity = "SEV-1" | "SEV-2" | "SEV-3";
+
+export interface CreateDraft {
+  inputKind: InputKind;
+  sentryAccountId: string;
+  sentryProjectResourceIds: string[];
+  slackInputResourceId: string;
+  outputMode: OutputMode;
+  outputChannelResourceId: string;
+  severities: Severity[];
+  githubAccountId: string;
+  repositoryIds: string[];
+  prMode: AgentPrMode;
+  contextAccountIds: string[];
+  contextResourceIds: string[];
+  workspaceSecretRecordIds: string[];
+  createLinearTickets: boolean;
+  linearIssueTemplate: string;
+  instructions: string;
+}
+
+export type SavedCreateDraft = Partial<CreateDraft> & {
+  postScope?: "all" | "selected";
+};
+
+export function draftForSessionStorage(draft: CreateDraft): SavedCreateDraft {
+  return {
+    inputKind: draft.inputKind,
+    sentryAccountId: draft.sentryAccountId,
+    sentryProjectResourceIds: draft.sentryProjectResourceIds,
+    slackInputResourceId: draft.slackInputResourceId,
+    outputMode: draft.outputMode,
+    outputChannelResourceId: draft.outputChannelResourceId,
+    severities: draft.severities,
+    githubAccountId: draft.githubAccountId,
+    repositoryIds: draft.repositoryIds,
+    prMode: draft.prMode,
+    contextAccountIds: draft.contextAccountIds,
+    contextResourceIds: draft.contextResourceIds,
+    workspaceSecretRecordIds: draft.workspaceSecretRecordIds,
+    createLinearTickets: draft.createLinearTickets,
+    linearIssueTemplate: draft.linearIssueTemplate,
+    instructions: draft.instructions,
+  };
+}
+
+export function workspaceSecretRecordIdsForDraft(
+  options: Pick<AgentOptions, "secrets">,
+  saved: SavedCreateDraft,
+  configured: Partial<CreateDraft>,
+): string[] {
+  const selectedIds =
+    saved.workspaceSecretRecordIds ?? configured.workspaceSecretRecordIds;
+
+  return selectedIds?.filter((id) =>
+    options.secrets.some((secret) => secret.id === id),
+  ) ?? [];
+}

--- a/apps/control-plane/src/pages/agent-create.tsx
+++ b/apps/control-plane/src/pages/agent-create.tsx
@@ -169,8 +169,9 @@ function storageKey(base: string, agentId: string | undefined): string {
 function saveDraftToSessionStorage(
   key: string,
   draft: CreateDraft,
+  options: AgentOptions,
 ): void {
-  const persistedDraft = draftForSessionStorage(draft);
+  const persistedDraft = draftForSessionStorage(draft, options);
   window.sessionStorage.setItem(key, JSON.stringify(persistedDraft));
 }
 
@@ -770,8 +771,8 @@ export function AgentCreatePage() {
 
   useEffect(() => {
     if (!draft) return;
-    saveDraftToSessionStorage(draftStorageKey, draft);
-  }, [draft, draftStorageKey]);
+    saveDraftToSessionStorage(draftStorageKey, draft, options);
+  }, [draft, draftStorageKey, options]);
 
   useEffect(() => {
     window.sessionStorage.setItem(
@@ -1029,7 +1030,7 @@ export function AgentCreatePage() {
       provider === "upstash" ||
       provider === "langfuse"
     ) {
-      saveDraftToSessionStorage(draftStorageKey, currentDraft);
+      saveDraftToSessionStorage(draftStorageKey, currentDraft, options);
       if (provider === "aws") setConnectingAws(true);
       else if (provider === "datadog") setChoosingDatadogSite(true);
       else if (provider === "clickstack") setConnectingClickStack(true);
@@ -1038,13 +1039,13 @@ export function AgentCreatePage() {
       return;
     }
     if (provider === "custom_mcp") {
-      saveDraftToSessionStorage(draftStorageKey, currentDraft);
+      saveDraftToSessionStorage(draftStorageKey, currentDraft, options);
       setConfiguringCustomMcp(true);
       return;
     }
     connectingProviderRef.current = provider;
     setConnectingProvider(provider);
-    saveDraftToSessionStorage(draftStorageKey, currentDraft);
+    saveDraftToSessionStorage(draftStorageKey, currentDraft, options);
     const separator = connectionUrl.includes("?") ? "&" : "?";
     const params = new URLSearchParams({ returnTo });
     window.location.assign(`${connectionUrl}${separator}${params}`);

--- a/apps/control-plane/src/pages/agent-create.tsx
+++ b/apps/control-plane/src/pages/agent-create.tsx
@@ -11,7 +11,6 @@ import { Link, useNavigate, useParams } from "react-router-dom";
 import {
   type AgentConfiguration,
   type AgentOptions,
-  type AgentPrMode,
   type IntegrationSummary,
   fetchAgent,
   fetchAgentOptions,
@@ -55,10 +54,15 @@ import {
   TextAreaField,
 } from "../design-system";
 import { useDocumentTitle } from "../use-document-title";
+import {
+  draftForSessionStorage,
+  workspaceSecretRecordIdsForDraft,
+  type CreateDraft,
+  type OutputMode,
+  type SavedCreateDraft,
+  type Severity,
+} from "./agent-create-draft";
 
-type InputKind = "sentry_issue" | "slack_channel";
-type OutputMode = "thread" | "output_channel";
-type Severity = "SEV-1" | "SEV-2" | "SEV-3";
 type CreateStep = 1 | 2 | 3 | 4;
 type ContextCategory =
   | "Observability"
@@ -103,31 +107,6 @@ const MULTI_ACCOUNT_CONTEXT_PROVIDERS = new Set<IntegrationSummary["id"]>([
   "custom_mcp",
   "langfuse",
 ]);
-
-interface CreateDraft {
-  inputKind: InputKind;
-  sentryAccountId: string;
-  sentryProjectResourceIds: string[];
-  slackInputResourceId: string;
-  outputMode: OutputMode;
-  outputChannelResourceId: string;
-  severities: Severity[];
-  githubAccountId: string;
-  repositoryIds: string[];
-  prMode: AgentPrMode;
-  contextAccountIds: string[];
-  contextResourceIds: string[];
-  workspaceSecretRecordIds: string[];
-  createLinearTickets: boolean;
-  linearIssueTemplate: string;
-  instructions: string;
-}
-
-type SavedCreateDraft = Partial<
-  Omit<CreateDraft, "workspaceSecretRecordIds">
-> & {
-  postScope?: "all" | "selected";
-};
 
 const EMPTY_OPTIONS: AgentOptions = {
   accounts: [],
@@ -191,23 +170,7 @@ function saveDraftToSessionStorage(
   key: string,
   draft: CreateDraft,
 ): void {
-  const persistedDraft: SavedCreateDraft = {
-    inputKind: draft.inputKind,
-    sentryAccountId: draft.sentryAccountId,
-    sentryProjectResourceIds: draft.sentryProjectResourceIds,
-    slackInputResourceId: draft.slackInputResourceId,
-    outputMode: draft.outputMode,
-    outputChannelResourceId: draft.outputChannelResourceId,
-    severities: draft.severities,
-    githubAccountId: draft.githubAccountId,
-    repositoryIds: draft.repositoryIds,
-    prMode: draft.prMode,
-    contextAccountIds: draft.contextAccountIds,
-    contextResourceIds: draft.contextResourceIds,
-    createLinearTickets: draft.createLinearTickets,
-    linearIssueTemplate: draft.linearIssueTemplate,
-    instructions: draft.instructions,
-  };
+  const persistedDraft = draftForSessionStorage(draft);
   window.sessionStorage.setItem(key, JSON.stringify(persistedDraft));
 }
 
@@ -328,11 +291,11 @@ function createInitialDraft(
     ) ??
     defaultContext.repositoryIds;
   const configuredPrMode = saved.prMode ?? configured.prMode;
-  const workspaceSecretRecordIds =
-    configured.workspaceSecretRecordIds?.filter((id) =>
-      options.secrets.some((secret) => secret.id === id),
-    ) ??
-    [];
+  const workspaceSecretRecordIds = workspaceSecretRecordIdsForDraft(
+    options,
+    saved,
+    configured,
+  );
 
   return {
     inputKind: saved.inputKind ?? configured.inputKind ?? "sentry_issue",


### PR DESCRIPTION
## Summary
- persist selected workspace secret IDs in the create-agent session draft
- restore only secrets that still exist in the workspace
- keep draft persistence logic outside the page component and cover it with a focused regression test

## Validation
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test` (109 files, 749 tests)
- `pnpm build:app`
- storyboard smoke
- create-agent browser smoke, including selection surviving reload

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist workspace secret selections across reloads by storing secret names in the session draft and restoring IDs on load. Previously selections were not saved; now they survive reloads, skip deleted secrets, and migrate legacy drafts that stored IDs.

- Adds `apps/control-plane/src/pages/agent-create-draft.ts` with `draftForSessionStorage` (serializes selected IDs to `workspaceSecretNames`) and `workspaceSecretRecordIdsForDraft` (restores from names, legacy IDs, or configured defaults; deduplicates and filters by `AgentOptions.secrets`).
- Updates `agent-create.tsx` to use these helpers; `saveDraftToSessionStorage` now takes `options`.
- Adds `agent-create-draft.test.ts` covering legacy ID migration and valid secret restoration.
- No migration required; existing session drafts auto-migrate to names.

<sup>Written for commit 0f46df1359acd5e456032b40910e256de7023cf5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/responder-oss/pull/52?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

