### PR TITLE
Install curl in sandbox environments

### DIFF
--- a/apps/worker/src/sandbox.test.ts
+++ b/apps/worker/src/sandbox.test.ts
@@ -63,13 +63,13 @@ describe("Daytona sandbox preparation", () => {
     expect(session.execCommand).toHaveBeenCalledWith(
       expect.objectContaining({
         cmd: expect.stringContaining(
-          "command -v git >/dev/null 2>&1 && command -v python3 >/dev/null 2>&1 && command -v rg >/dev/null 2>&1",
+          "command -v curl >/dev/null 2>&1 && command -v git >/dev/null 2>&1 && command -v python3 >/dev/null 2>&1 && command -v rg >/dev/null 2>&1",
         ),
       }),
     );
     expect(session.execCommand).toHaveBeenCalledWith(
       expect.objectContaining({
-        cmd: expect.stringContaining("install -y -qq git python3 ripgrep"),
+        cmd: expect.stringContaining("install -y -qq curl git python3 ripgrep"),
       }),
     );
   });
@@ -82,7 +82,7 @@ describe("Daytona sandbox preparation", () => {
     } as unknown as DaytonaSandboxSession;
 
     await expect(prepareDaytonaSandbox(session)).rejects.toThrow(
-      "Unable to install git, Python 3, and ripgrep in Daytona: python3 unavailable",
+      "Unable to install curl, git, Python 3, and ripgrep in Daytona: python3 unavailable",
     );
   });
 
@@ -92,7 +92,7 @@ describe("Daytona sandbox preparation", () => {
     } as unknown as DaytonaSandboxSession;
 
     await expect(prepareDaytonaSandbox(session)).rejects.toThrow(
-      "Unable to install git, Python 3, and ripgrep in Daytona",
+      "Unable to install curl, git, Python 3, and ripgrep in Daytona",
     );
   });
 });

--- a/apps/worker/src/sandbox.ts
+++ b/apps/worker/src/sandbox.ts
@@ -136,18 +136,19 @@ export async function prepareDaytonaSandbox(
   const output = await session.execCommand({
     cmd: [
       "set -eu",
-      "if command -v git >/dev/null 2>&1 && command -v python3 >/dev/null 2>&1 && command -v rg >/dev/null 2>&1; then exit 0; fi",
-      "if ! command -v apt-get >/dev/null 2>&1; then echo 'git, Python 3, or ripgrep is unavailable and apt-get is missing' >&2; exit 1; fi",
+      "if command -v curl >/dev/null 2>&1 && command -v git >/dev/null 2>&1 && command -v python3 >/dev/null 2>&1 && command -v rg >/dev/null 2>&1; then exit 0; fi",
+      "if ! command -v apt-get >/dev/null 2>&1; then echo 'curl, git, Python 3, or ripgrep is unavailable and apt-get is missing' >&2; exit 1; fi",
       "if [ \"$(id -u)\" -eq 0 ]; then",
       "  apt-get update -qq",
-      "  DEBIAN_FRONTEND=noninteractive apt-get install -y -qq git python3 ripgrep",
+      "  DEBIAN_FRONTEND=noninteractive apt-get install -y -qq curl git python3 ripgrep",
       "elif command -v sudo >/dev/null 2>&1; then",
       "  sudo apt-get update -qq",
-      "  sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq git python3 ripgrep",
+      "  sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq curl git python3 ripgrep",
       "else",
-      "  echo 'git, Python 3, and ripgrep installation require root access' >&2",
+      "  echo 'curl, git, Python 3, and ripgrep installation require root access' >&2",
       "  exit 1",
       "fi",
+      "command -v curl >/dev/null",
       "command -v git >/dev/null",
       "command -v python3 >/dev/null",
       "command -v rg >/dev/null",
@@ -158,7 +159,7 @@ export async function prepareDaytonaSandbox(
   if (!execSucceeded(output)) {
     const detail = output.split("\nOutput:\n", 2)[1]?.trim();
     throw new Error(
-      `Unable to install git, Python 3, and ripgrep in Daytona${detail ? `: ${detail}` : ""}`,
+      `Unable to install curl, git, Python 3, and ripgrep in Daytona${detail ? `: ${detail}` : ""}`,
     );
   }
 }


### PR DESCRIPTION
## Summary
- require curl during Daytona sandbox preparation
- install curl with the existing investigation tool bundle when missing
- include curl in preparation failures and focused coverage

## Validation
- pnpm typecheck
- pnpm lint
- pnpm test (112 files, 786 tests)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds curl to Daytona sandbox preparation so HTTP-based tooling works reliably. We now require and verify curl alongside git, Python 3, and ripgrep, and install it when missing.

- Uses apt-get to install curl with the existing bundle when running as root or via sudo.
- Emits clearer errors if apt-get or root access is unavailable, mentioning curl.
- Verifies curl post-install and updates tests to cover the new requirement.

<sup>Written for commit aa81170ae067c2b8967b7e34f5fb7a6f9c5aeb5e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/responder-oss/pull/61?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

