### PR TITLE
Safeguard legacy job handoff

### DIFF
--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -258,7 +258,7 @@ async function shutdown(signal: string): Promise<void> {
   try {
     await boss.stop({
       graceful: true,
-      timeout: workerGracefulShutdownTimeoutMs,
+      timeout: workerGracefulShutdownTimeoutMs(),
     });
   } finally {
     await flushWorkerMonitoring();

--- a/apps/worker/src/legacy-job-heartbeat.test.ts
+++ b/apps/worker/src/legacy-job-heartbeat.test.ts
@@ -39,22 +39,20 @@ describe("legacy investigation heartbeat rollout migration", () => {
     expect(executeSql).toHaveBeenCalledTimes(4);
   });
 
-  it("adopts an abandoned active row after the ECS shutdown window", async () => {
+  it("never reclassifies an active row after the handoff window", async () => {
     const executeSql = vi
       .fn()
       .mockResolvedValueOnce({ rows: [] })
-      .mockResolvedValueOnce({ rows: [{ id: "job-id" }] })
-      .mockResolvedValueOnce({ rows: [] });
+      .mockResolvedValueOnce({ rows: [{ id: "job-id" }] });
 
     await migrateLegacyInvestigationHeartbeats(
       { getDb: () => ({ executeSql }) },
       { graceMs: 0, now: () => 0 },
     );
 
-    expect(executeSql).toHaveBeenNthCalledWith(
-      3,
-      expect.stringContaining("heartbeat_on = now()"),
-      [investigationQueue, 60],
+    expect(executeSql).toHaveBeenCalledTimes(2);
+    expect(executeSql.mock.calls.flat().join("\n")).not.toContain(
+      "heartbeat_on = now()",
     );
   });
 });

--- a/apps/worker/src/legacy-job-heartbeat.ts
+++ b/apps/worker/src/legacy-job-heartbeat.ts
@@ -2,7 +2,7 @@ import {
   investigationHeartbeatSeconds,
   investigationQueue,
 } from "@responder/core/jobs";
-import { legacyHeartbeatAdoptionGraceMs } from "./shutdown-policy.js";
+import { legacyHeartbeatHandoffWaitMs } from "./shutdown-policy.js";
 
 const pollIntervalMs = 1_000;
 
@@ -31,7 +31,7 @@ export async function migrateLegacyInvestigationHeartbeats(
   const database = boss.getDb();
   const now = options.now ?? Date.now;
   const waitFor = options.wait ?? wait;
-  const deadline = now() + (options.graceMs ?? legacyHeartbeatAdoptionGraceMs);
+  const deadline = now() + (options.graceMs ?? legacyHeartbeatHandoffWaitMs());
 
   while (true) {
     await database.executeSql(
@@ -52,22 +52,7 @@ export async function migrateLegacyInvestigationHeartbeats(
       [investigationQueue],
     );
     if (active.rows.length === 0) return;
-    if (now() < deadline) {
-      await waitFor(pollIntervalMs);
-      continue;
-    }
-
-    // The previous ECS task has exhausted its stop timeout. Any legacy active
-    // row is abandoned, so initialize its heartbeat for pg-boss supervision.
-    await database.executeSql(
-      `UPDATE pgboss.job
-       SET heartbeat_seconds = $2,
-           heartbeat_on = now()
-     WHERE name = $1
-       AND state = 'active'
-       AND heartbeat_seconds IS NULL`,
-      [investigationQueue, investigationHeartbeatSeconds],
-    );
-    return;
+    if (now() >= deadline) return;
+    await waitFor(pollIntervalMs);
   }
 }

--- a/apps/worker/src/shutdown-policy.test.ts
+++ b/apps/worker/src/shutdown-policy.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import {
+  legacyHeartbeatHandoffWaitMs,
+  workerGracefulShutdownTimeoutMs,
+} from "./shutdown-policy.js";
+
+describe("worker shutdown policy", () => {
+  it("uses the deployment-provided graceful timeout", () => {
+    const environment = {
+      WORKER_GRACEFUL_SHUTDOWN_TIMEOUT_MS: "90000",
+    };
+
+    expect(workerGracefulShutdownTimeoutMs(environment)).toBe(90_000);
+    expect(legacyHeartbeatHandoffWaitMs(environment)).toBe(105_000);
+  });
+
+  it("falls back to the safe default for invalid values", () => {
+    expect(workerGracefulShutdownTimeoutMs({
+      WORKER_GRACEFUL_SHUTDOWN_TIMEOUT_MS: "invalid",
+    })).toBe(110_000);
+  });
+});

--- a/apps/worker/src/shutdown-policy.ts
+++ b/apps/worker/src/shutdown-policy.ts
@@ -1,6 +1,21 @@
-export const workerGracefulShutdownTimeoutMs = 110_000;
+const defaultWorkerGracefulShutdownTimeoutMs = 110_000;
 
-// Allow the old task's graceful stop plus a small scheduling margin before a
-// startup migration treats its legacy active job as abandoned.
-export const legacyHeartbeatAdoptionGraceMs =
-  workerGracefulShutdownTimeoutMs + 15_000;
+export function workerGracefulShutdownTimeoutMs(
+  environment: NodeJS.ProcessEnv = process.env,
+): number {
+  const configured = Number.parseInt(
+    environment.WORKER_GRACEFUL_SHUTDOWN_TIMEOUT_MS ?? "",
+    10,
+  );
+  return Number.isFinite(configured) && configured >= 1_000
+    ? configured
+    : defaultWorkerGracefulShutdownTimeoutMs;
+}
+
+// Wait slightly longer than the old task's graceful stop for it to hand active
+// jobs back. This never reclassifies active work by itself.
+export function legacyHeartbeatHandoffWaitMs(
+  environment: NodeJS.ProcessEnv = process.env,
+): number {
+  return workerGracefulShutdownTimeoutMs(environment) + 15_000;
+}


### PR DESCRIPTION
## Summary
- never reclassify a legacy active job that may still have a healthy owner
- wait for graceful handoff and migrate only queued or retryable legacy jobs
- read the worker graceful-stop timeout from deployment configuration
- cover the handoff safety rule and shutdown policy with focused tests

## Testing
- pnpm typecheck
- pnpm lint
- pnpm test (114 files, 799 tests)

Follow-up to #60. Required by superloglabs/responder#151.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the migrator from reclassifying legacy active jobs during rollout; it now waits for the handoff window and only migrates queued or retryable jobs. The worker’s graceful shutdown timeout is read from deployment configuration with a safe default.

- Active legacy jobs are no longer “adopted” or updated with a heartbeat.
- The handoff wait equals `WORKER_GRACEFUL_SHUTDOWN_TIMEOUT_MS` plus 15s.
- The worker reads `WORKER_GRACEFUL_SHUTDOWN_TIMEOUT_MS` and falls back to 110s for invalid values.
- Adds focused tests for the handoff rule and shutdown policy.

<sup>Written for commit 19989e5a25ad4d522a74935a636b44df50695fa4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/responder-oss/pull/62?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

