### PR TITLE
Let customers rerun investigations

### DIFF
--- a/apps/control-plane/server/agents/routes.test.ts
+++ b/apps/control-plane/server/agents/routes.test.ts
@@ -11,6 +11,8 @@ import {
 } from "../../../../packages/core/src/db/integrations.js";
 import {
   getInvestigationDetail,
+  getInvestigationForRetry,
+  investigationCanBeRetried,
   listInvestigationTraceEvents,
 } from "../../../../packages/core/src/db/investigations.js";
 import {
@@ -18,6 +20,7 @@ import {
   findWorkspaceSecretByName,
 } from "../../../../packages/core/src/db/workspace-secrets.js";
 import { getActiveTenant } from "../tenant.js";
+import { queueInvestigationRetry } from "../investigations/queue.js";
 import { listSlackChannels } from "../integrations/slack.js";
 import {
   createDaytonaWorkspaceSecret,
@@ -108,6 +111,99 @@ const tenant = {
     email: "test@example.com",
   },
 };
+
+describe("investigation reruns", () => {
+  const agentId = "30000000-0000-4000-8000-000000000000";
+  const investigationId = "40000000-0000-4000-8000-000000000000";
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("queues a finished investigation for its active workspace", async () => {
+    vi.mocked(getActiveTenant).mockResolvedValue(tenant);
+    vi.mocked(getInvestigationForRetry).mockResolvedValue({
+      id: investigationId,
+      input: {
+        body: "Original alert",
+        externalEventId: "event-1",
+        provider: "sentry",
+        title: "Production error",
+      },
+      status: "resolved",
+    });
+    vi.mocked(investigationCanBeRetried).mockReturnValue(true);
+    vi.mocked(queueInvestigationRetry).mockResolvedValue({
+      investigationId,
+      jobId: "job-1",
+      kind: "queued",
+    });
+
+    const response = await app.request(
+      `/api/agents/${agentId}/investigations/${investigationId}/retry`,
+      { method: "POST" },
+    );
+
+    expect(response.status).toBe(202);
+    await expect(response.json()).resolves.toEqual({
+      investigationId,
+      sessionId: "openai-daytona:job-1",
+    });
+    expect(queueInvestigationRetry).toHaveBeenCalledWith({
+      investigationId,
+      organizationId: tenant.organizationId,
+    });
+  });
+
+  it("returns the billing limit without starting the rerun", async () => {
+    vi.mocked(getActiveTenant).mockResolvedValue(tenant);
+    vi.mocked(getInvestigationForRetry).mockResolvedValue({
+      id: investigationId,
+      input: {
+        body: "Original alert",
+        externalEventId: "event-1",
+        provider: "sentry",
+        title: "Production error",
+      },
+      status: "resolved",
+    });
+    vi.mocked(investigationCanBeRetried).mockReturnValue(true);
+    vi.mocked(queueInvestigationRetry).mockResolvedValue({ kind: "blocked" });
+
+    const response = await app.request(
+      `/api/agents/${agentId}/investigations/${investigationId}/retry`,
+      { method: "POST" },
+    );
+
+    expect(response.status).toBe(402);
+    await expect(response.json()).resolves.toEqual({
+      error: "Monthly investigation allowance exhausted",
+    });
+  });
+
+  it("does not rerun active investigations", async () => {
+    vi.mocked(getActiveTenant).mockResolvedValue(tenant);
+    vi.mocked(getInvestigationForRetry).mockResolvedValue({
+      id: investigationId,
+      input: {
+        body: "Original alert",
+        externalEventId: "event-1",
+        provider: "sentry",
+        title: "Production error",
+      },
+      status: "investigating",
+    });
+    vi.mocked(investigationCanBeRetried).mockReturnValue(false);
+
+    const response = await app.request(
+      `/api/agents/${agentId}/investigations/${investigationId}/retry`,
+      { method: "POST" },
+    );
+
+    expect(response.status).toBe(409);
+    expect(queueInvestigationRetry).not.toHaveBeenCalled();
+  });
+});
 
 describe("workspace secrets", () => {
   afterEach(() => {

--- a/apps/control-plane/server/agents/routes.ts
+++ b/apps/control-plane/server/agents/routes.ts
@@ -453,7 +453,16 @@ export const agentRoutes = new Hono()
     }
 
     try {
-      const retry = await queueInvestigationRetry(investigation.id);
+      const retry = await queueInvestigationRetry({
+        investigationId: investigation.id,
+        organizationId: tenant.organizationId,
+      });
+      if (retry.kind === "blocked") {
+        return context.json(
+          { error: "Monthly investigation allowance exhausted" },
+          402,
+        );
+      }
       return context.json(
         {
           investigationId: retry.investigationId,
@@ -464,7 +473,7 @@ export const agentRoutes = new Hono()
     } catch (error) {
       return context.json(
         {
-          error: error instanceof Error ? error.message : "Unable to retry investigation",
+          error: error instanceof Error ? error.message : "Unable to rerun investigation",
         },
         502,
       );

--- a/apps/control-plane/server/investigations/queue.test.ts
+++ b/apps/control-plane/server/investigations/queue.test.ts
@@ -16,6 +16,7 @@ const mocks = vi.hoisted(() => ({
   notifyBillingLimitReached: vi.fn(),
   prepareInvestigationRetry: vi.fn(),
   prepareWorkerQueues: vi.fn(),
+  refundInvestigation: vi.fn(),
   setIssuePullRequestSession: vi.fn(),
 }));
 
@@ -25,6 +26,7 @@ vi.mock("../../../../packages/core/src/analytics.js", () => ({
 
 vi.mock("../../../../packages/core/src/billing/autumn.js", () => ({
   consumeInvestigation: mocks.consumeInvestigation,
+  refundInvestigation: mocks.refundInvestigation,
 }));
 
 vi.mock("../../../../packages/core/src/billing/notifications.js", () => ({
@@ -116,12 +118,14 @@ describe("investigation queue", () => {
     mocks.consumeInvestigation.mockResolvedValue({
       allowed: true,
       configured: false,
+      consumed: true,
       nextResetAt: null,
     });
     mocks.bossStart.mockResolvedValue(undefined);
     mocks.captureAnalyticsEvent.mockResolvedValue(undefined);
     mocks.prepareWorkerQueues.mockResolvedValue(undefined);
     mocks.notifyBillingLimitReached.mockResolvedValue(undefined);
+    mocks.refundInvestigation.mockResolvedValue(undefined);
     mocks.prepareInvestigationRetry.mockResolvedValue({
       config: created.config,
       input: request,
@@ -220,6 +224,11 @@ describe("investigation queue", () => {
     expect(mocks.prepareInvestigationRetry).toHaveBeenCalledWith(
       created.investigationId,
     );
+    expect(mocks.bossSend).toHaveBeenCalledWith(
+      "responder-investigations",
+      expect.objectContaining({ config: created.config }),
+      expect.any(Object),
+    );
     expect(mocks.captureAnalyticsEvent).toHaveBeenCalledWith({
       distinctId: `investigation:${created.investigationId}`,
       event: "investigation rerun",
@@ -238,6 +247,7 @@ describe("investigation queue", () => {
     mocks.consumeInvestigation.mockResolvedValue({
       allowed: false,
       configured: true,
+      consumed: false,
       nextResetAt: 1_800_000_000,
     });
 
@@ -255,6 +265,24 @@ describe("investigation queue", () => {
     expect(mocks.prepareInvestigationRetry).not.toHaveBeenCalled();
     expect(mocks.bossSend).not.toHaveBeenCalled();
     expect(mocks.captureAnalyticsEvent).not.toHaveBeenCalled();
+  });
+
+  it("refunds a metered rerun that loses the terminal-state claim", async () => {
+    const error = new Error("Only finished investigations can be retried");
+    mocks.prepareInvestigationRetry.mockRejectedValue(error);
+
+    await expect(
+      queueInvestigationRetry({
+        investigationId: created.investigationId,
+        organizationId: created.config.organizationId,
+      }),
+    ).rejects.toBe(error);
+
+    expect(mocks.refundInvestigation).toHaveBeenCalledWith(
+      created.config.organizationId,
+      created.investigationId,
+    );
+    expect(mocks.bossSend).not.toHaveBeenCalled();
   });
 
   it("fails a remediation request when the queue cannot start", async () => {

--- a/apps/control-plane/server/investigations/queue.test.ts
+++ b/apps/control-plane/server/investigations/queue.test.ts
@@ -300,7 +300,7 @@ describe("investigation queue", () => {
   });
 
   it("does not enqueue a rerun when its billing reservation cannot be confirmed", async () => {
-    mocks.finalizeInvestigationReservation.mockRejectedValue(
+    mocks.finalizeInvestigationReservation.mockRejectedValueOnce(
       new Error("billing unavailable"),
     );
 
@@ -314,6 +314,11 @@ describe("investigation queue", () => {
     expect(mocks.failInvestigation).toHaveBeenCalledWith(
       created.investigationId,
       "Unable to confirm investigation rerun billing",
+    );
+    expect(mocks.finalizeInvestigationReservation).toHaveBeenNthCalledWith(
+      2,
+      "rerun-reservation-1",
+      "release",
     );
     expect(mocks.bossSend).not.toHaveBeenCalled();
   });

--- a/apps/control-plane/server/investigations/queue.test.ts
+++ b/apps/control-plane/server/investigations/queue.test.ts
@@ -11,12 +11,13 @@ const mocks = vi.hoisted(() => ({
   discardPendingInvestigation: vi.fn(),
   failInvestigation: vi.fn(),
   failIssuePullRequest: vi.fn(),
+  finalizeInvestigationReservation: vi.fn(),
   getIssuePullRequestForRemediation: vi.fn(),
   getRuntimeAgentConfig: vi.fn(),
   notifyBillingLimitReached: vi.fn(),
   prepareInvestigationRetry: vi.fn(),
   prepareWorkerQueues: vi.fn(),
-  refundInvestigation: vi.fn(),
+  reserveInvestigation: vi.fn(),
   setIssuePullRequestSession: vi.fn(),
 }));
 
@@ -26,7 +27,8 @@ vi.mock("../../../../packages/core/src/analytics.js", () => ({
 
 vi.mock("../../../../packages/core/src/billing/autumn.js", () => ({
   consumeInvestigation: mocks.consumeInvestigation,
-  refundInvestigation: mocks.refundInvestigation,
+  finalizeInvestigationReservation: mocks.finalizeInvestigationReservation,
+  reserveInvestigation: mocks.reserveInvestigation,
 }));
 
 vi.mock("../../../../packages/core/src/billing/notifications.js", () => ({
@@ -118,14 +120,19 @@ describe("investigation queue", () => {
     mocks.consumeInvestigation.mockResolvedValue({
       allowed: true,
       configured: false,
-      consumed: true,
       nextResetAt: null,
+    });
+    mocks.reserveInvestigation.mockResolvedValue({
+      allowed: true,
+      configured: true,
+      nextResetAt: null,
+      reservationId: "rerun-reservation-1",
     });
     mocks.bossStart.mockResolvedValue(undefined);
     mocks.captureAnalyticsEvent.mockResolvedValue(undefined);
     mocks.prepareWorkerQueues.mockResolvedValue(undefined);
     mocks.notifyBillingLimitReached.mockResolvedValue(undefined);
-    mocks.refundInvestigation.mockResolvedValue(undefined);
+    mocks.finalizeInvestigationReservation.mockResolvedValue(undefined);
     mocks.prepareInvestigationRetry.mockResolvedValue({
       config: created.config,
       input: request,
@@ -217,13 +224,20 @@ describe("investigation queue", () => {
       kind: "queued",
     });
 
-    expect(mocks.consumeInvestigation).toHaveBeenCalledWith(
+    expect(mocks.reserveInvestigation).toHaveBeenCalledWith(
       created.config.organizationId,
       created.investigationId,
     );
     expect(mocks.prepareInvestigationRetry).toHaveBeenCalledWith(
       created.investigationId,
     );
+    expect(mocks.finalizeInvestigationReservation).toHaveBeenCalledWith(
+      "rerun-reservation-1",
+      "confirm",
+    );
+    expect(
+      mocks.finalizeInvestigationReservation.mock.invocationCallOrder[0],
+    ).toBeLessThan(mocks.bossSend.mock.invocationCallOrder[0] ?? 0);
     expect(mocks.bossSend).toHaveBeenCalledWith(
       "responder-investigations",
       expect.objectContaining({ config: created.config }),
@@ -244,11 +258,11 @@ describe("investigation queue", () => {
   });
 
   it("leaves a finished investigation untouched when rerun billing is blocked", async () => {
-    mocks.consumeInvestigation.mockResolvedValue({
+    mocks.reserveInvestigation.mockResolvedValue({
       allowed: false,
       configured: true,
-      consumed: false,
       nextResetAt: 1_800_000_000,
+      reservationId: null,
     });
 
     await expect(
@@ -267,7 +281,7 @@ describe("investigation queue", () => {
     expect(mocks.captureAnalyticsEvent).not.toHaveBeenCalled();
   });
 
-  it("refunds a metered rerun that loses the terminal-state claim", async () => {
+  it("releases a reserved rerun that loses the terminal-state claim", async () => {
     const error = new Error("Only finished investigations can be retried");
     mocks.prepareInvestigationRetry.mockRejectedValue(error);
 
@@ -278,9 +292,28 @@ describe("investigation queue", () => {
       }),
     ).rejects.toBe(error);
 
-    expect(mocks.refundInvestigation).toHaveBeenCalledWith(
-      created.config.organizationId,
+    expect(mocks.finalizeInvestigationReservation).toHaveBeenCalledWith(
+      "rerun-reservation-1",
+      "release",
+    );
+    expect(mocks.bossSend).not.toHaveBeenCalled();
+  });
+
+  it("does not enqueue a rerun when its billing reservation cannot be confirmed", async () => {
+    mocks.finalizeInvestigationReservation.mockRejectedValue(
+      new Error("billing unavailable"),
+    );
+
+    await expect(
+      queueInvestigationRetry({
+        investigationId: created.investigationId,
+        organizationId: created.config.organizationId,
+      }),
+    ).rejects.toThrow("Billing service unavailable");
+
+    expect(mocks.failInvestigation).toHaveBeenCalledWith(
       created.investigationId,
+      "Unable to confirm investigation rerun billing",
     );
     expect(mocks.bossSend).not.toHaveBeenCalled();
   });

--- a/apps/control-plane/server/investigations/queue.test.ts
+++ b/apps/control-plane/server/investigations/queue.test.ts
@@ -201,17 +201,59 @@ describe("investigation queue", () => {
     expect(mocks.captureAnalyticsEvent).not.toHaveBeenCalled();
   });
 
-  it("does not count a retry as a newly created investigation", async () => {
+  it("charges and enqueues a rerun with its refreshed configuration", async () => {
     await expect(
-      queueInvestigationRetry(created.investigationId),
+      queueInvestigationRetry({
+        investigationId: created.investigationId,
+        organizationId: created.config.organizationId,
+      }),
     ).resolves.toEqual({
       investigationId: created.investigationId,
       jobId: "21212121-2121-4121-8121-212121212121",
+      kind: "queued",
     });
 
+    expect(mocks.consumeInvestigation).toHaveBeenCalledWith(
+      created.config.organizationId,
+      created.investigationId,
+    );
     expect(mocks.prepareInvestigationRetry).toHaveBeenCalledWith(
       created.investigationId,
     );
+    expect(mocks.captureAnalyticsEvent).toHaveBeenCalledWith({
+      distinctId: `investigation:${created.investigationId}`,
+      event: "investigation rerun",
+      organizationId: created.config.organizationId,
+      properties: {
+        $process_person_profile: false,
+        agent_config_version_id: created.config.id,
+        agent_id: created.config.agentId,
+        investigation_id: created.investigationId,
+        provider: request.provider,
+      },
+    });
+  });
+
+  it("leaves a finished investigation untouched when rerun billing is blocked", async () => {
+    mocks.consumeInvestigation.mockResolvedValue({
+      allowed: false,
+      configured: true,
+      nextResetAt: 1_800_000_000,
+    });
+
+    await expect(
+      queueInvestigationRetry({
+        investigationId: created.investigationId,
+        organizationId: created.config.organizationId,
+      }),
+    ).resolves.toEqual({ kind: "blocked" });
+
+    expect(mocks.notifyBillingLimitReached).toHaveBeenCalledWith(
+      created.config.organizationId,
+      1_800_000_000,
+    );
+    expect(mocks.prepareInvestigationRetry).not.toHaveBeenCalled();
+    expect(mocks.bossSend).not.toHaveBeenCalled();
     expect(mocks.captureAnalyticsEvent).not.toHaveBeenCalled();
   });
 

--- a/apps/control-plane/server/investigations/queue.ts
+++ b/apps/control-plane/server/investigations/queue.ts
@@ -23,6 +23,10 @@ type QueueResult =
   | { investigationId: string; kind: "duplicate" }
   | { investigationId: string; jobId: string; kind: "queued" };
 
+type RetryQueueResult =
+  | { kind: "blocked" }
+  | { investigationId: string; jobId: string; kind: "queued" };
+
 let boss: ReturnType<typeof createJobBoss> | undefined;
 let bossStart: Promise<ReturnType<typeof createJobBoss>> | undefined;
 
@@ -124,8 +128,42 @@ export async function queueInvestigation(
   }
 }
 
-export async function queueInvestigationRetry(investigationId: string) {
-  const result = await prepareInvestigationRetry(investigationId);
+export async function queueInvestigationRetry(input: {
+  investigationId: string;
+  organizationId: string;
+}): Promise<RetryQueueResult> {
+  try {
+    const access = await consumeInvestigation(
+      input.organizationId,
+      input.investigationId,
+    );
+    if (!access.allowed) {
+      await notifyBillingLimitReached(
+        input.organizationId,
+        access.nextResetAt,
+      ).catch((error: unknown) => {
+        console.error("Unable to send billing limit notifications", error);
+      });
+      return { kind: "blocked" };
+    }
+  } catch (error) {
+    console.error("Unable to meter investigation rerun", error);
+    throw new Error("Billing service unavailable", { cause: error });
+  }
+
+  const result = await prepareInvestigationRetry(input.investigationId);
+  await captureAnalyticsEvent({
+    distinctId: `investigation:${result.investigationId}`,
+    event: "investigation rerun",
+    organizationId: result.config.organizationId,
+    properties: {
+      $process_person_profile: false,
+      agent_config_version_id: result.config.id,
+      agent_id: result.config.agentId,
+      investigation_id: result.investigationId,
+      provider: result.input.provider,
+    },
+  });
   try {
     const jobId = await (await getBoss()).send(
       investigationQueue,
@@ -152,7 +190,11 @@ export async function queueInvestigationRetry(investigationId: string) {
       { singletonKey: `retry:${result.investigationId}:${Date.now()}` },
     );
     if (!jobId) throw new Error("The investigation retry job was not created");
-    return { investigationId: result.investigationId, jobId };
+    return {
+      investigationId: result.investigationId,
+      jobId,
+      kind: "queued",
+    };
   } catch (error) {
     await failInvestigation(
       result.investigationId,

--- a/apps/control-plane/server/investigations/queue.ts
+++ b/apps/control-plane/server/investigations/queue.ts
@@ -1,6 +1,7 @@
 import {
   consumeInvestigation,
-  refundInvestigation,
+  finalizeInvestigationReservation,
+  reserveInvestigation,
 } from "../../../../packages/core/src/billing/autumn.js";
 import { notifyBillingLimitReached } from "../../../../packages/core/src/billing/notifications.js";
 import { captureAnalyticsEvent } from "../../../../packages/core/src/analytics.js";
@@ -135,24 +136,23 @@ export async function queueInvestigationRetry(input: {
   investigationId: string;
   organizationId: string;
 }): Promise<RetryQueueResult> {
-  let metered = false;
+  let reservation: Awaited<ReturnType<typeof reserveInvestigation>>;
   try {
-    const access = await consumeInvestigation(
+    reservation = await reserveInvestigation(
       input.organizationId,
       input.investigationId,
     );
-    if (!access.allowed) {
+    if (!reservation.allowed) {
       await notifyBillingLimitReached(
         input.organizationId,
-        access.nextResetAt,
+        reservation.nextResetAt,
       ).catch((error: unknown) => {
         console.error("Unable to send billing limit notifications", error);
       });
       return { kind: "blocked" };
     }
-    metered = access.consumed;
   } catch (error) {
-    console.error("Unable to meter investigation rerun", error);
+    console.error("Unable to reserve investigation rerun", error);
     throw new Error("Billing service unavailable", { cause: error });
   }
 
@@ -160,16 +160,34 @@ export async function queueInvestigationRetry(input: {
   try {
     result = await prepareInvestigationRetry(input.investigationId);
   } catch (error) {
-    if (metered) {
-      await refundInvestigation(
-        input.organizationId,
-        input.investigationId,
-      ).catch((refundError: unknown) => {
-        console.error("Unable to refund investigation rerun", refundError);
+    if (reservation.reservationId) {
+      await finalizeInvestigationReservation(
+        reservation.reservationId,
+        "release",
+      ).catch((releaseError: unknown) => {
+        // The provider automatically releases this reservation at expiry.
+        console.error("Unable to release investigation rerun", releaseError);
       });
     }
     throw error;
   }
+
+  if (reservation.reservationId) {
+    try {
+      await finalizeInvestigationReservation(
+        reservation.reservationId,
+        "confirm",
+      );
+    } catch (error) {
+      await failInvestigation(
+        result.investigationId,
+        "Unable to confirm investigation rerun billing",
+      );
+      console.error("Unable to meter investigation rerun", error);
+      throw new Error("Billing service unavailable", { cause: error });
+    }
+  }
+
   await captureAnalyticsEvent({
     distinctId: `investigation:${result.investigationId}`,
     event: "investigation rerun",

--- a/apps/control-plane/server/investigations/queue.ts
+++ b/apps/control-plane/server/investigations/queue.ts
@@ -1,4 +1,7 @@
-import { consumeInvestigation } from "../../../../packages/core/src/billing/autumn.js";
+import {
+  consumeInvestigation,
+  refundInvestigation,
+} from "../../../../packages/core/src/billing/autumn.js";
 import { notifyBillingLimitReached } from "../../../../packages/core/src/billing/notifications.js";
 import { captureAnalyticsEvent } from "../../../../packages/core/src/analytics.js";
 import {
@@ -132,6 +135,7 @@ export async function queueInvestigationRetry(input: {
   investigationId: string;
   organizationId: string;
 }): Promise<RetryQueueResult> {
+  let metered = false;
   try {
     const access = await consumeInvestigation(
       input.organizationId,
@@ -146,12 +150,26 @@ export async function queueInvestigationRetry(input: {
       });
       return { kind: "blocked" };
     }
+    metered = access.consumed;
   } catch (error) {
     console.error("Unable to meter investigation rerun", error);
     throw new Error("Billing service unavailable", { cause: error });
   }
 
-  const result = await prepareInvestigationRetry(input.investigationId);
+  let result: Awaited<ReturnType<typeof prepareInvestigationRetry>>;
+  try {
+    result = await prepareInvestigationRetry(input.investigationId);
+  } catch (error) {
+    if (metered) {
+      await refundInvestigation(
+        input.organizationId,
+        input.investigationId,
+      ).catch((refundError: unknown) => {
+        console.error("Unable to refund investigation rerun", refundError);
+      });
+    }
+    throw error;
+  }
   await captureAnalyticsEvent({
     distinctId: `investigation:${result.investigationId}`,
     event: "investigation rerun",

--- a/apps/control-plane/server/investigations/queue.ts
+++ b/apps/control-plane/server/investigations/queue.ts
@@ -179,6 +179,13 @@ export async function queueInvestigationRetry(input: {
         "confirm",
       );
     } catch (error) {
+      await finalizeInvestigationReservation(
+        reservation.reservationId,
+        "release",
+      ).catch((releaseError: unknown) => {
+        // The provider automatically releases this reservation at expiry.
+        console.error("Unable to release investigation rerun", releaseError);
+      });
       await failInvestigation(
         result.investigationId,
         "Unable to confirm investigation rerun billing",

--- a/apps/control-plane/src/pages/agent-detail.tsx
+++ b/apps/control-plane/src/pages/agent-detail.tsx
@@ -19,7 +19,6 @@ import {
   fetchAgent,
   fetchAgentOptions,
   relativeTime,
-  retryInvestigation,
   setAgentEnabled,
 } from "../agents-api";
 import {
@@ -30,7 +29,6 @@ import { AppShell } from "../components/app-shell";
 import { AgentDetailSkeleton } from "../components/screen-skeletons";
 import {
   Badge,
-  Button,
   DataTable,
   Panel,
   Switch,
@@ -310,28 +308,8 @@ export function AgentDetailPage() {
   const [loading, setLoading] = useState(true);
   const [notFound, setNotFound] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [retryError, setRetryError] = useState<string | null>(null);
-  const [retryingId, setRetryingId] = useState<string | null>(null);
   const [updatingEnabled, setUpdatingEnabled] = useState(false);
   useDocumentTitle(agent?.name ?? "Agent");
-
-  async function retry(investigationId: string) {
-    if (!agentId || retryingId) return;
-    setRetryError(null);
-    setRetryingId(investigationId);
-    try {
-      await retryInvestigation(agentId, investigationId);
-      setAgent(await fetchAgent(agentId));
-    } catch (caught: unknown) {
-      setRetryError(
-        caught instanceof Error
-          ? caught.message
-          : "Unable to retry investigation",
-      );
-    } finally {
-      setRetryingId(null);
-    }
-  }
 
   async function updateEnabled(enabled: boolean) {
     if (!agentId || !agent || updatingEnabled || enabled === agent.enabled) return;
@@ -432,25 +410,6 @@ export function AgentDetailPage() {
       ),
     },
     {
-      align: "right",
-      header: "Action",
-      key: "action",
-      render: (investigation) =>
-        investigation.status === "failed" ? (
-          <Button
-            aria-label={`Retry ${investigation.title}`}
-            disabled={retryingId !== null && retryingId !== investigation.id}
-            loading={retryingId === investigation.id}
-            onClick={() => void retry(investigation.id)}
-            size="small"
-            variant="secondary"
-          >
-            Retry
-          </Button>
-        ) : null,
-      width: "96px",
-    },
-    {
       header: "Status",
       key: "status",
       render: (investigation) => (
@@ -526,7 +485,6 @@ export function AgentDetailPage() {
           <h2 id="investigation-title">Investigations</h2>
           <span>{agent.investigations.length} total</span>
         </header>
-        {retryError ? <p className="formError">{retryError}</p> : null}
         <DataTable
           aria-label="Agent investigations"
           columns={investigationColumns}

--- a/apps/control-plane/src/pages/investigation-detail.tsx
+++ b/apps/control-plane/src/pages/investigation-detail.tsx
@@ -239,7 +239,7 @@ export function InvestigationDetailPage() {
   const [loading, setLoading] = useState(true);
   const [notFound, setNotFound] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [retrying, setRetrying] = useState(false);
+  const [rerunning, setRerunning] = useState(false);
   useDocumentTitle(detail?.investigation.title ?? "Investigation");
 
   async function load() {
@@ -248,9 +248,9 @@ export function InvestigationDetailPage() {
     setDetail(loaded);
   }
 
-  async function retry() {
-    if (!agentId || !investigationId || retrying) return;
-    setRetrying(true);
+  async function rerun() {
+    if (!agentId || !investigationId || rerunning) return;
+    setRerunning(true);
     setError(null);
     try {
       await retryInvestigation(agentId, investigationId);
@@ -259,10 +259,10 @@ export function InvestigationDetailPage() {
       setError(
         caught instanceof Error
           ? caught.message
-          : "Unable to retry investigation",
+          : "Unable to rerun investigation",
       );
     } finally {
-      setRetrying(false);
+      setRerunning(false);
     }
   }
 
@@ -397,9 +397,21 @@ export function InvestigationDetailPage() {
           </Link>
           <div className="investigationHero__title">
             <h1>{investigation.title}</h1>
-            {showHeroStatus ? (
-              <Badge tone={status.tone}>{status.label}</Badge>
-            ) : null}
+            <div className="investigationHero__actions">
+              {showHeroStatus ? (
+                <Badge tone={status.tone}>{status.label}</Badge>
+              ) : null}
+              {!isLive && !investigation.isReplay ? (
+                <Button
+                  loading={rerunning}
+                  onClick={() => void rerun()}
+                  size="small"
+                  variant="secondary"
+                >
+                  Rerun with current configuration
+                </Button>
+              ) : null}
+            </div>
           </div>
           <p>
             {triggerContext(investigation.input)} · Started{" "}
@@ -441,16 +453,6 @@ export function InvestigationDetailPage() {
                         "Responder could not complete this investigation."}
                     </p>
                   </div>
-                  {!investigation.isReplay ? (
-                    <Button
-                      loading={retrying}
-                      onClick={() => void retry()}
-                      size="small"
-                      variant="secondary"
-                    >
-                      Retry investigation
-                    </Button>
-                  ) : null}
                 </div>
               </Panel>
             </section>

--- a/apps/control-plane/src/styles.css
+++ b/apps/control-plane/src/styles.css
@@ -2988,6 +2988,13 @@ button:disabled {
   gap: 24px;
 }
 
+.investigationHero__actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex: 0 0 auto;
+}
+
 .investigationHero h1 {
   margin: 0;
   color: var(--ds-text-primary);

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -16,6 +16,7 @@ activity can be separated from other products sharing the PostHog project.
 | `agent created` | A new agent and its initial configuration are persisted | `agent_id`, `trigger_kind`, `model`, `enabled`, `pr_mode` |
 | `prompt copied` | A user clicks **Copy prompt** in Slack | `issue_id`, `issue_found`, `team_id`, `channel_id`, `surface` |
 | `investigation created` | A new investigation or replay is persisted and accepted for processing | `investigation_id`, `agent_id`, `provider`, `is_replay`, `source_investigation_id` |
+| `investigation rerun` | A finished investigation is accepted for another run with the active Agent configuration | `investigation_id`, `agent_id`, `agent_config_version_id`, `provider` |
 
 Events associated with a workspace include `organization_id` and the PostHog
 `organization` group. Authenticated events use the Better Auth user ID as their

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -67,6 +67,14 @@ Agent configuration and runtime profiles are immutable versions. An
 investigation pins both versions when it is created, so later configuration
 changes cannot alter a queued or replayed run.
 
+A workspace member can rerun a finished investigation from its detail page.
+The rerun reuses the original provider input but replaces the investigation's
+report and trace with a run against the Agent's active configuration, the active
+runtime profile, current provider data, and current repository heads. Previous
+issue records remain available after their investigation links are replaced.
+Reruns consume the normal investigation allowance and use normal delivery and
+external-action behavior.
+
 Postgres and pg-boss hold investigation, remediation, and follow-up work.
 Delivery may be at least once, so handlers use idempotency keys and state
 transitions rather than assuming a job runs exactly once.

--- a/packages/core/src/analytics.ts
+++ b/packages/core/src/analytics.ts
@@ -11,6 +11,7 @@ export interface AnalyticsEvent {
     | "agent created"
     | "integration connected"
     | "investigation created"
+    | "investigation rerun"
     | "organization created"
     | "pr merged"
     | "pr opened"

--- a/packages/core/src/billing/autumn.test.ts
+++ b/packages/core/src/billing/autumn.test.ts
@@ -3,6 +3,7 @@ import type { Customer } from "autumn-js";
 import {
   consumeInvestigation,
   getBillingSummary,
+  reserveInvestigation,
   summarizeBillingCustomer,
 } from "./autumn.js";
 
@@ -30,8 +31,15 @@ describe("Autumn billing", () => {
     ).resolves.toEqual({
       allowed: true,
       configured: false,
-      consumed: false,
       nextResetAt: null,
+    });
+    await expect(
+      reserveInvestigation("organization-1", "investigation-1"),
+    ).resolves.toEqual({
+      allowed: true,
+      configured: false,
+      nextResetAt: null,
+      reservationId: null,
     });
   });
 
@@ -88,7 +96,6 @@ describe("Autumn billing", () => {
     ).resolves.toEqual({
       allowed: true,
       configured: false,
-      consumed: false,
       nextResetAt: null,
     });
   });

--- a/packages/core/src/billing/autumn.test.ts
+++ b/packages/core/src/billing/autumn.test.ts
@@ -30,6 +30,7 @@ describe("Autumn billing", () => {
     ).resolves.toEqual({
       allowed: true,
       configured: false,
+      consumed: false,
       nextResetAt: null,
     });
   });
@@ -87,6 +88,7 @@ describe("Autumn billing", () => {
     ).resolves.toEqual({
       allowed: true,
       configured: false,
+      consumed: false,
       nextResetAt: null,
     });
   });

--- a/packages/core/src/billing/autumn.ts
+++ b/packages/core/src/billing/autumn.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { Autumn, type Customer } from "autumn-js";
 
 export const INVESTIGATIONS_FEATURE_ID = "responder_investigations";
@@ -25,8 +26,11 @@ export interface BillingSummary {
 export interface InvestigationAccess {
   allowed: boolean;
   configured: boolean;
-  consumed: boolean;
   nextResetAt: number | null;
+}
+
+export interface InvestigationReservationAccess extends InvestigationAccess {
+  reservationId: string | null;
 }
 
 let autumnClient: Autumn | undefined;
@@ -76,7 +80,6 @@ export async function consumeInvestigation(
     return {
       allowed: true,
       configured: false,
-      consumed: false,
       nextResetAt: null,
     };
   }
@@ -88,7 +91,6 @@ export async function consumeInvestigation(
     return {
       allowed: true,
       configured: false,
-      consumed: false,
       nextResetAt: null,
     };
   }
@@ -100,7 +102,6 @@ export async function consumeInvestigation(
     return {
       allowed: true,
       configured: true,
-      consumed: false,
       nextResetAt: null,
     };
   }
@@ -116,26 +117,88 @@ export async function consumeInvestigation(
   return {
     allowed: result.allowed,
     configured: true,
-    consumed: result.allowed,
     nextResetAt: result.balance?.nextResetAt ?? null,
   };
 }
 
-export async function refundInvestigation(
+const investigationReservationLifetimeMs = 5 * 60 * 1000;
+
+export async function reserveInvestigation(
   organizationId: string,
   investigationId: string,
-): Promise<void> {
-  if (!billingIsEnabled()) return;
-  const client = requireAutumnClient();
-  await client.track({
+): Promise<InvestigationReservationAccess> {
+  if (!billingIsEnabled()) {
+    return {
+      allowed: true,
+      configured: false,
+      nextResetAt: null,
+      reservationId: null,
+    };
+  }
+  const client = getAutumnClient();
+  if (!client) {
+    if (process.env.NODE_ENV === "production") {
+      throw new Error("AUTUMN_SECRET_KEY is required in production");
+    }
+    return {
+      allowed: true,
+      configured: false,
+      nextResetAt: null,
+      reservationId: null,
+    };
+  }
+
+  const customer = await getOrCreateCustomer(client, organizationId);
+  if (customer.id === null) {
+    return {
+      allowed: true,
+      configured: true,
+      nextResetAt: null,
+      reservationId: null,
+    };
+  }
+
+  const reservationId = `investigation-rerun:${randomUUID()}`;
+  // An expiring provider-side lock makes abandoned or failed rerun claims
+  // self-releasing even if this process cannot send a release request.
+  const result = await client.check({
     customerId: organizationId,
     featureId: INVESTIGATIONS_FEATURE_ID,
-    value: -1,
-    properties: {
-      investigationId,
-      reason: "rerun_not_started",
+    requiredBalance: 1,
+    sendEvent: true,
+    properties: { investigationId },
+    lock: {
+      enabled: true,
+      expiresAt: Date.now() + investigationReservationLifetimeMs,
+      lockId: reservationId,
     },
   });
+
+  return {
+    allowed: result.allowed,
+    configured: true,
+    nextResetAt: result.balance?.nextResetAt ?? null,
+    reservationId: result.allowed ? reservationId : null,
+  };
+}
+
+export async function finalizeInvestigationReservation(
+  reservationId: string,
+  action: "confirm" | "release",
+): Promise<void> {
+  if (!billingIsEnabled()) return;
+  await requireAutumnClient().balances.finalize(
+    {
+      action,
+      lockId: reservationId,
+    },
+    {
+      retries: {
+        strategy: "backoff",
+        retryConnectionErrors: true,
+      },
+    },
+  );
 }
 
 export function summarizeBillingCustomer(customer: Customer): BillingSummary {

--- a/packages/core/src/billing/autumn.ts
+++ b/packages/core/src/billing/autumn.ts
@@ -25,6 +25,7 @@ export interface BillingSummary {
 export interface InvestigationAccess {
   allowed: boolean;
   configured: boolean;
+  consumed: boolean;
   nextResetAt: number | null;
 }
 
@@ -72,21 +73,36 @@ export async function consumeInvestigation(
   investigationId: string,
 ): Promise<InvestigationAccess> {
   if (!billingIsEnabled()) {
-    return { allowed: true, configured: false, nextResetAt: null };
+    return {
+      allowed: true,
+      configured: false,
+      consumed: false,
+      nextResetAt: null,
+    };
   }
   const client = getAutumnClient();
   if (!client) {
     if (process.env.NODE_ENV === "production") {
       throw new Error("AUTUMN_SECRET_KEY is required in production");
     }
-    return { allowed: true, configured: false, nextResetAt: null };
+    return {
+      allowed: true,
+      configured: false,
+      consumed: false,
+      nextResetAt: null,
+    };
   }
 
   const customer = await getOrCreateCustomer(client, organizationId);
   if (customer.id === null) {
     // Autumn's SDK fails open during a provider outage. Preserve that behavior so
     // incident response is not taken down by the billing system.
-    return { allowed: true, configured: true, nextResetAt: null };
+    return {
+      allowed: true,
+      configured: true,
+      consumed: false,
+      nextResetAt: null,
+    };
   }
 
   const result = await client.check({
@@ -100,8 +116,26 @@ export async function consumeInvestigation(
   return {
     allowed: result.allowed,
     configured: true,
+    consumed: result.allowed,
     nextResetAt: result.balance?.nextResetAt ?? null,
   };
+}
+
+export async function refundInvestigation(
+  organizationId: string,
+  investigationId: string,
+): Promise<void> {
+  if (!billingIsEnabled()) return;
+  const client = requireAutumnClient();
+  await client.track({
+    customerId: organizationId,
+    featureId: INVESTIGATIONS_FEATURE_ID,
+    value: -1,
+    properties: {
+      investigationId,
+      reason: "rerun_not_started",
+    },
+  });
 }
 
 export function summarizeBillingCustomer(customer: Customer): BillingSummary {

--- a/packages/core/src/db/investigations.test.ts
+++ b/packages/core/src/db/investigations.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import { getDatabase } from "./client.js";
 import {
   customMcpCredentialUpdateFailureEvent,
   customMcpConnectionsLoadedEvent,
@@ -8,8 +9,13 @@ import {
   customMcpTokenRefreshSuccessEvent,
   customMcpReconnectError,
   investigationCanBeRetried,
+  prepareInvestigationRetry,
   replayReportMarkdownUpdate,
 } from "./investigations.js";
+
+vi.mock("./client.js", () => ({
+  getDatabase: vi.fn(),
+}));
 
 describe("investigation retry", () => {
   it("allows terminal investigations to run again", () => {
@@ -20,6 +26,86 @@ describe("investigation retry", () => {
   it("does not allow a duplicate run while work is active", () => {
     expect(investigationCanBeRetried("pending")).toBe(false);
     expect(investigationCanBeRetried("investigating")).toBe(false);
+  });
+
+  it("switches to the active agent configuration without deleting old issues", async () => {
+    const sourceInput = {
+      agentId: "agent-1",
+      body: "Original alert",
+      externalEventId: "event-1",
+      provider: "sentry" as const,
+      title: "Production error",
+    };
+    const investigationQuery = {
+      from: vi.fn(),
+      innerJoin: vi.fn(),
+      where: vi.fn(),
+      limit: vi.fn().mockResolvedValue([{
+        agentId: "agent-1",
+        configId: "active-config",
+        createLinearTickets: true,
+        id: "investigation-1",
+        input: sourceInput,
+        linearIssueTemplate: "Current template",
+        model: "current-model",
+        organizationId: "organization-1",
+        prMode: "always",
+        prompt: "Current instructions",
+        status: "resolved",
+      }]),
+    };
+    investigationQuery.from.mockReturnValue(investigationQuery);
+    investigationQuery.innerJoin.mockReturnValue(investigationQuery);
+    investigationQuery.where.mockReturnValue(investigationQuery);
+    const profileQuery = {
+      from: vi.fn(),
+      innerJoin: vi.fn(),
+      where: vi.fn(),
+      limit: vi.fn().mockResolvedValue([{ id: "active-runtime" }]),
+    };
+    profileQuery.from.mockReturnValue(profileQuery);
+    profileQuery.innerJoin.mockReturnValue(profileQuery);
+    profileQuery.where.mockReturnValue(profileQuery);
+    const select = vi
+      .fn()
+      .mockReturnValueOnce(investigationQuery)
+      .mockReturnValueOnce(profileQuery);
+    const deleteWhere = vi.fn().mockResolvedValue([]);
+    const set = vi.fn(() => ({
+      where: vi.fn(() => ({
+        returning: vi.fn().mockResolvedValue([{ id: "investigation-1" }]),
+      })),
+    }));
+    const tx = {
+      delete: vi.fn(() => ({ where: deleteWhere })),
+      select,
+      update: vi.fn(() => ({ set })),
+    };
+    const transaction = vi.fn(async (callback) => callback(tx));
+    vi.mocked(getDatabase).mockReturnValue({ transaction } as never);
+
+    await expect(
+      prepareInvestigationRetry("investigation-1"),
+    ).resolves.toEqual({
+      config: {
+        agentId: "agent-1",
+        createLinearTickets: true,
+        id: "active-config",
+        linearIssueTemplate: "Current template",
+        model: "current-model",
+        organizationId: "organization-1",
+        prMode: "always",
+        prompt: "Current instructions",
+      },
+      input: sourceInput,
+      investigationId: "investigation-1",
+      runtimeProfileId: "active-runtime",
+    });
+    expect(tx.delete).toHaveBeenCalledTimes(2);
+    expect(set).toHaveBeenCalledWith(expect.objectContaining({
+      agentConfigVersionId: "active-config",
+      runtimeProfileId: "active-runtime",
+    }));
   });
 });
 

--- a/packages/core/src/db/investigations.test.ts
+++ b/packages/core/src/db/investigations.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
 import { getDatabase } from "./client.js";
 import {
+  investigationIssues,
+  investigationTraceEvents,
+  issues,
+} from "./schema.js";
+import {
   customMcpCredentialUpdateFailureEvent,
   customMcpConnectionsLoadedEvent,
   customMcpRuntimeAccountSkippedEvent,
@@ -101,7 +106,9 @@ describe("investigation retry", () => {
       investigationId: "investigation-1",
       runtimeProfileId: "active-runtime",
     });
-    expect(tx.delete).toHaveBeenCalledTimes(2);
+    expect(tx.delete).toHaveBeenNthCalledWith(1, investigationIssues);
+    expect(tx.delete).toHaveBeenNthCalledWith(2, investigationTraceEvents);
+    expect(tx.delete).not.toHaveBeenCalledWith(issues);
     expect(set).toHaveBeenCalledWith(expect.objectContaining({
       agentConfigVersionId: "active-config",
       runtimeProfileId: "active-runtime",

--- a/packages/core/src/db/investigations.ts
+++ b/packages/core/src/db/investigations.ts
@@ -46,7 +46,6 @@ import {
   investigationReplayRequests,
   investigationTraceEvents,
   investigations,
-  issues,
   repositories,
   runtimeProfiles,
   webhookReceipts,
@@ -301,10 +300,13 @@ export async function prepareInvestigationRetry(
       })
       .from(investigations)
       .innerJoin(
-        agentConfigVersions,
-        eq(agentConfigVersions.id, investigations.agentConfigVersionId),
+        agents,
+        eq(agents.id, investigations.agentId),
       )
-      .innerJoin(agents, eq(agents.id, investigations.agentId))
+      .innerJoin(
+        agentConfigVersions,
+        eq(agentConfigVersions.id, agents.activeVersionId),
+      )
       .where(eq(investigations.id, investigationId))
       .limit(1);
     const investigation = rows[0];
@@ -334,34 +336,9 @@ export async function prepareInvestigationRetry(
     const activeProfile = activeProfiles[0];
     if (!activeProfile) throw new InstanceRuntimeProfileError();
 
-    const previousLinks = await tx
-      .select({
-        issueId: investigationIssues.issueId,
-        relationship: investigationIssues.relationship,
-      })
-      .from(investigationIssues)
-      .where(eq(investigationIssues.investigationId, investigationId));
     await tx
       .delete(investigationIssues)
       .where(eq(investigationIssues.investigationId, investigationId));
-    for (const link of previousLinks) {
-      if (link.relationship !== "new") continue;
-      const remainingLinks = await tx
-        .select({ issueId: investigationIssues.issueId })
-        .from(investigationIssues)
-        .where(eq(investigationIssues.issueId, link.issueId))
-        .limit(1);
-      if (remainingLinks.length === 0) {
-        await tx
-          .delete(issues)
-          .where(
-            and(
-              eq(issues.id, link.issueId),
-              eq(issues.organizationId, investigation.organizationId),
-            ),
-          );
-      }
-    }
 
     await tx
       .delete(investigationTraceEvents)
@@ -370,12 +347,14 @@ export async function prepareInvestigationRetry(
     const reset = await tx
       .update(investigations)
       .set({
+        agentConfigVersionId: investigation.configId,
         status: "pending",
         finding: null,
         structuredReport: null,
         reportMarkdown: null,
         eveSessionId: null,
         failureReason: null,
+        slackTraceItems: [],
         startedAt: null,
         completedAt: null,
         runtimeProfileId: activeProfile.id,


### PR DESCRIPTION
## Summary
- let workspace members rerun a finished investigation from its detail page
- rerun against the active agent configuration and current data while retaining historical issue records
- meter reruns and preserve normal Slack, pull request, and Linear behavior

## Validation
- pnpm typecheck
- pnpm lint
- pnpm test
- pnpm build

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Let workspace members rerun finished investigations from the investigation detail page. Reruns use the active Agent configuration and current data, meter against the investigation allowance, and keep Slack/PR/Linear behavior and existing issue records unchanged.

- UI: Add “Rerun with current configuration” in the investigation hero (hidden for live runs and replays). Remove the retry action from the agent detail list. Minor hero layout CSS.
- API: POST /api/agents/:agentId/investigations/:investigationId/retry reads the active tenant and returns 202 with sessionId when queued, 402 when the monthly allowance is exhausted (no run started), 409 when the investigation is not terminal, and 502 with “Unable to rerun investigation” on errors.
- Billing/Queue/DB: Reserve rerun usage before claiming the rerun, confirm before enqueue, release the reservation on preparation or confirmation failure, and notify on limit reached. Fail the investigation and surface “Billing service unavailable” if confirmation cannot complete. prepareInvestigationRetry switches to the Agent’s active configuration and runtime profile, clears trace and link tables, resets fields (including slackTraceItems), preserves issue records, and emits “investigation rerun”.
- Docs/Tests: Add the “investigation rerun” analytics event and tests for endpoint statuses, blocked billing, reservation confirm/release, configuration/runtime switching, and analytics emission.

- Rollout: Update internal callers of queueInvestigationRetry to pass organizationId and handle the blocked result. Clients must handle HTTP 402 from the rerun endpoint and display the billing limit message.

<sup>Written for commit d728c9f7f7697f5b7c4aa50158352217d7488276. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/responder-oss/pull/53?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

