### PR TITLE
Recover interrupted investigations promptly

### DIFF
--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -44,6 +44,7 @@ import {
   completeInvestigationRun,
   deliverPersistedInvestigationAfterFailure,
 } from "./investigation-completion.js";
+import { maintainLegacyInvestigationHeartbeat } from "./legacy-job-heartbeat.js";
 import {
   runInvestigationAgent,
   safeInvestigationError,
@@ -286,15 +287,49 @@ await boss.work(pullRequestReviewQueue, { localConcurrency: 1 }, async ([job]) =
   return processPullRequestReviewJob(job.id, payload, process.env);
 });
 await boss.work(investigationQueue, { localConcurrency: 1 }, async ([job]) => {
+  const stopLegacyHeartbeat = await maintainLegacyInvestigationHeartbeat(
+    boss,
+    job,
+  );
+  try {
   const payload = responderJobSchema.parse(job.data);
   if (payload.kind === "remediation") {
     // Drain jobs queued by older workers while all new remediations use the
     // versioned exclusive queue above.
     return processRemediationJob(job.id, payload, process.env);
   }
-  await markInvestigationStarted(
+  const investigationState = await markInvestigationStarted(
     payload.investigationId,
     `openai-daytona:${job.id}`,
+  );
+  if (investigationState === "completed") {
+    const deliveryWarnings = await deliverPersistedInvestigationAfterFailure({
+      deliveryRunId: job.id,
+      investigationFailed: false,
+      investigationId: payload.investigationId,
+      replay: payload.replay,
+    });
+    await reportIncompleteSlackDelivery({
+      deliveryWarnings,
+      investigationId: payload.investigationId,
+      jobId: job.id,
+      organizationId: payload.config.organizationId,
+    });
+    console.log(
+      JSON.stringify({
+        event: "investigation_job_recovered",
+        investigationId: payload.investigationId,
+        jobId: job.id,
+      }),
+    );
+    return { investigationId: payload.investigationId };
+  }
+  console.log(
+    JSON.stringify({
+      event: "investigation_job_started",
+      investigationId: payload.investigationId,
+      jobId: job.id,
+    }),
   );
 
   let finalizingSlackCard = false;
@@ -389,6 +424,7 @@ await boss.work(investigationQueue, { localConcurrency: 1 }, async ([job]) => {
       },
     );
     const deliveryWarnings = await completeInvestigationRun({
+      deliveryRunId: job.id,
       investigationId: payload.investigationId,
       replay: payload.replay,
       report,
@@ -425,6 +461,7 @@ await boss.work(investigationQueue, { localConcurrency: 1 }, async ([job]) => {
       "Investigation failed before remediation could be queued",
     );
     const deliveryWarnings = await deliverPersistedInvestigationAfterFailure({
+      deliveryRunId: job.id,
       investigationFailed,
       investigationId: payload.investigationId,
       replay: payload.replay,
@@ -450,6 +487,9 @@ await boss.work(investigationQueue, { localConcurrency: 1 }, async ([job]) => {
       }),
     );
     throw new Error(message, { cause: error });
+  }
+  } finally {
+    stopLegacyHeartbeat();
   }
 });
 
@@ -485,7 +525,7 @@ async function shutdown(signal: string): Promise<void> {
   await remediationRecoveryDrain;
   console.log(JSON.stringify({ event: "worker_stopping", signal }));
   try {
-    await boss.stop({ graceful: true, timeout: 25_000 });
+    await boss.stop({ graceful: true, timeout: 110_000 });
   } finally {
     await flushWorkerMonitoring();
   }

--- a/apps/worker/src/investigation-completion.test.ts
+++ b/apps/worker/src/investigation-completion.test.ts
@@ -25,6 +25,7 @@ describe("investigation completion", () => {
     await expect(
       completeInvestigationRun(
         {
+          deliveryRunId: "job-id",
           investigationId: "investigation-id",
           replay: false,
           report: "Final report",
@@ -34,6 +35,7 @@ describe("investigation completion", () => {
     ).resolves.toEqual([]);
 
     expect(order).toEqual(["complete", "deliver"]);
+    expect(deliver).toHaveBeenCalledWith("investigation-id", "job-id");
     expect(completeReplay).not.toHaveBeenCalled();
   });
 
@@ -44,6 +46,7 @@ describe("investigation completion", () => {
 
     await completeInvestigationRun(
       {
+        deliveryRunId: "job-id",
         investigationId: "replay-id",
         replay: true,
         report: "Replay report",
@@ -66,6 +69,7 @@ describe("investigation completion", () => {
     await expect(
       completeInvestigationRun(
         {
+          deliveryRunId: "job-id",
           investigationId: "investigation-id",
           replay: false,
           report: "Final report",
@@ -92,6 +96,7 @@ describe("investigation completion", () => {
     await expect(
       completeInvestigationRun(
         {
+          deliveryRunId: "job-id",
           investigationId: "replay-id",
           replay: true,
           report: "Replay report",
@@ -113,6 +118,7 @@ describe("investigation completion", () => {
 
     await deliverPersistedInvestigationAfterFailure(
       {
+        deliveryRunId: "job-id",
         investigationFailed: false,
         investigationId: "investigation-id",
         replay: false,
@@ -120,6 +126,42 @@ describe("investigation completion", () => {
       deliver,
     );
 
-    expect(deliver).toHaveBeenCalledWith("investigation-id");
+    expect(deliver).toHaveBeenCalledWith("investigation-id", "job-id");
+  });
+
+  it("delivers the persisted report when a completed job is recovered", async () => {
+    const deliver = vi.fn().mockResolvedValue([]);
+
+    await expect(
+      deliverPersistedInvestigationAfterFailure(
+        {
+          deliveryRunId: "job-id",
+          investigationFailed: false,
+          investigationId: "investigation-id",
+          replay: false,
+        },
+        deliver,
+      ),
+    ).resolves.toEqual([]);
+
+    expect(deliver).toHaveBeenCalledWith("investigation-id", "job-id");
+  });
+
+  it("does not deliver a recovered replay investigation", async () => {
+    const deliver = vi.fn().mockResolvedValue([]);
+
+    await expect(
+      deliverPersistedInvestigationAfterFailure(
+        {
+          deliveryRunId: "job-id",
+          investigationFailed: false,
+          investigationId: "replay-id",
+          replay: true,
+        },
+        deliver,
+      ),
+    ).resolves.toEqual([]);
+
+    expect(deliver).not.toHaveBeenCalled();
   });
 });

--- a/apps/worker/src/investigation-completion.ts
+++ b/apps/worker/src/investigation-completion.ts
@@ -18,6 +18,7 @@ const defaultDependencies: InvestigationCompletionDependencies = {
 
 export async function completeInvestigationRun(
   input: {
+    deliveryRunId: string;
     investigationId: string;
     replay: boolean;
     report: string;
@@ -51,11 +52,12 @@ export async function completeInvestigationRun(
     );
     throw error;
   }
-  return dependencies.deliver(input.investigationId);
+  return dependencies.deliver(input.investigationId, input.deliveryRunId);
 }
 
 export async function deliverPersistedInvestigationAfterFailure(
   input: {
+    deliveryRunId: string;
     investigationFailed: boolean;
     investigationId: string;
     replay: boolean;
@@ -64,5 +66,5 @@ export async function deliverPersistedInvestigationAfterFailure(
     deliverCompletedInvestigationWithWarnings,
 ): Promise<string[]> {
   if (input.replay || input.investigationFailed) return [];
-  return deliver(input.investigationId);
+  return deliver(input.investigationId, input.deliveryRunId);
 }

--- a/apps/worker/src/legacy-job-heartbeat.test.ts
+++ b/apps/worker/src/legacy-job-heartbeat.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { investigationQueue } from "@responder/core/jobs";
+import { maintainLegacyInvestigationHeartbeat } from "./legacy-job-heartbeat.js";
+
+describe("legacy investigation heartbeat rollout", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("maintains a heartbeat after fetching a pre-rollout job", async () => {
+    vi.useFakeTimers();
+    const executeSql = vi.fn().mockResolvedValue({ rows: [{ id: "job-id" }] });
+    const touch = vi.fn().mockResolvedValue({ affected: 1 });
+    const boss = {
+      emit: vi.fn(),
+      getDb: () => ({ executeSql }),
+      touch,
+    } as never;
+
+    const stop = await maintainLegacyInvestigationHeartbeat(boss, {
+      heartbeatSeconds: null,
+      id: "job-id",
+    });
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    expect(executeSql).toHaveBeenCalledWith(
+      expect.stringContaining("UPDATE pgboss.job"),
+      [investigationQueue, "job-id", 60],
+    );
+    expect(touch).toHaveBeenCalledWith(investigationQueue, "job-id");
+    stop();
+  });
+
+  it("stays dormant for jobs created with the queue heartbeat", async () => {
+    const executeSql = vi.fn();
+    const touch = vi.fn();
+
+    const stop = await maintainLegacyInvestigationHeartbeat({
+      getDb: () => ({ executeSql }),
+      touch,
+    } as never, {
+      heartbeatSeconds: 60,
+      id: "job-id",
+    });
+
+    stop();
+    expect(executeSql).not.toHaveBeenCalled();
+    expect(touch).not.toHaveBeenCalled();
+  });
+});

--- a/apps/worker/src/legacy-job-heartbeat.ts
+++ b/apps/worker/src/legacy-job-heartbeat.ts
@@ -1,0 +1,45 @@
+import { investigationQueue } from "@responder/core/jobs";
+
+const heartbeatSeconds = 60;
+
+interface LegacyHeartbeatBoss {
+  emit(event: "error", error: Error): boolean;
+  getDb(): {
+    executeSql(text: string, values?: unknown[]): Promise<{ rows: unknown[] }>;
+  };
+  touch(name: string, id: string): Promise<unknown>;
+}
+
+// Rollout bridge for jobs fetched before responder-investigations stored a
+// heartbeat. It is dormant for every job created after that queue update and
+// can be removed once no pre-rollout jobs remain in pg-boss retention.
+export async function maintainLegacyInvestigationHeartbeat(
+  boss: LegacyHeartbeatBoss,
+  job: { heartbeatSeconds: number | null; id: string },
+): Promise<() => void> {
+  if (job.heartbeatSeconds !== null) return () => undefined;
+
+  const adopted = await boss.getDb().executeSql(
+    `UPDATE pgboss.job
+     SET heartbeat_seconds = $3,
+         heartbeat_on = now()
+     WHERE name = $1
+       AND id = $2::uuid
+       AND state = 'active'
+       AND heartbeat_seconds IS NULL
+     RETURNING id`,
+    [investigationQueue, job.id, heartbeatSeconds],
+  );
+  if (adopted.rows.length === 0) return () => undefined;
+
+  const timer = setInterval(() => {
+    void boss.touch(investigationQueue, job.id).catch((error: unknown) => {
+      boss.emit(
+        "error",
+        error instanceof Error ? error : new Error(String(error)),
+      );
+    });
+  }, heartbeatSeconds * 500);
+  timer.unref();
+  return () => clearInterval(timer);
+}

--- a/apps/worker/src/report.ts
+++ b/apps/worker/src/report.ts
@@ -41,9 +41,10 @@ function reportToolResult(input: {
 
 export async function deliverCompletedInvestigationWithWarnings(
   investigationId: string,
+  deliveryRunId: string = investigationId,
 ): Promise<string[]> {
   try {
-    return await deliverInvestigationToSlack(investigationId);
+    return await deliverInvestigationToSlack(investigationId, deliveryRunId);
   } catch (error) {
     const message =
       error instanceof Error ? error.message : "Slack delivery failed";

--- a/packages/core/src/db/investigations.test.ts
+++ b/packages/core/src/db/investigations.test.ts
@@ -14,6 +14,7 @@ import {
   customMcpTokenRefreshSuccessEvent,
   customMcpReconnectError,
   investigationCanBeRetried,
+  markInvestigationStarted,
   prepareInvestigationRetry,
   replayReportMarkdownUpdate,
 } from "./investigations.js";
@@ -113,6 +114,49 @@ describe("investigation retry", () => {
       agentConfigVersionId: "active-config",
       runtimeProfileId: "active-runtime",
     }));
+  });
+});
+
+describe("investigation worker recovery", () => {
+  it("starts an investigation that still needs work", async () => {
+    const returning = vi.fn().mockResolvedValue([{ id: "investigation-1" }]);
+    const where = vi.fn(() => ({ returning }));
+    const set = vi.fn(() => ({ where }));
+    vi.mocked(getDatabase).mockReturnValue({
+      update: vi.fn(() => ({ set })),
+    } as never);
+
+    await expect(
+      markInvestigationStarted("investigation-1", "openai-daytona:job-1"),
+    ).resolves.toBe("started");
+    expect(set).toHaveBeenCalledWith(expect.objectContaining({
+      completedAt: null,
+      eveSessionId: "openai-daytona:job-1",
+      failureReason: null,
+      status: "investigating",
+    }));
+  });
+
+  it("preserves a report that completed before the worker stopped", async () => {
+    const returning = vi.fn().mockResolvedValue([]);
+    const updateWhere = vi.fn(() => ({ returning }));
+    const set = vi.fn(() => ({ where: updateWhere }));
+    const selectQuery = {
+      from: vi.fn(),
+      where: vi.fn(),
+      limit: vi.fn().mockResolvedValue([{ status: "resolved" }]),
+    };
+    selectQuery.from.mockReturnValue(selectQuery);
+    selectQuery.where.mockReturnValue(selectQuery);
+    vi.mocked(getDatabase).mockReturnValue({
+      select: vi.fn(() => selectQuery),
+      update: vi.fn(() => ({ set })),
+    } as never);
+
+    await expect(
+      markInvestigationStarted("investigation-1", "openai-daytona:job-1"),
+    ).resolves.toBe("completed");
+    expect(set).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/packages/core/src/db/investigations.ts
+++ b/packages/core/src/db/investigations.ts
@@ -2246,8 +2246,9 @@ export async function beginInvestigation(
 export async function markInvestigationStarted(
   investigationId: string,
   eveSessionId: string,
-): Promise<void> {
-  await getDatabase()
+): Promise<"completed" | "started"> {
+  const database = getDatabase();
+  const started = await database
     .update(investigations)
     .set({
       completedAt: null,
@@ -2257,7 +2258,22 @@ export async function markInvestigationStarted(
       startedAt: new Date(),
       updatedAt: new Date(),
     })
-    .where(eq(investigations.id, investigationId));
+    .where(
+      and(
+        eq(investigations.id, investigationId),
+        inArray(investigations.status, ["pending", "investigating", "failed"]),
+      ),
+    )
+    .returning({ id: investigations.id });
+  if (started[0]) return "started";
+
+  const existing = await database
+    .select({ status: investigations.status })
+    .from(investigations)
+    .where(eq(investigations.id, investigationId))
+    .limit(1);
+  if (existing[0]?.status === "resolved") return "completed";
+  throw new Error("Investigation is unavailable");
 }
 
 export async function discardPendingInvestigation(

--- a/packages/core/src/integrations/slack-delivery.test.ts
+++ b/packages/core/src/integrations/slack-delivery.test.ts
@@ -1,7 +1,39 @@
 import { describe, expect, it } from "vitest";
-import { slackIssueMessage } from "./slack-delivery.js";
+import {
+  slackDeliveryClientMessageId,
+  slackIssueMessage,
+} from "./slack-delivery.js";
 
 describe("Slack issue delivery", () => {
+  it("uses stable, destination-specific message IDs for retry deduplication", () => {
+    const first = slackDeliveryClientMessageId(
+      "job-id",
+      "source:C123:issue:issue-id",
+    );
+
+    expect(first).toBe(
+      slackDeliveryClientMessageId(
+        "job-id",
+        "source:C123:issue:issue-id",
+      ),
+    );
+    expect(first).not.toBe(
+      slackDeliveryClientMessageId(
+        "job-id",
+        "output:C123:issue:issue-id",
+      ),
+    );
+    expect(first).not.toBe(
+      slackDeliveryClientMessageId(
+        "manual-rerun-job-id",
+        "source:C123:issue:issue-id",
+      ),
+    );
+    expect(first).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+    );
+  });
+
   it("shows root cause and an ordered timeline in the issue message", () => {
     const message = slackIssueMessage({
       id: "07070707-0707-4707-8707-070707070707",

--- a/packages/core/src/integrations/slack-delivery.ts
+++ b/packages/core/src/integrations/slack-delivery.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { z } from "zod";
 import { decryptCredentials } from "../credentials/encryption.js";
 import { responderIssueUrl } from "../responder-urls.js";
@@ -22,6 +23,26 @@ const slackCredentialsSchema = z.object({
 });
 
 type DeliveryIssue = SlackInvestigationDeliveryContext["issues"][number];
+
+export function slackDeliveryClientMessageId(
+  deliveryRunId: string,
+  deliveryKey: string,
+): string {
+  const bytes = createHash("sha256")
+    .update(`${deliveryRunId}:${deliveryKey}`)
+    .digest()
+    .subarray(0, 16);
+  bytes[6] = (bytes[6]! & 0x0f) | 0x50;
+  bytes[8] = (bytes[8]! & 0x3f) | 0x80;
+  const hex = bytes.toString("hex");
+  return [
+    hex.slice(0, 8),
+    hex.slice(8, 12),
+    hex.slice(12, 16),
+    hex.slice(16, 20),
+    hex.slice(20),
+  ].join("-");
+}
 
 export function filterSlackOutputIssues(
   issues: DeliveryIssue[],
@@ -216,6 +237,7 @@ export async function reconcileCompletedInvestigationSlackCard(
 
 async function deliverSourceThread(
   context: SlackInvestigationDeliveryContext,
+  deliveryRunId: string,
 ): Promise<void> {
   if (!context.source) return;
   const token = accessToken(context.source.encryptedCredentials);
@@ -249,6 +271,10 @@ async function deliverSourceThread(
     await postSlackMessage({
       accessToken: token,
       channelId: context.source.channelId,
+      clientMessageId: slackDeliveryClientMessageId(
+        deliveryRunId,
+        `source:${context.source.channelId}:summary`,
+      ),
       text: completionText,
       threadTimestamp: context.source.threadTimestamp,
     });
@@ -269,6 +295,10 @@ async function deliverSourceThread(
         accessToken: token,
         blocks: message.blocks,
         channelId: context.source.channelId,
+        clientMessageId: slackDeliveryClientMessageId(
+          deliveryRunId,
+          `source:${context.source.channelId}:issue:${issue.id}`,
+        ),
         text: message.text,
         threadTimestamp: context.source.threadTimestamp,
       });
@@ -318,6 +348,7 @@ async function deliverSourceThread(
 
 async function deliverOutputChannel(
   context: SlackInvestigationDeliveryContext,
+  deliveryRunId: string,
 ): Promise<void> {
   if (!context.output) return;
   const token = accessToken(context.output.encryptedCredentials);
@@ -331,6 +362,10 @@ async function deliverOutputChannel(
       accessToken: token,
       blocks: message.blocks,
       channelId: context.output.channelId,
+      clientMessageId: slackDeliveryClientMessageId(
+        deliveryRunId,
+        `output:${context.output.channelId}:issue:${issue.id}`,
+      ),
       text: message.text,
     });
   }
@@ -338,12 +373,13 @@ async function deliverOutputChannel(
 
 export async function deliverInvestigationToSlack(
   investigationId: string,
+  deliveryRunId: string = investigationId,
 ): Promise<string[]> {
   const context = await getSlackInvestigationDeliveryContext(investigationId);
   if (!context) return [];
   const results = await Promise.allSettled([
-    deliverSourceThread(context),
-    deliverOutputChannel(context),
+    deliverSourceThread(context, deliveryRunId),
+    deliverOutputChannel(context, deliveryRunId),
   ]);
   return results.flatMap((result) =>
     result.status === "rejected"

--- a/packages/core/src/integrations/slack.test.ts
+++ b/packages/core/src/integrations/slack.test.ts
@@ -46,6 +46,7 @@ describe("Slack delivery client", () => {
       postSlackMessage({
         accessToken: "xoxb-test",
         channelId: "C123",
+        clientMessageId: "16161616-1616-4616-8616-161616161616",
         text: "I’m investigating this alert.",
         threadTimestamp: "1785500000.000100",
       }),
@@ -56,6 +57,7 @@ describe("Slack delivery client", () => {
       expect.objectContaining({
         body: JSON.stringify({
           channel: "C123",
+          client_msg_id: "16161616-1616-4616-8616-161616161616",
           text: "I’m investigating this alert.",
           thread_ts: "1785500000.000100",
         }),

--- a/packages/core/src/integrations/slack.ts
+++ b/packages/core/src/integrations/slack.ts
@@ -121,11 +121,15 @@ export async function postSlackMessage(input: {
   accessToken: string;
   blocks?: unknown[];
   channelId: string;
+  clientMessageId?: string;
   text: string;
   threadTimestamp?: string;
 }): Promise<string | null> {
   const response = await callSlackApi(input.accessToken, "chat.postMessage", {
     channel: input.channelId,
+    ...(input.clientMessageId
+      ? { client_msg_id: input.clientMessageId }
+      : {}),
     text: input.text,
     ...(input.blocks ? { blocks: input.blocks } : {}),
     ...(input.threadTimestamp ? { thread_ts: input.threadTimestamp } : {}),

--- a/packages/core/src/jobs.test.ts
+++ b/packages/core/src/jobs.test.ts
@@ -21,8 +21,14 @@ describe("background jobs", () => {
 
   it("enforces Linear request singleton keys at the queue policy boundary", async () => {
     const createQueue = vi.fn().mockResolvedValue(undefined);
+    const executeSql = vi.fn().mockResolvedValue({ rows: [] });
+    const updateQueue = vi.fn().mockResolvedValue(undefined);
 
-    await prepareWorkerQueues({ createQueue } as never);
+    await prepareWorkerQueues({
+      createQueue,
+      getDb: () => ({ executeSql }),
+      updateQueue,
+    } as never);
 
     expect(linearTicketQueue).toBe("responder-linear-tickets-v2");
     expect(createQueue).toHaveBeenCalledWith(
@@ -31,10 +37,40 @@ describe("background jobs", () => {
     );
   });
 
+  it("detects interrupted investigations without shortening their runtime limit", async () => {
+    const createQueue = vi.fn().mockResolvedValue(undefined);
+    const executeSql = vi.fn().mockResolvedValue({ rows: [] });
+    const updateQueue = vi.fn().mockResolvedValue(undefined);
+
+    await prepareWorkerQueues({
+      createQueue,
+      getDb: () => ({ executeSql }),
+      updateQueue,
+    } as never);
+
+    expect(createQueue).toHaveBeenCalledWith(
+      investigationQueue,
+      expect.objectContaining({
+        expireInSeconds: 3_600,
+        heartbeatSeconds: 60,
+        retryLimit: 2,
+      }),
+    );
+    expect(updateQueue).toHaveBeenCalledWith(investigationQueue, {
+      heartbeatSeconds: 60,
+    });
+  });
+
   it("uses a versioned exclusive queue for remediation side effects", async () => {
     const createQueue = vi.fn().mockResolvedValue(undefined);
+    const executeSql = vi.fn().mockResolvedValue({ rows: [] });
+    const updateQueue = vi.fn().mockResolvedValue(undefined);
 
-    await prepareWorkerQueues({ createQueue } as never);
+    await prepareWorkerQueues({
+      createQueue,
+      getDb: () => ({ executeSql }),
+      updateQueue,
+    } as never);
 
     expect(remediationQueue).toBe("responder-remediations-v2");
     expect(createQueue).toHaveBeenCalledWith(
@@ -49,8 +85,14 @@ describe("background jobs", () => {
 
   it("serializes pull request review side effects without dropping later events", async () => {
     const createQueue = vi.fn().mockResolvedValue(undefined);
+    const executeSql = vi.fn().mockResolvedValue({ rows: [] });
+    const updateQueue = vi.fn().mockResolvedValue(undefined);
 
-    await prepareWorkerQueues({ createQueue } as never);
+    await prepareWorkerQueues({
+      createQueue,
+      getDb: () => ({ executeSql }),
+      updateQueue,
+    } as never);
 
     expect(pullRequestReviewQueue).toBe("responder-pull-request-reviews-v1");
     expect(createQueue).toHaveBeenCalledWith(

--- a/packages/core/src/jobs.ts
+++ b/packages/core/src/jobs.ts
@@ -17,6 +17,8 @@ export const linearTicketQueue = "responder-linear-tickets-v2";
 export const remediationQueue = "responder-remediations-v2";
 export const pullRequestReviewQueue = "responder-pull-request-reviews-v1";
 
+const investigationHeartbeatSeconds = 60;
+
 export const workerHealthJobSchema = z.object({
   marker: z.string().min(1),
   requestedAt: z.iso.datetime(),
@@ -130,6 +132,7 @@ export async function prepareWorkerQueues(boss: PgBoss): Promise<void> {
     boss.createQueue(investigationQueue, {
       deleteAfterSeconds: 604_800,
       expireInSeconds: 3_600,
+      heartbeatSeconds: investigationHeartbeatSeconds,
       notify: true,
       retryBackoff: true,
       retryDelay: 30,
@@ -170,4 +173,10 @@ export async function prepareWorkerQueues(boss: PgBoss): Promise<void> {
       retryLimit: 5,
     }),
   ]);
+  // createQueue leaves an existing queue unchanged. Reconcile the heartbeat
+  // separately so future jobs use it on the durable production queue. Active
+  // jobs from the old task are failed back to the queue by pg-boss shutdown.
+  await boss.updateQueue(investigationQueue, {
+    heartbeatSeconds: investigationHeartbeatSeconds,
+  });
 }


### PR DESCRIPTION
## Summary

- add worker heartbeats so interrupted investigations become retryable promptly
- allow more time for graceful worker shutdown
- preserve reports committed before interruption instead of rerunning completed work
- add internal attempt and recovery events

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
- `pnpm build:app`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recovers interrupted investigations promptly and prevents re-running completed work. Previously, interrupted jobs could wait up to 1h and redo finished steps; we now detect liveness via 60s heartbeats and safely recover completed runs by re-delivering their reports.

- Adds a 60s heartbeat to `investigationQueue` and reconciles it via `updateQueue`; legacy active jobs without a heartbeat are adopted and kept alive via periodic `touch`.
- `markInvestigationStarted` returns "started" or "completed" and only updates `pending`/`investigating`/`failed`, preserving already resolved runs.
- Re-delivers the persisted report on recovery and reports incomplete Slack delivery warnings; recovered replays skip delivery.
- Deduplicates Slack posts using stable, destination-scoped `client_msg_id`s derived from the job run ID.
- Keeps the 1h job runtime limit; the heartbeat does not shorten expiry.
- Increases worker graceful shutdown timeout to 110s.

<sup>Written for commit 0c890042966f181c9370ca51f5de840d2bdf3aa0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/responder-oss/pull/59?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

