### PR TITLE
Isolate legacy heartbeat rollout migration

### DIFF
--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -44,7 +44,8 @@ import {
   completeInvestigationRun,
   deliverPersistedInvestigationAfterFailure,
 } from "./investigation-completion.js";
-import { maintainLegacyInvestigationHeartbeat } from "./legacy-job-heartbeat.js";
+import { migrateLegacyInvestigationHeartbeats } from "./legacy-job-heartbeat.js";
+import { workerGracefulShutdownTimeoutMs } from "./shutdown-policy.js";
 import {
   runInvestigationAgent,
   safeInvestigationError,
@@ -85,6 +86,11 @@ let stopping = false;
 let replayRequestDrain: Promise<void> | undefined;
 let linearTicketDrain: Promise<void> | undefined;
 let remediationRecoveryDrain: Promise<void> | undefined;
+const pollers: {
+  linearTicket?: NodeJS.Timeout;
+  remediationRecovery?: NodeJS.Timeout;
+  replayRequest?: NodeJS.Timeout;
+} = {};
 
 const replayRequestQueue = {
   send: (
@@ -239,6 +245,42 @@ boss.on("error", (error) => {
   void reportWorkerException(error, { operation: "worker" });
 });
 
+async function shutdown(signal: string): Promise<void> {
+  if (stopping) return;
+  stopping = true;
+  if (pollers.replayRequest) clearInterval(pollers.replayRequest);
+  if (pollers.linearTicket) clearInterval(pollers.linearTicket);
+  if (pollers.remediationRecovery) clearInterval(pollers.remediationRecovery);
+  await replayRequestDrain;
+  await linearTicketDrain;
+  await remediationRecoveryDrain;
+  console.log(JSON.stringify({ event: "worker_stopping", signal }));
+  try {
+    await boss.stop({
+      graceful: true,
+      timeout: workerGracefulShutdownTimeoutMs,
+    });
+  } finally {
+    await flushWorkerMonitoring();
+  }
+}
+
+for (const signal of ["SIGINT", "SIGTERM"] as const) {
+  process.once(signal, () => {
+    void shutdown(signal)
+      .then(() => process.exit(0))
+      .catch((error: unknown) => {
+        console.error(
+          JSON.stringify({
+            error: error instanceof Error ? error.message : String(error),
+            event: "worker_shutdown_failed",
+          }),
+        );
+        process.exit(1);
+      });
+  });
+}
+
 await boss.start();
 await prepareWorkerQueues(boss);
 await boss.work(workerHealthQueue, { localConcurrency: 1 }, async ([job]) => {
@@ -286,12 +328,10 @@ await boss.work(pullRequestReviewQueue, { localConcurrency: 1 }, async ([job]) =
   const payload = pullRequestReviewJobSchema.parse(job.data);
   return processPullRequestReviewJob(job.id, payload, process.env);
 });
+// Only investigation consumption waits for the one-time legacy handoff. The
+// other queues above remain available, with shutdown handling already active.
+await migrateLegacyInvestigationHeartbeats(boss);
 await boss.work(investigationQueue, { localConcurrency: 1 }, async ([job]) => {
-  const stopLegacyHeartbeat = await maintainLegacyInvestigationHeartbeat(
-    boss,
-    job,
-  );
-  try {
   const payload = responderJobSchema.parse(job.data);
   if (payload.kind === "remediation") {
     // Drain jobs queued by older workers while all new remediations use the
@@ -488,61 +528,25 @@ await boss.work(investigationQueue, { localConcurrency: 1 }, async ([job]) => {
     );
     throw new Error(message, { cause: error });
   }
-  } finally {
-    stopLegacyHeartbeat();
-  }
 });
 
 void drainInvestigationReplayRequests();
 void drainLinearTicketRequests();
 void drainAbandonedRemediationRequests();
-const replayRequestPoller = setInterval(
+pollers.replayRequest = setInterval(
   () => void drainInvestigationReplayRequests(),
   2_000,
 );
-replayRequestPoller.unref();
-const linearTicketPoller = setInterval(
+pollers.replayRequest.unref();
+pollers.linearTicket = setInterval(
   () => void drainLinearTicketRequests(),
   10_000,
 );
-linearTicketPoller.unref();
-const remediationRecoveryPoller = setInterval(
+pollers.linearTicket.unref();
+pollers.remediationRecovery = setInterval(
   () => void drainAbandonedRemediationRequests(),
   5 * 60 * 1_000,
 );
-remediationRecoveryPoller.unref();
+pollers.remediationRecovery.unref();
 
 console.log(JSON.stringify({ event: "worker_ready" }));
-
-async function shutdown(signal: string): Promise<void> {
-  if (stopping) return;
-  stopping = true;
-  clearInterval(replayRequestPoller);
-  clearInterval(linearTicketPoller);
-  clearInterval(remediationRecoveryPoller);
-  await replayRequestDrain;
-  await linearTicketDrain;
-  await remediationRecoveryDrain;
-  console.log(JSON.stringify({ event: "worker_stopping", signal }));
-  try {
-    await boss.stop({ graceful: true, timeout: 110_000 });
-  } finally {
-    await flushWorkerMonitoring();
-  }
-}
-
-for (const signal of ["SIGINT", "SIGTERM"] as const) {
-  process.once(signal, () => {
-    void shutdown(signal)
-      .then(() => process.exit(0))
-      .catch((error: unknown) => {
-        console.error(
-          JSON.stringify({
-            error: error instanceof Error ? error.message : String(error),
-            event: "worker_shutdown_failed",
-          }),
-        );
-        process.exit(1);
-      });
-  });
-}

--- a/apps/worker/src/legacy-job-heartbeat.test.ts
+++ b/apps/worker/src/legacy-job-heartbeat.test.ts
@@ -1,50 +1,60 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { investigationQueue } from "@responder/core/jobs";
-import { maintainLegacyInvestigationHeartbeat } from "./legacy-job-heartbeat.js";
+import { migrateLegacyInvestigationHeartbeats } from "./legacy-job-heartbeat.js";
 
-describe("legacy investigation heartbeat rollout", () => {
-  afterEach(() => {
-    vi.useRealTimers();
-  });
+describe("legacy investigation heartbeat rollout migration", () => {
+  it("migrates queued legacy jobs before normal work starts", async () => {
+    const executeSql = vi
+      .fn()
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] });
 
-  it("maintains a heartbeat after fetching a pre-rollout job", async () => {
-    vi.useFakeTimers();
-    const executeSql = vi.fn().mockResolvedValue({ rows: [{ id: "job-id" }] });
-    const touch = vi.fn().mockResolvedValue({ affected: 1 });
-    const boss = {
-      emit: vi.fn(),
+    await migrateLegacyInvestigationHeartbeats({
       getDb: () => ({ executeSql }),
-      touch,
-    } as never;
-
-    const stop = await maintainLegacyInvestigationHeartbeat(boss, {
-      heartbeatSeconds: null,
-      id: "job-id",
     });
-    await vi.advanceTimersByTimeAsync(30_000);
 
-    expect(executeSql).toHaveBeenCalledWith(
-      expect.stringContaining("UPDATE pgboss.job"),
-      [investigationQueue, "job-id", 60],
+    expect(executeSql).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining("state IN ('created', 'retry')"),
+      [investigationQueue, 60],
     );
-    expect(touch).toHaveBeenCalledWith(investigationQueue, "job-id");
-    stop();
+    expect(executeSql).toHaveBeenCalledTimes(2);
   });
 
-  it("stays dormant for jobs created with the queue heartbeat", async () => {
-    const executeSql = vi.fn();
-    const touch = vi.fn();
+  it("waits for the old task to hand an active job back", async () => {
+    const executeSql = vi
+      .fn()
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ id: "job-id" }] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] });
+    const wait = vi.fn().mockResolvedValue(undefined);
 
-    const stop = await maintainLegacyInvestigationHeartbeat({
-      getDb: () => ({ executeSql }),
-      touch,
-    } as never, {
-      heartbeatSeconds: 60,
-      id: "job-id",
-    });
+    await migrateLegacyInvestigationHeartbeats(
+      { getDb: () => ({ executeSql }) },
+      { now: () => 0, wait },
+    );
 
-    stop();
-    expect(executeSql).not.toHaveBeenCalled();
-    expect(touch).not.toHaveBeenCalled();
+    expect(wait).toHaveBeenCalledWith(1_000);
+    expect(executeSql).toHaveBeenCalledTimes(4);
+  });
+
+  it("adopts an abandoned active row after the ECS shutdown window", async () => {
+    const executeSql = vi
+      .fn()
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ id: "job-id" }] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    await migrateLegacyInvestigationHeartbeats(
+      { getDb: () => ({ executeSql }) },
+      { graceMs: 0, now: () => 0 },
+    );
+
+    expect(executeSql).toHaveBeenNthCalledWith(
+      3,
+      expect.stringContaining("heartbeat_on = now()"),
+      [investigationQueue, 60],
+    );
   });
 });

--- a/apps/worker/src/legacy-job-heartbeat.ts
+++ b/apps/worker/src/legacy-job-heartbeat.ts
@@ -1,45 +1,73 @@
-import { investigationQueue } from "@responder/core/jobs";
+import {
+  investigationHeartbeatSeconds,
+  investigationQueue,
+} from "@responder/core/jobs";
+import { legacyHeartbeatAdoptionGraceMs } from "./shutdown-policy.js";
 
-const heartbeatSeconds = 60;
+const pollIntervalMs = 1_000;
 
-interface LegacyHeartbeatBoss {
-  emit(event: "error", error: Error): boolean;
+interface LegacyHeartbeatMigrationBoss {
   getDb(): {
     executeSql(text: string, values?: unknown[]): Promise<{ rows: unknown[] }>;
   };
-  touch(name: string, id: string): Promise<unknown>;
 }
 
-// Rollout bridge for jobs fetched before responder-investigations stored a
-// heartbeat. It is dormant for every job created after that queue update and
-// can be removed once no pre-rollout jobs remain in pg-boss retention.
-export async function maintainLegacyInvestigationHeartbeat(
-  boss: LegacyHeartbeatBoss,
-  job: { heartbeatSeconds: number | null; id: string },
-): Promise<() => void> {
-  if (job.heartbeatSeconds !== null) return () => undefined;
+interface LegacyHeartbeatMigrationOptions {
+  graceMs?: number;
+  now?: () => number;
+  wait?: (milliseconds: number) => Promise<void>;
+}
 
-  const adopted = await boss.getDb().executeSql(
-    `UPDATE pgboss.job
-     SET heartbeat_seconds = $3,
-         heartbeat_on = now()
+const wait = (milliseconds: number) =>
+  new Promise<void>((resolve) => setTimeout(resolve, milliseconds));
+
+// One-time rollout migration for jobs created before heartbeat support.
+// Remove this module and startup call after 2026-09-02, when pg-boss's
+// seven-day job retention guarantees no pre-rollout job can remain.
+export async function migrateLegacyInvestigationHeartbeats(
+  boss: LegacyHeartbeatMigrationBoss,
+  options: LegacyHeartbeatMigrationOptions = {},
+): Promise<void> {
+  const database = boss.getDb();
+  const now = options.now ?? Date.now;
+  const waitFor = options.wait ?? wait;
+  const deadline = now() + (options.graceMs ?? legacyHeartbeatAdoptionGraceMs);
+
+  while (true) {
+    await database.executeSql(
+      `UPDATE pgboss.job
+       SET heartbeat_seconds = $2
+       WHERE name = $1
+         AND state IN ('created', 'retry')
+         AND heartbeat_seconds IS NULL`,
+      [investigationQueue, investigationHeartbeatSeconds],
+    );
+    const active = await database.executeSql(
+      `SELECT id
+       FROM pgboss.job
+       WHERE name = $1
+         AND state = 'active'
+         AND heartbeat_seconds IS NULL
+       LIMIT 1`,
+      [investigationQueue],
+    );
+    if (active.rows.length === 0) return;
+    if (now() < deadline) {
+      await waitFor(pollIntervalMs);
+      continue;
+    }
+
+    // The previous ECS task has exhausted its stop timeout. Any legacy active
+    // row is abandoned, so initialize its heartbeat for pg-boss supervision.
+    await database.executeSql(
+      `UPDATE pgboss.job
+       SET heartbeat_seconds = $2,
+           heartbeat_on = now()
      WHERE name = $1
-       AND id = $2::uuid
        AND state = 'active'
-       AND heartbeat_seconds IS NULL
-     RETURNING id`,
-    [investigationQueue, job.id, heartbeatSeconds],
-  );
-  if (adopted.rows.length === 0) return () => undefined;
-
-  const timer = setInterval(() => {
-    void boss.touch(investigationQueue, job.id).catch((error: unknown) => {
-      boss.emit(
-        "error",
-        error instanceof Error ? error : new Error(String(error)),
-      );
-    });
-  }, heartbeatSeconds * 500);
-  timer.unref();
-  return () => clearInterval(timer);
+       AND heartbeat_seconds IS NULL`,
+      [investigationQueue, investigationHeartbeatSeconds],
+    );
+    return;
+  }
 }

--- a/apps/worker/src/shutdown-policy.ts
+++ b/apps/worker/src/shutdown-policy.ts
@@ -1,0 +1,6 @@
+export const workerGracefulShutdownTimeoutMs = 110_000;
+
+// Allow the old task's graceful stop plus a small scheduling margin before a
+// startup migration treats its legacy active job as abandoned.
+export const legacyHeartbeatAdoptionGraceMs =
+  workerGracefulShutdownTimeoutMs + 15_000;

--- a/packages/core/src/jobs.ts
+++ b/packages/core/src/jobs.ts
@@ -17,7 +17,7 @@ export const linearTicketQueue = "responder-linear-tickets-v2";
 export const remediationQueue = "responder-remediations-v2";
 export const pullRequestReviewQueue = "responder-pull-request-reviews-v1";
 
-const investigationHeartbeatSeconds = 60;
+export const investigationHeartbeatSeconds = 60;
 
 export const workerHealthJobSchema = z.object({
   marker: z.string().min(1),


### PR DESCRIPTION
## Summary
- move pre-heartbeat job adoption out of the normal investigation handler
- migrate legacy queued jobs before workers start consuming investigations
- wait through the old ECS task shutdown window before adopting abandoned active rows
- document the explicit removal date for the temporary migration

## Testing
- pnpm typecheck
- pnpm lint
- pnpm test (113 files, 797 tests)

Follow-up to #59. Required by superloglabs/responder#151.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Isolates the legacy investigation heartbeat rollout into a one-time startup migration so pre-rollout jobs get pg-boss heartbeat supervision before investigations start, preventing double-runs during ECS task handoff.

- Sets heartbeat_seconds on queued legacy investigation jobs before starting investigation consumers.
- Polls active legacy rows; waits up to 125s, then adopts abandoned rows by setting heartbeat_on.
- Starts all other queues immediately; only investigations wait for the migration.
- Removes the per-job heartbeat touch in the investigation worker path.
- Exports `investigationHeartbeatSeconds` from `@responder/core` for the migration.
- Centralizes shutdown timeouts in `shutdown-policy.ts`; `boss.stop` reads `workerGracefulShutdownTimeoutMs`.
- Temporary migration slated for removal after 2026-09-02.

<sup>Written for commit f98307846e4c4bcf7d2ee0cedfa52b2eba4908e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/responder-oss/pull/60?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

