### PR TITLE
Enable investigation sandbox capabilities

### DIFF
--- a/apps/worker/src/investigate.test.ts
+++ b/apps/worker/src/investigate.test.ts
@@ -115,9 +115,13 @@ describe("sandbox agent configuration", () => {
 
   it("gives investigations and replays the same sandbox capabilities", () => {
     expect(investigationCapabilities(true).map(({ type }) => type)).toEqual([
+      "filesystem",
+      "shell",
       "compaction",
     ]);
     expect(investigationCapabilities(false).map(({ type }) => type)).toEqual([
+      "filesystem",
+      "shell",
       "compaction",
     ]);
   });

--- a/apps/worker/src/investigate.ts
+++ b/apps/worker/src/investigate.ts
@@ -171,9 +171,7 @@ export function sandboxAgentConfig(
 
 export function investigationCapabilities(replay: boolean) {
   void replay;
-  return Capabilities.default().filter(
-    (capability) => capability.type === "compaction",
-  );
+  return Capabilities.default();
 }
 
 export function investigationInstructions(input: {


### PR DESCRIPTION
## Summary

- expose the standard filesystem, shell, and compaction capabilities to investigations
- keep replay runs aligned with normal investigations
- update the focused capability coverage

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables the default sandbox capability set for investigations and replays. Previously investigations only allowed compaction; now filesystem and shell are included, and replays match investigations.

- New Features
- Both investigations and replays receive the default capability set.
- The sandbox now permits filesystem and shell access in addition to compaction.
- Expands permissions; ensure environments expect filesystem and shell usage.

<sup>Written for commit defc5caeae693f9828bac7f654569f8a26fd0fbd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/responder-oss/pull/55?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

