### PR TITLE
Install Python in sandbox environments

### DIFF
--- a/apps/worker/src/sandbox.test.ts
+++ b/apps/worker/src/sandbox.test.ts
@@ -73,6 +73,28 @@ describe("Daytona sandbox preparation", () => {
       }),
     );
   });
+
+  it("reports sandbox preparation command failures", async () => {
+    const session = {
+      execCommand: vi.fn().mockResolvedValue(
+        "Chunk ID: abc123\nProcess exited with code 1\nOutput:\npython3 unavailable\n",
+      ),
+    } as unknown as DaytonaSandboxSession;
+
+    await expect(prepareDaytonaSandbox(session)).rejects.toThrow(
+      "Unable to install git, Python 3, and ripgrep in Daytona: python3 unavailable",
+    );
+  });
+
+  it("rejects sandbox output without a successful exit marker", async () => {
+    const session = {
+      execCommand: vi.fn().mockResolvedValue("unexpected output"),
+    } as unknown as DaytonaSandboxSession;
+
+    await expect(prepareDaytonaSandbox(session)).rejects.toThrow(
+      "Unable to install git, Python 3, and ripgrep in Daytona",
+    );
+  });
 });
 
 describe("Daytona sandbox cleanup", () => {

--- a/apps/worker/src/sandbox.test.ts
+++ b/apps/worker/src/sandbox.test.ts
@@ -52,7 +52,7 @@ function cleanupHarness(options?: {
 }
 
 describe("Daytona sandbox preparation", () => {
-  it("ensures git and ripgrep are installed before the agent starts", async () => {
+  it("ensures investigation tools are installed before the agent starts", async () => {
     const session = {
       execCommand: vi.fn().mockResolvedValue(
         "Chunk ID: abc123\nWall time: 0.0100 seconds\nProcess exited with code 0\nOutput:\n",
@@ -62,7 +62,14 @@ describe("Daytona sandbox preparation", () => {
     await expect(prepareDaytonaSandbox(session)).resolves.toBeUndefined();
     expect(session.execCommand).toHaveBeenCalledWith(
       expect.objectContaining({
-        cmd: expect.stringContaining("install -y -qq git ripgrep"),
+        cmd: expect.stringContaining(
+          "command -v git >/dev/null 2>&1 && command -v python3 >/dev/null 2>&1 && command -v rg >/dev/null 2>&1",
+        ),
+      }),
+    );
+    expect(session.execCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cmd: expect.stringContaining("install -y -qq git python3 ripgrep"),
       }),
     );
   });

--- a/apps/worker/src/sandbox.ts
+++ b/apps/worker/src/sandbox.ts
@@ -136,19 +136,20 @@ export async function prepareDaytonaSandbox(
   const output = await session.execCommand({
     cmd: [
       "set -eu",
-      "if command -v git >/dev/null 2>&1 && command -v rg >/dev/null 2>&1; then exit 0; fi",
-      "if ! command -v apt-get >/dev/null 2>&1; then echo 'git or ripgrep is unavailable and apt-get is missing' >&2; exit 1; fi",
+      "if command -v git >/dev/null 2>&1 && command -v python3 >/dev/null 2>&1 && command -v rg >/dev/null 2>&1; then exit 0; fi",
+      "if ! command -v apt-get >/dev/null 2>&1; then echo 'git, Python 3, or ripgrep is unavailable and apt-get is missing' >&2; exit 1; fi",
       "if [ \"$(id -u)\" -eq 0 ]; then",
       "  apt-get update -qq",
-      "  DEBIAN_FRONTEND=noninteractive apt-get install -y -qq git ripgrep",
+      "  DEBIAN_FRONTEND=noninteractive apt-get install -y -qq git python3 ripgrep",
       "elif command -v sudo >/dev/null 2>&1; then",
       "  sudo apt-get update -qq",
-      "  sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq git ripgrep",
+      "  sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq git python3 ripgrep",
       "else",
-      "  echo 'git and ripgrep installation require root access' >&2",
+      "  echo 'git, Python 3, and ripgrep installation require root access' >&2",
       "  exit 1",
       "fi",
       "command -v git >/dev/null",
+      "command -v python3 >/dev/null",
       "command -v rg >/dev/null",
     ].join("\n"),
     maxOutputTokens: 2_000,
@@ -157,7 +158,7 @@ export async function prepareDaytonaSandbox(
   if (!execSucceeded(output)) {
     const detail = output.split("\nOutput:\n", 2)[1]?.trim();
     throw new Error(
-      `Unable to install git and ripgrep in Daytona${detail ? `: ${detail}` : ""}`,
+      `Unable to install git, Python 3, and ripgrep in Daytona${detail ? `: ${detail}` : ""}`,
     );
   }
 }


### PR DESCRIPTION
## Summary

- require `python3` alongside the existing sandbox command-line tools
- install Python automatically when the base image does not provide it
- cover both the availability check and package installation command

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Python 3 to the Daytona sandbox prerequisites and auto-installs it when missing. Previously we only ensured git and ripgrep; now we also require Python 3 and return clear errors if installation or commands fail.

**New Features**
- Requires apt-get and root/sudo for installs; otherwise exits with an explicit message.
- Verifies git, Python 3, and ripgrep are on PATH after install.
- Extends tests to cover failure cases (missing Python 3 and unexpected output) and the updated install commands.

<sup>Written for commit 352dbbe5e2153ff9e9915e386e0321cdae1ebe00. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/responder-oss/pull/57?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

