### PR TITLE
Fix Vercel tool parameter schema

### DIFF
--- a/apps/worker/src/vercel.test.ts
+++ b/apps/worker/src/vercel.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   buildVercelReadUrl,
+  createVercelTools,
   executeVercelRead,
   searchVercelOperations,
 } from "./vercel.js";
@@ -34,6 +35,70 @@ describe("Vercel read tools", () => {
         }),
       ]),
     );
+  });
+
+  it("exposes strict-compatible parameter arrays and converts them internally", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(Response.json({ id: "prj-1" }));
+    vi.stubGlobal("fetch", fetchMock);
+    const callTool = createVercelTools([connection]).find(
+      ({ name }) => name === "call_vercel_api",
+    )!;
+
+    expect(callTool.parameters).toMatchObject({
+      properties: {
+        pathParameters: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              name: { type: "string" },
+              value: expect.any(Object),
+            },
+            required: ["name", "value"],
+            additionalProperties: false,
+          },
+        },
+        queryParameters: { type: "array" },
+      },
+      required: expect.arrayContaining(["pathParameters", "queryParameters"]),
+      additionalProperties: false,
+    });
+
+    await callTool.invoke(
+      undefined as never,
+      JSON.stringify({
+        accountId: connection.accountId,
+        operationId: "getProject",
+        pathParameters: [{ name: "idOrName", value: "prj-1" }],
+        queryParameters: [{ name: "teamId", value: "attacker-team" }],
+      }),
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const requestedUrl = new URL(fetchMock.mock.calls[0]![0] as URL);
+    expect(requestedUrl.pathname).toBe("/v9/projects/prj-1");
+    expect(requestedUrl.searchParams.get("teamId")).toBe("team-1");
+  });
+
+  it("rejects duplicate model-supplied parameter names", async () => {
+    const callTool = createVercelTools([connection]).find(
+      ({ name }) => name === "call_vercel_api",
+    )!;
+
+    await expect(
+      callTool.invoke(
+        undefined as never,
+        JSON.stringify({
+          accountId: connection.accountId,
+          operationId: "getProject",
+          pathParameters: [
+            { name: "idOrName", value: "prj-1" },
+            { name: "idOrName", value: "prj-other" },
+          ],
+          queryParameters: [],
+        }),
+      ),
+    ).resolves.toContain("Duplicate Vercel path parameter: idOrName");
   });
 
   it("builds a fixed-origin, team-scoped project request", () => {

--- a/apps/worker/src/vercel.ts
+++ b/apps/worker/src/vercel.ts
@@ -432,6 +432,31 @@ const parameterValueSchema = z.union([
   z.boolean(),
   z.array(z.union([z.string(), z.number(), z.boolean()])),
 ]);
+const parameterEntrySchema = z.object({
+  name: z
+    .string()
+    .trim()
+    .min(1)
+    .max(200)
+    .describe("Exact parameter name returned by search_vercel_api"),
+  value: parameterValueSchema.describe(
+    "Parameter value using the type returned by search_vercel_api",
+  ),
+});
+
+function parameterEntriesToRecord(
+  entries: Array<z.infer<typeof parameterEntrySchema>>,
+  location: "path" | "query",
+): Record<string, ParameterValue> {
+  const parameters = Object.create(null) as Record<string, ParameterValue>;
+  for (const { name, value } of entries) {
+    if (Object.hasOwn(parameters, name)) {
+      throw new Error(`Duplicate Vercel ${location} parameter: ${name}`);
+    }
+    parameters[name] = value;
+  }
+  return parameters;
+}
 
 export function createVercelTools(connections: RuntimeVercelConnection[]) {
   if (connections.length === 0) return [];
@@ -458,16 +483,29 @@ export function createVercelTools(connections: RuntimeVercelConnection[]) {
     description: `Execute one operation returned by search_vercel_api. Only generated GET operations are accepted. Connected accounts: ${accountDescription}`,
     parameters: z.object({
       accountId: z.string().uuid().optional(),
-      operationId: z.string().trim().min(1).max(200),
-      pathParameters: z.record(z.string(), parameterValueSchema).default({}),
-      queryParameters: z.record(z.string(), parameterValueSchema).default({}),
+      operationId: z
+        .string()
+        .trim()
+        .min(1)
+        .max(200)
+        .describe("Exact operation ID returned by search_vercel_api"),
+      pathParameters: z
+        .array(parameterEntrySchema)
+        .max(30)
+        .default([])
+        .describe("Path parameters returned for the selected operation"),
+      queryParameters: z
+        .array(parameterEntrySchema)
+        .max(30)
+        .default([])
+        .describe("Query parameters returned for the selected operation"),
     }),
     async execute({ accountId, operationId, pathParameters, queryParameters }) {
       return executeVercelRead({
         connection: selectedConnection(connections, accountId),
         operationId,
-        pathParameters,
-        queryParameters,
+        pathParameters: parameterEntriesToRecord(pathParameters, "path"),
+        queryParameters: parameterEntriesToRecord(queryParameters, "query"),
       });
     },
   });


### PR DESCRIPTION
## Summary
- expose Vercel path and query parameters as strict-compatible name/value arrays
- convert parameter entries internally before catalog validation
- reject duplicate parameter names and cover the generated schema with regression tests

## Validation
- pnpm typecheck
- pnpm lint
- pnpm test

Hosted deployment PR: https://github.com/superloglabs/responder/pull/146