### PR TITLE
Refresh GitHub repositories in agent context

### DIFF
--- a/apps/control-plane/server/agents/routes.test.ts
+++ b/apps/control-plane/server/agents/routes.test.ts
@@ -6,7 +6,9 @@ import {
   setAgentEnabled,
 } from "../../../../packages/core/src/db/agents.js";
 import {
+  listConnectedIntegrationAccounts,
   listConnectedIntegrationAccountCredentials,
+  replaceRepositories,
   replaceIntegrationResources,
 } from "../../../../packages/core/src/db/integrations.js";
 import {
@@ -22,6 +24,7 @@ import {
 import { getActiveTenant } from "../tenant.js";
 import { queueInvestigationRetry } from "../investigations/queue.js";
 import { listSlackChannels } from "../integrations/slack.js";
+import { listGitHubRepositories } from "../integrations/github.js";
 import {
   createDaytonaWorkspaceSecret,
   deleteDaytonaWorkspaceSecret,
@@ -42,8 +45,10 @@ vi.mock("../../../../packages/core/src/db/agents.js", () => ({
 }));
 vi.mock("../../../../packages/core/src/db/integrations.js", () => ({
   getSlackChannelConnection: vi.fn(),
+  listConnectedIntegrationAccounts: vi.fn(),
   listConnectedIntegrationAccountCredentials: vi.fn(),
   markSlackChannelJoined: vi.fn(),
+  replaceRepositories: vi.fn(),
   replaceIntegrationResources: vi.fn(),
 }));
 vi.mock("../../../../packages/core/src/db/investigations.js", () => ({
@@ -67,6 +72,9 @@ vi.mock("../integrations/slack.js", () => ({
       this.slackCode = slackCode;
     }
   },
+}));
+vi.mock("../integrations/github.js", () => ({
+  listGitHubRepositories: vi.fn(),
 }));
 vi.mock("../tenant.js", () => ({
   getActiveTenant: vi.fn(),
@@ -506,6 +514,82 @@ describe("Slack channel option refresh", () => {
       code: "slack_refresh_failed",
     });
     expect(replaceIntegrationResources).not.toHaveBeenCalled();
+    expect(listAgentOptions).not.toHaveBeenCalled();
+  });
+});
+
+describe("GitHub repository option refresh", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.restoreAllMocks();
+  });
+
+  it("fetches live repositories for every connected GitHub installation", async () => {
+    vi.mocked(getActiveTenant).mockResolvedValue(tenant);
+    vi.mocked(listConnectedIntegrationAccounts).mockResolvedValue([
+      { id: "github-account-1", externalAccountId: "123" },
+      { id: "github-account-2", externalAccountId: "456" },
+    ]);
+    vi.mocked(listGitHubRepositories)
+      .mockResolvedValueOnce([
+        {
+          externalId: "1001",
+          fullName: "acme/new-repository",
+          defaultBranch: "main",
+          private: true,
+          metadata: {},
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          externalId: "1002",
+          fullName: "example/api",
+          defaultBranch: "main",
+          private: false,
+          metadata: {},
+        },
+      ]);
+    vi.mocked(listAgentOptions).mockResolvedValue(options);
+
+    const response = await app.request("/api/agents/options/refresh/github", {
+      method: "POST",
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual(options);
+    expect(listGitHubRepositories).toHaveBeenCalledTimes(2);
+    expect(listGitHubRepositories).toHaveBeenCalledWith(123);
+    expect(listGitHubRepositories).toHaveBeenCalledWith(456);
+    expect(replaceRepositories).toHaveBeenCalledWith(
+      "github-account-1",
+      [expect.objectContaining({ fullName: "acme/new-repository" })],
+    );
+    expect(replaceRepositories).toHaveBeenCalledWith(
+      "github-account-2",
+      [expect.objectContaining({ fullName: "example/api" })],
+    );
+  });
+
+  it("returns a retryable error without replacing repositories when GitHub fails", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    vi.mocked(getActiveTenant).mockResolvedValue(tenant);
+    vi.mocked(listConnectedIntegrationAccounts).mockResolvedValue([
+      { id: "github-account-1", externalAccountId: "123" },
+    ]);
+    vi.mocked(listGitHubRepositories).mockRejectedValue(
+      new Error("GitHub unavailable"),
+    );
+
+    const response = await app.request("/api/agents/options/refresh/github", {
+      method: "POST",
+    });
+
+    expect(response.status).toBe(502);
+    await expect(response.json()).resolves.toEqual({
+      error: "Unable to refresh GitHub repositories",
+      code: "github_refresh_failed",
+    });
+    expect(replaceRepositories).not.toHaveBeenCalled();
     expect(listAgentOptions).not.toHaveBeenCalled();
   });
 });

--- a/apps/control-plane/server/agents/routes.test.ts
+++ b/apps/control-plane/server/agents/routes.test.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { decryptCredentials } from "../../../../packages/core/src/credentials/encryption.js";
 import {
+  disableAgentsWithUnavailableRepositories,
   listAgentOptions,
   setAgentEnabled,
 } from "../../../../packages/core/src/db/agents.js";
@@ -36,6 +37,7 @@ vi.mock("../../../../packages/core/src/credentials/encryption.js", () => ({
 }));
 vi.mock("../../../../packages/core/src/db/agents.js", () => ({
   createAgent: vi.fn(),
+  disableAgentsWithUnavailableRepositories: vi.fn(),
   getAgent: vi.fn(),
   listAgentOptions: vi.fn(),
   listAgents: vi.fn(),
@@ -567,6 +569,9 @@ describe("GitHub repository option refresh", () => {
     expect(replaceRepositories).toHaveBeenCalledWith(
       "github-account-2",
       [expect.objectContaining({ fullName: "example/api" })],
+    );
+    expect(disableAgentsWithUnavailableRepositories).toHaveBeenCalledWith(
+      tenant.organizationId,
     );
   });
 

--- a/apps/control-plane/server/agents/routes.ts
+++ b/apps/control-plane/server/agents/routes.ts
@@ -7,6 +7,7 @@ import { decryptCredentials } from "../../../../packages/core/src/credentials/en
 import {
   AgentConfigurationError,
   createAgent,
+  disableAgentsWithUnavailableRepositories,
   getAgent,
   listAgentOptions,
   listAgents,
@@ -285,6 +286,7 @@ export const agentRoutes = new Hono()
 
     try {
       await refreshGitHubRepositories(tenant.organizationId);
+      await disableAgentsWithUnavailableRepositories(tenant.organizationId);
       return context.json(await listAgentOptions(tenant.organizationId));
     } catch (error) {
       console.error("Unable to refresh GitHub repositories", error);

--- a/apps/control-plane/server/agents/routes.ts
+++ b/apps/control-plane/server/agents/routes.ts
@@ -15,8 +15,10 @@ import {
 } from "../../../../packages/core/src/db/agents.js";
 import {
   getSlackChannelConnection,
+  listConnectedIntegrationAccounts,
   listConnectedIntegrationAccountCredentials,
   markSlackChannelJoined,
+  replaceRepositories,
   replaceIntegrationResources,
 } from "../../../../packages/core/src/db/integrations.js";
 import {
@@ -36,6 +38,7 @@ import {
   listSlackChannels,
   SlackChannelJoinError,
 } from "../integrations/slack.js";
+import { listGitHubRepositories } from "../integrations/github.js";
 import { getActiveTenant } from "../tenant.js";
 import { queueInvestigationRetry } from "../investigations/queue.js";
 import {
@@ -46,6 +49,8 @@ import {
 const slackCredentialsSchema = z.object({
   accessToken: z.string().min(1),
 });
+
+const githubInstallationIdSchema = z.coerce.number().int().positive();
 
 const agentEnabledSchema = z.object({
   enabled: z.boolean(),
@@ -130,6 +135,24 @@ export async function refreshSlackChannelResources(
         "slack_channel",
         channels,
       );
+    }),
+  );
+}
+
+export async function refreshGitHubRepositories(
+  organizationId: string,
+): Promise<void> {
+  const accounts = await listConnectedIntegrationAccounts(
+    organizationId,
+    "github",
+  );
+
+  await Promise.all(
+    accounts.map(async (account) => {
+      const repositories = await listGitHubRepositories(
+        githubInstallationIdSchema.parse(account.externalAccountId),
+      );
+      await replaceRepositories(account.id, repositories);
     }),
   );
 }
@@ -249,6 +272,26 @@ export const agentRoutes = new Hono()
         {
           error: "Unable to refresh Slack channels",
           code: "slack_refresh_failed",
+        },
+        502,
+      );
+    }
+  })
+  .post("/options/refresh/github", async (context) => {
+    const tenant = await getActiveTenant(context.req.raw.headers);
+    if (tenant.ok === false) {
+      return context.json({ error: tenant.error }, tenant.status);
+    }
+
+    try {
+      await refreshGitHubRepositories(tenant.organizationId);
+      return context.json(await listAgentOptions(tenant.organizationId));
+    } catch (error) {
+      console.error("Unable to refresh GitHub repositories", error);
+      return context.json(
+        {
+          error: "Unable to refresh GitHub repositories",
+          code: "github_refresh_failed",
         },
         502,
       );

--- a/apps/control-plane/server/index.test.ts
+++ b/apps/control-plane/server/index.test.ts
@@ -253,17 +253,20 @@ describe("control-plane API", () => {
   });
 
   it("rejects unauthenticated agent writes", async () => {
-    const [createResponse, refreshResponse] = await Promise.all([
+    const [createResponse, slackRefreshResponse, githubRefreshResponse] =
+      await Promise.all([
       app.request("/api/agents", {
         method: "POST",
         body: "{}",
         headers: { "content-type": "application/json" },
       }),
       app.request("/api/agents/options/refresh/slack", { method: "POST" }),
+      app.request("/api/agents/options/refresh/github", { method: "POST" }),
     ]);
 
     expect(createResponse.status).toBe(401);
-    expect(refreshResponse.status).toBe(401);
+    expect(slackRefreshResponse.status).toBe(401);
+    expect(githubRefreshResponse.status).toBe(401);
   });
 
   it("rejects unauthenticated billing requests", async () => {

--- a/apps/control-plane/src/agents-api.ts
+++ b/apps/control-plane/src/agents-api.ts
@@ -471,6 +471,12 @@ export async function refreshSlackAgentOptions(): Promise<AgentOptions> {
   });
 }
 
+export async function refreshGitHubAgentOptions(): Promise<AgentOptions> {
+  return apiJson<AgentOptions>("/api/agents/options/refresh/github", {
+    method: "POST",
+  });
+}
+
 export async function createWorkspaceSecret(input: {
   name: string;
   value: string;

--- a/apps/control-plane/src/pages/agent-create.tsx
+++ b/apps/control-plane/src/pages/agent-create.tsx
@@ -16,6 +16,7 @@ import {
   fetchAgentOptions,
   fetchIntegrations,
   createWorkspaceSecret,
+  refreshGitHubAgentOptions,
   refreshSlackAgentOptions,
   saveAgent,
   slackChannelLabel,
@@ -498,6 +499,11 @@ export function AgentCreatePage() {
   const [connectingClickStack, setConnectingClickStack] = useState(false);
   const [connectingAws, setConnectingAws] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [refreshingGithubRepositories, setRefreshingGithubRepositories] =
+    useState(false);
+  const [githubRefreshError, setGithubRefreshError] = useState<string | null>(
+    null,
+  );
   const [refreshingSlackChannels, setRefreshingSlackChannels] = useState(false);
   const [slackRefreshError, setSlackRefreshError] = useState<string | null>(null);
   const [secretName, setSecretName] = useState("");
@@ -505,6 +511,7 @@ export function AgentCreatePage() {
   const [secretHosts, setSecretHosts] = useState("");
   const [creatingSecret, setCreatingSecret] = useState(false);
   const [secretError, setSecretError] = useState<string | null>(null);
+  const githubRefreshInFlight = useRef<Promise<void> | null>(null);
   const slackRefreshInFlight = useRef<Promise<void> | null>(null);
   const connectingProviderRef = useRef<IntegrationSummary["id"] | null>(null);
   const [notice] = useState(connectionNotice);
@@ -1004,6 +1011,51 @@ export function AgentCreatePage() {
     return refresh;
   }
 
+  function refreshGithubRepositories(): Promise<void> {
+    if (githubRefreshInFlight.current) return githubRefreshInFlight.current;
+
+    setRefreshingGithubRepositories(true);
+    setGithubRefreshError(null);
+    const refresh = refreshGitHubAgentOptions()
+      .then((freshOptions) => {
+        const freshRepositoryIds = new Set(
+          freshOptions.repositories.map((repository) => repository.id),
+        );
+        setOptions(freshOptions);
+        setDraft((current) => {
+          if (!current) return current;
+          const repositoryIds = current.repositoryIds.filter((id) =>
+            freshRepositoryIds.has(id),
+          );
+          return {
+            ...current,
+            repositoryIds,
+            prMode: repositoryIds.length === 0 ? "disabled" : current.prMode,
+          };
+        });
+      })
+      .catch((caught: unknown) => {
+        setGithubRefreshError(
+          caught instanceof Error
+            ? caught.message
+            : "Unable to refresh GitHub repositories",
+        );
+      })
+      .finally(() => {
+        setRefreshingGithubRepositories(false);
+        if (githubRefreshInFlight.current === refresh) {
+          githubRefreshInFlight.current = null;
+        }
+      });
+    githubRefreshInFlight.current = refresh;
+    return refresh;
+  }
+
+  function openGithubDialog() {
+    setGithubDialogOpen(true);
+    void refreshGithubRepositories();
+  }
+
   function integrationFor(provider: IntegrationSummary["id"]) {
     return integrations.find((integration) => integration.id === provider);
   }
@@ -1151,7 +1203,7 @@ export function AgentCreatePage() {
     }
     const firstRepository = options.repositories[0];
     if (!firstRepository) {
-      setGithubDialogOpen(true);
+      openGithubDialog();
       return;
     }
     updateDraft({ repositoryIds: [firstRepository.id], prMode: "manual" });
@@ -1971,7 +2023,7 @@ export function AgentCreatePage() {
                       <ContextIntegrationControls
                         enabled={draft.repositoryIds.length > 0}
                         label="GitHub"
-                        onConfigure={() => setGithubDialogOpen(true)}
+                        onConfigure={openGithubDialog}
                         onToggle={toggleGithubContextIntegration}
                       />
                     }
@@ -2066,6 +2118,9 @@ export function AgentCreatePage() {
                                 </label>
                               </div>
                               <div className="repositoryConnectList">
+                                {refreshingGithubRepositories ? (
+                                  <p>Refreshing repositories…</p>
+                                ) : null}
                                 {filteredGithubRepositories.map((repository) => {
                                   const selected = draft.repositoryIds.includes(
                                     repository.id,
@@ -2130,6 +2185,14 @@ export function AgentCreatePage() {
                                 ) : null}
                               </div>
                             </div>
+
+                          {!refreshingGithubRepositories && githubRefreshError ? (
+                            <Alert
+                              role="alert"
+                              title={`${githubRefreshError}. Showing the last available list.`}
+                              tone="danger"
+                            />
+                          ) : null}
 
                           <div className="contextSettingRow">
                             <span>

--- a/apps/control-plane/src/pages/agent-create.tsx
+++ b/apps/control-plane/src/pages/agent-create.tsx
@@ -1,4 +1,5 @@
 import {
+  useCallback,
   useEffect,
   useMemo,
   useRef,
@@ -517,6 +518,46 @@ export function AgentCreatePage() {
   const [notice] = useState(connectionNotice);
   useDocumentTitle(isEditing ? "Edit agent" : "Create agent");
 
+  const refreshGithubRepositories = useCallback((): Promise<void> => {
+    if (githubRefreshInFlight.current) return githubRefreshInFlight.current;
+
+    setRefreshingGithubRepositories(true);
+    setGithubRefreshError(null);
+    const refresh = refreshGitHubAgentOptions()
+      .then((freshOptions) => {
+        const freshRepositoryIds = new Set(
+          freshOptions.repositories.map((repository) => repository.id),
+        );
+        setOptions(freshOptions);
+        setDraft((current) => {
+          if (!current) return current;
+          const repositoryIds = current.repositoryIds.filter((id) =>
+            freshRepositoryIds.has(id),
+          );
+          return {
+            ...current,
+            repositoryIds,
+            prMode: repositoryIds.length === 0 ? "disabled" : current.prMode,
+          };
+        });
+      })
+      .catch((caught: unknown) => {
+        setGithubRefreshError(
+          caught instanceof Error
+            ? caught.message
+            : "Unable to refresh GitHub repositories",
+        );
+      })
+      .finally(() => {
+        setRefreshingGithubRepositories(false);
+        if (githubRefreshInFlight.current === refresh) {
+          githubRefreshInFlight.current = null;
+        }
+      });
+    githubRefreshInFlight.current = refresh;
+    return refresh;
+  }, []);
+
   useEffect(() => {
     if (
       !githubDialogOpen &&
@@ -782,6 +823,11 @@ export function AgentCreatePage() {
   }, [draft, draftStorageKey, options]);
 
   useEffect(() => {
+    if (!githubJustConnected || loading) return;
+    void refreshGithubRepositories();
+  }, [githubJustConnected, loading, refreshGithubRepositories]);
+
+  useEffect(() => {
     window.sessionStorage.setItem(
       stepStorageKey,
       activeStep.toString(),
@@ -1008,46 +1054,6 @@ export function AgentCreatePage() {
         }
       });
     slackRefreshInFlight.current = refresh;
-    return refresh;
-  }
-
-  function refreshGithubRepositories(): Promise<void> {
-    if (githubRefreshInFlight.current) return githubRefreshInFlight.current;
-
-    setRefreshingGithubRepositories(true);
-    setGithubRefreshError(null);
-    const refresh = refreshGitHubAgentOptions()
-      .then((freshOptions) => {
-        const freshRepositoryIds = new Set(
-          freshOptions.repositories.map((repository) => repository.id),
-        );
-        setOptions(freshOptions);
-        setDraft((current) => {
-          if (!current) return current;
-          const repositoryIds = current.repositoryIds.filter((id) =>
-            freshRepositoryIds.has(id),
-          );
-          return {
-            ...current,
-            repositoryIds,
-            prMode: repositoryIds.length === 0 ? "disabled" : current.prMode,
-          };
-        });
-      })
-      .catch((caught: unknown) => {
-        setGithubRefreshError(
-          caught instanceof Error
-            ? caught.message
-            : "Unable to refresh GitHub repositories",
-        );
-      })
-      .finally(() => {
-        setRefreshingGithubRepositories(false);
-        if (githubRefreshInFlight.current === refresh) {
-          githubRefreshInFlight.current = null;
-        }
-      });
-    githubRefreshInFlight.current = refresh;
     return refresh;
   }
 

--- a/packages/core/src/db/integrations.ts
+++ b/packages/core/src/db/integrations.ts
@@ -508,6 +508,25 @@ export async function listConnectedIntegrationAccountCredentials(
     );
 }
 
+export async function listConnectedIntegrationAccounts(
+  organizationId: string,
+  provider: IntegrationProvider,
+) {
+  return getDatabase()
+    .select({
+      id: integrationAccounts.id,
+      externalAccountId: integrationAccounts.externalAccountId,
+    })
+    .from(integrationAccounts)
+    .where(
+      and(
+        eq(integrationAccounts.organizationId, organizationId),
+        eq(integrationAccounts.provider, provider),
+        eq(integrationAccounts.status, "connected"),
+      ),
+    );
+}
+
 export interface SyncedIntegrationResource {
   externalId: string;
   displayName: string;


### PR DESCRIPTION
## Summary
- refresh repositories from every connected GitHub installation when repository configuration opens
- update the stored repository snapshot and remove selections that are no longer available
- keep the last available list visible when GitHub refresh fails

## Validation
- pnpm typecheck
- pnpm lint
- pnpm test
- pnpm build

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes GitHub repositories when the repository picker opens so users see live repos across all connected installations. Previously the list was static; now we fetch and persist current repos, drop selections that disappeared, keep the last list on failure, and disable agents that reference unavailable repositories.

- Adds `POST /api/agents/options/refresh/github` to fetch repositories for each connected GitHub installation and persist them per account.
- Returns 502 with code `github_refresh_failed` on GitHub errors and leaves stored repositories unchanged.
- Agent create UI refreshes on dialog open and after connecting GitHub, shows a loading state, and displays an error while keeping the last available list.
- Removes repository selections that are no longer available; if none remain, sets PR mode to disabled.
- Disables agents with unavailable repositories after a refresh.
- Adds `listConnectedIntegrationAccounts` DB query to enumerate connected GitHub installations.

<sup>Written for commit 02114233bc59c87b49b189068cdf670f07843733. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/responder-oss/pull/58?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

