### PR TITLE
Log Sentry MCP transport failures

### DIFF
--- a/apps/worker/src/investigate.ts
+++ b/apps/worker/src/investigate.ts
@@ -400,7 +400,9 @@ export async function runInvestigationAgent(
     ? createAxiomMcpServer(axiomConnection)
     : null;
   const sentryServer = sentryConnection
-    ? createSentryMcpServer(sentryConnection)
+    ? createSentryMcpServer(sentryConnection, {
+        investigationId: job.investigationId,
+      })
     : null;
   const customMcpServers = customMcpConnections.map(createCustomMcpServer);
   const clickStackServer = clickStackConnection

--- a/apps/worker/src/sentry.test.ts
+++ b/apps/worker/src/sentry.test.ts
@@ -1,5 +1,32 @@
-import { describe, expect, it } from "vitest";
-import { sentryMcpHeaders } from "./sentry.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  createSentryMcpFetch,
+  createSentryMcpServer,
+  sentryMcpHeaders,
+} from "./sentry.js";
+
+const { serverCallToolResult, serverConstructor } = vi.hoisted(() => ({
+  serverCallToolResult: vi.fn(),
+  serverConstructor: vi.fn(),
+}));
+
+vi.mock("@openai/agents", () => ({
+  MCPServerStreamableHttp: class {
+    constructor(options: unknown) {
+      serverConstructor(options);
+    }
+
+    callToolResult(...args: unknown[]) {
+      return serverCallToolResult(...args);
+    }
+  },
+}));
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  serverCallToolResult.mockReset();
+  serverConstructor.mockClear();
+});
 
 describe("Sentry MCP", () => {
   it("uses the explicit upstream-token authorization scheme", () => {
@@ -11,5 +38,150 @@ describe("Sentry MCP", () => {
         projectSlug: "api",
       }),
     ).toEqual({ authorization: "Sentry-Bearer sentry-test-token" });
+  });
+
+  it("adds investigation-aware transport logging to the MCP server", () => {
+    createSentryMcpServer(
+      {
+        accessToken: "sentry-test-token",
+        mcpUrl: "https://mcp.sentry.dev/mcp/acme/api?skills=inspect",
+        organizationSlug: "acme",
+        projectSlug: "api",
+      },
+      { investigationId: "investigation-1" },
+    );
+
+    expect(serverConstructor).toHaveBeenCalledWith(
+      expect.objectContaining({ fetch: expect.any(Function) }),
+    );
+  });
+
+  it("logs every tool-call failure with its investigation", async () => {
+    const failure = new Error("sanitized transport failure");
+    failure.name = "MCPTransportError";
+    serverCallToolResult.mockRejectedValue(failure);
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const server = createSentryMcpServer(
+      {
+        accessToken: "sentry-test-token",
+        mcpUrl: "https://mcp.sentry.dev/mcp/acme/api?skills=inspect",
+        organizationSlug: "acme",
+        projectSlug: "api",
+      },
+      { investigationId: "investigation-1" },
+    );
+
+    await expect(server.callToolResult("search_events", {})).rejects.toBe(
+      failure,
+    );
+
+    expect(JSON.parse(String(consoleError.mock.calls[0]?.[0]))).toEqual({
+      durationMs: expect.any(Number),
+      errorName: "MCPTransportError",
+      event: "sentry_mcp_tool_call_failed",
+      investigationId: "investigation-1",
+      toolName: "search_events",
+    });
+  });
+
+  it("logs safe HTTP failure details without request arguments or response bodies", async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response("upstream secret response", {
+        headers: {
+          "retry-after": "10",
+          "x-request-id": "upstream-request-1",
+        },
+        status: 503,
+      }),
+    );
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const sentryFetch = createSentryMcpFetch(
+      { investigationId: "investigation-1" },
+      fetchImpl,
+    );
+
+    await sentryFetch("https://mcp.sentry.dev/mcp/acme?skills=inspect", {
+      body: JSON.stringify({
+        id: 1,
+        jsonrpc: "2.0",
+        method: "tools/call",
+        params: {
+          arguments: { query: "customer secret" },
+          name: "search_events",
+        },
+      }),
+      headers: { authorization: "Sentry-Bearer sentry-test-token" },
+      method: "POST",
+    });
+
+    const log = String(consoleError.mock.calls[0]?.[0]);
+    expect(JSON.parse(log)).toEqual({
+      durationMs: expect.any(Number),
+      event: "sentry_mcp_http_error",
+      investigationId: "investigation-1",
+      mcpMethod: "tools/call",
+      method: "POST",
+      retryAfter: "10",
+      status: 503,
+      toolName: "search_events",
+      upstreamRequestId: "upstream-request-1",
+    });
+    expect(log).not.toContain("customer secret");
+    expect(log).not.toContain("sentry-test-token");
+    expect(log).not.toContain("upstream secret response");
+  });
+
+  it("logs safe network error codes and rethrows the original failure", async () => {
+    const cause = Object.assign(new Error("connect timed out"), {
+      code: "UND_ERR_CONNECT_TIMEOUT",
+    });
+    const failure = Object.assign(new TypeError("fetch failed"), { cause });
+    const fetchImpl = vi.fn<typeof fetch>().mockRejectedValue(failure);
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const sentryFetch = createSentryMcpFetch(
+      { investigationId: "investigation-2" },
+      fetchImpl,
+    );
+
+    await expect(
+      sentryFetch("https://mcp.sentry.dev/mcp/acme?skills=inspect", {
+        body: JSON.stringify({
+          id: 1,
+          jsonrpc: "2.0",
+          method: "tools/call",
+          params: { name: "get_sentry_resource" },
+        }),
+        method: "POST",
+      }),
+    ).rejects.toBe(failure);
+
+    expect(JSON.parse(String(consoleError.mock.calls[0]?.[0]))).toEqual({
+      causeCode: "UND_ERR_CONNECT_TIMEOUT",
+      causeName: "Error",
+      durationMs: expect.any(Number),
+      errorName: "TypeError",
+      event: "sentry_mcp_transport_error",
+      investigationId: "investigation-2",
+      mcpMethod: "tools/call",
+      method: "POST",
+      toolName: "get_sentry_resource",
+    });
+  });
+
+  it("does not report an unsupported optional stream as a failure", async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(new Response(null, { status: 405 }));
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const sentryFetch = createSentryMcpFetch(
+      { investigationId: "investigation-3" },
+      fetchImpl,
+    );
+
+    await sentryFetch("https://mcp.sentry.dev/mcp/acme?skills=inspect", {
+      method: "GET",
+    });
+
+    expect(consoleError).not.toHaveBeenCalled();
   });
 });

--- a/apps/worker/src/sentry.test.ts
+++ b/apps/worker/src/sentry.test.ts
@@ -129,13 +129,104 @@ describe("Sentry MCP", () => {
       event: "sentry_mcp_tool_call_failed",
       investigationId: "investigation-1",
       toolName: "search_events",
-      transport: {
-        durationMs: expect.any(Number),
-        kind: "http",
-        mcpMethod: "tools/call",
-        method: "POST",
-        status: 503,
+      transportFailureCount: 1,
+      transportFailures: [
+        {
+          durationMs: expect.any(Number),
+          kind: "http",
+          mcpMethod: "tools/call",
+          method: "POST",
+          status: 503,
+        },
+      ],
+    });
+  });
+
+  it("keeps every transport failure from a failed tool call", async () => {
+    const failure = new Error("sanitized transport failure");
+    failure.name = "MCPTransportError";
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(null, { status: 503 }))
+      .mockResolvedValueOnce(new Response(null, { status: 504 }));
+    const server = createSentryMcpServer(
+      {
+        accessToken: "sentry-test-token",
+        mcpUrl: "https://mcp.sentry.dev/mcp/acme/api?skills=inspect",
+        organizationSlug: "acme",
+        projectSlug: "api",
       },
+      { investigationId: "investigation-1" },
+    );
+    serverCallToolResult.mockImplementation(async () => {
+      const fetchImpl = serverOptions.current?.fetch as typeof fetch;
+      const request = {
+        body: JSON.stringify({
+          id: 1,
+          jsonrpc: "2.0",
+          method: "tools/call",
+          params: { name: "search_events" },
+        }),
+        method: "POST",
+      };
+      await fetchImpl("https://mcp.sentry.dev/mcp/acme?skills=inspect", request);
+      await fetchImpl("https://mcp.sentry.dev/mcp/acme?skills=inspect", request);
+      throw failure;
+    });
+
+    await expect(server.callToolResult("search_events", {})).rejects.toBe(
+      failure,
+    );
+
+    expect(consoleError).toHaveBeenCalledTimes(1);
+    const log = JSON.parse(String(consoleError.mock.calls[0]?.[0]));
+    expect(log.transportFailureCount).toBe(2);
+    expect(log.transportFailures).toEqual([
+      expect.objectContaining({ kind: "http", status: 503 }),
+      expect.objectContaining({ kind: "http", status: 504 }),
+    ]);
+  });
+
+  it("logs transport failures when a tool retry recovers", async () => {
+    const consoleInfo = vi.spyOn(console, "info").mockImplementation(() => {});
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(null, { status: 503 }),
+    );
+    const server = createSentryMcpServer(
+      {
+        accessToken: "sentry-test-token",
+        mcpUrl: "https://mcp.sentry.dev/mcp/acme/api?skills=inspect",
+        organizationSlug: "acme",
+        projectSlug: "api",
+      },
+      { investigationId: "investigation-1" },
+    );
+    serverCallToolResult.mockImplementation(async () => {
+      const fetchImpl = serverOptions.current?.fetch as typeof fetch;
+      await fetchImpl("https://mcp.sentry.dev/mcp/acme?skills=inspect", {
+        body: JSON.stringify({
+          id: 1,
+          jsonrpc: "2.0",
+          method: "tools/call",
+          params: { name: "search_events" },
+        }),
+        method: "POST",
+      });
+      return { content: [] };
+    });
+
+    await server.callToolResult("search_events", {});
+
+    expect(consoleInfo).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(String(consoleInfo.mock.calls[0]?.[0]))).toEqual({
+      durationMs: expect.any(Number),
+      event: "sentry_mcp_tool_call_recovered",
+      investigationId: "investigation-1",
+      toolName: "search_events",
+      transportFailureCount: 1,
+      transportFailures: [
+        expect.objectContaining({ kind: "http", status: 503 }),
+      ],
     });
   });
 

--- a/apps/worker/src/sentry.test.ts
+++ b/apps/worker/src/sentry.test.ts
@@ -5,15 +5,19 @@ import {
   sentryMcpHeaders,
 } from "./sentry.js";
 
-const { serverCallToolResult, serverConstructor } = vi.hoisted(() => ({
-  serverCallToolResult: vi.fn(),
-  serverConstructor: vi.fn(),
-}));
+const { serverCallToolResult, serverConstructor, serverOptions } = vi.hoisted(
+  () => ({
+    serverCallToolResult: vi.fn(),
+    serverConstructor: vi.fn(),
+    serverOptions: { current: null as Record<string, unknown> | null },
+  }),
+);
 
 vi.mock("@openai/agents", () => ({
   MCPServerStreamableHttp: class {
     constructor(options: unknown) {
       serverConstructor(options);
+      serverOptions.current = options as Record<string, unknown>;
     }
 
     callToolResult(...args: unknown[]) {
@@ -26,6 +30,7 @@ afterEach(() => {
   vi.restoreAllMocks();
   serverCallToolResult.mockReset();
   serverConstructor.mockClear();
+  serverOptions.current = null;
 });
 
 describe("Sentry MCP", () => {
@@ -84,6 +89,56 @@ describe("Sentry MCP", () => {
     });
   });
 
+  it("combines tool and HTTP failure diagnostics into one event", async () => {
+    const failure = new Error("sanitized transport failure");
+    failure.name = "MCPTransportError";
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(null, { status: 503 }),
+    );
+    const server = createSentryMcpServer(
+      {
+        accessToken: "sentry-test-token",
+        mcpUrl: "https://mcp.sentry.dev/mcp/acme/api?skills=inspect",
+        organizationSlug: "acme",
+        projectSlug: "api",
+      },
+      { investigationId: "investigation-1" },
+    );
+    serverCallToolResult.mockImplementation(async () => {
+      const fetchImpl = serverOptions.current?.fetch as typeof fetch;
+      await fetchImpl("https://mcp.sentry.dev/mcp/acme?skills=inspect", {
+        body: JSON.stringify({
+          id: 1,
+          jsonrpc: "2.0",
+          method: "tools/call",
+          params: { name: "search_events" },
+        }),
+        method: "POST",
+      });
+      throw failure;
+    });
+    await expect(server.callToolResult("search_events", {})).rejects.toBe(
+      failure,
+    );
+
+    expect(consoleError).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(String(consoleError.mock.calls[0]?.[0]))).toEqual({
+      durationMs: expect.any(Number),
+      errorName: "MCPTransportError",
+      event: "sentry_mcp_tool_call_failed",
+      investigationId: "investigation-1",
+      toolName: "search_events",
+      transport: {
+        durationMs: expect.any(Number),
+        kind: "http",
+        mcpMethod: "tools/call",
+        method: "POST",
+        status: 503,
+      },
+    });
+  });
+
   it("logs safe HTTP failure details without request arguments or response bodies", async () => {
     const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
       new Response("upstream secret response", {
@@ -119,6 +174,7 @@ describe("Sentry MCP", () => {
       durationMs: expect.any(Number),
       event: "sentry_mcp_http_error",
       investigationId: "investigation-1",
+      kind: "http",
       mcpMethod: "tools/call",
       method: "POST",
       retryAfter: "10",
@@ -162,6 +218,7 @@ describe("Sentry MCP", () => {
       errorName: "TypeError",
       event: "sentry_mcp_transport_error",
       investigationId: "investigation-2",
+      kind: "network",
       mcpMethod: "tools/call",
       method: "POST",
       toolName: "get_sentry_resource",

--- a/apps/worker/src/sentry.ts
+++ b/apps/worker/src/sentry.ts
@@ -1,6 +1,155 @@
 import { MCPServerStreamableHttp } from "@openai/agents";
 import type { RuntimeSentryConnection } from "@responder/core/db/investigations";
 
+interface SentryMcpRequestContext {
+  investigationId: string;
+}
+
+interface SentryMcpRequestDetails {
+  mcpMethod?: string;
+  method: string;
+  toolName?: string;
+}
+
+class SentryMcpServer extends MCPServerStreamableHttp {
+  constructor(
+    options: ConstructorParameters<typeof MCPServerStreamableHttp>[0],
+    private readonly context: SentryMcpRequestContext,
+  ) {
+    super(options);
+  }
+
+  override async callToolResult(
+    ...args: Parameters<MCPServerStreamableHttp["callToolResult"]>
+  ): ReturnType<MCPServerStreamableHttp["callToolResult"]> {
+    const startedAt = performance.now();
+    try {
+      return await super.callToolResult(...args);
+    } catch (error) {
+      console.error(
+        JSON.stringify({
+          durationMs: Math.round(performance.now() - startedAt),
+          errorCode: errorCode(error),
+          errorName: errorName(error),
+          event: "sentry_mcp_tool_call_failed",
+          investigationId: this.context.investigationId,
+          toolName: args[0].slice(0, 100),
+        }),
+      );
+      throw error;
+    }
+  }
+}
+
+function requestDetails(
+  input: Parameters<typeof fetch>[0],
+  init: Parameters<typeof fetch>[1],
+): SentryMcpRequestDetails {
+  const method = (
+    init?.method ?? (input instanceof Request ? input.method : "GET")
+  ).toUpperCase();
+  if (method !== "POST" || typeof init?.body !== "string") return { method };
+
+  try {
+    const payload: unknown = JSON.parse(init.body);
+    if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+      return { method };
+    }
+    const record = payload as Record<string, unknown>;
+    const params =
+      record.params &&
+      typeof record.params === "object" &&
+      !Array.isArray(record.params)
+        ? (record.params as Record<string, unknown>)
+        : null;
+    return {
+      method,
+      ...(typeof record.method === "string"
+        ? { mcpMethod: record.method.slice(0, 100) }
+        : {}),
+      ...(record.method === "tools/call" && typeof params?.name === "string"
+        ? { toolName: params.name.slice(0, 100) }
+        : {}),
+    };
+  } catch {
+    return { method };
+  }
+}
+
+function errorName(error: unknown): string {
+  return error instanceof Error ? error.name.slice(0, 100) : typeof error;
+}
+
+function errorCode(error: unknown): string | undefined {
+  if (!error || typeof error !== "object") return undefined;
+  const code = (error as { code?: unknown }).code;
+  return typeof code === "string" && /^[A-Z0-9_-]{1,100}$/u.test(code)
+    ? code
+    : undefined;
+}
+
+function expectedUnsupportedRequest(
+  details: SentryMcpRequestDetails,
+  response: Response,
+): boolean {
+  return (
+    response.status === 405 &&
+    (details.method === "GET" || details.method === "DELETE")
+  );
+}
+
+export function createSentryMcpFetch(
+  context: SentryMcpRequestContext,
+  fetchImpl: typeof fetch = globalThis.fetch,
+): typeof fetch {
+  // The agent SDK redacts errors for every endpoint with a query string and
+  // drops the original cause. Sentry intentionally uses `?skills=inspect`, so
+  // record safe transport details before the SDK replaces the failure.
+  return async (input, init) => {
+    const startedAt = performance.now();
+    const details = requestDetails(input, init);
+    try {
+      const response = await fetchImpl(input, init);
+      if (!response.ok && !expectedUnsupportedRequest(details, response)) {
+        console.error(
+          JSON.stringify({
+            ...details,
+            durationMs: Math.round(performance.now() - startedAt),
+            event: "sentry_mcp_http_error",
+            investigationId: context.investigationId,
+            retryAfter: response.headers.get("retry-after") ?? undefined,
+            status: response.status,
+            statusText: response.statusText.slice(0, 100) || undefined,
+            upstreamRequestId:
+              response.headers.get("x-request-id") ??
+              response.headers.get("x-sentry-request-id") ??
+              undefined,
+          }),
+        );
+      }
+      return response;
+    } catch (error) {
+      const cause =
+        error && typeof error === "object"
+          ? (error as { cause?: unknown }).cause
+          : undefined;
+      console.error(
+        JSON.stringify({
+          ...details,
+          causeCode: errorCode(cause),
+          causeName: cause === undefined ? undefined : errorName(cause),
+          durationMs: Math.round(performance.now() - startedAt),
+          errorCode: errorCode(error),
+          errorName: errorName(error),
+          event: "sentry_mcp_transport_error",
+          investigationId: context.investigationId,
+        }),
+      );
+      throw error;
+    }
+  };
+}
+
 export function sentryMcpHeaders(
   connection: RuntimeSentryConnection,
 ): Record<string, string> {
@@ -11,16 +160,21 @@ export function sentryMcpHeaders(
 
 export function createSentryMcpServer(
   connection: RuntimeSentryConnection,
+  context: SentryMcpRequestContext,
 ): MCPServerStreamableHttp {
-  return new MCPServerStreamableHttp({
-    cacheToolsList: true,
-    clientSessionTimeoutSeconds: 300,
-    name: "sentry",
-    requestInit: {
-      headers: sentryMcpHeaders(connection),
+  return new SentryMcpServer(
+    {
+      cacheToolsList: true,
+      clientSessionTimeoutSeconds: 300,
+      fetch: createSentryMcpFetch(context),
+      name: "sentry",
+      requestInit: {
+        headers: sentryMcpHeaders(connection),
+      },
+      timeout: 30_000,
+      url: connection.mcpUrl,
+      useStructuredContent: true,
     },
-    timeout: 30_000,
-    url: connection.mcpUrl,
-    useStructuredContent: true,
-  });
+    context,
+  );
 }

--- a/apps/worker/src/sentry.ts
+++ b/apps/worker/src/sentry.ts
@@ -1,5 +1,6 @@
 import { MCPServerStreamableHttp } from "@openai/agents";
 import type { RuntimeSentryConnection } from "@responder/core/db/investigations";
+import { AsyncLocalStorage } from "node:async_hooks";
 
 interface SentryMcpRequestContext {
   investigationId: string;
@@ -11,10 +12,38 @@ interface SentryMcpRequestDetails {
   toolName?: string;
 }
 
+type SentryMcpTransportDiagnostics = Pick<
+  SentryMcpRequestDetails,
+  "mcpMethod" | "method" | "toolName"
+> &
+  (
+    | {
+        durationMs: number;
+        kind: "http";
+        retryAfter?: string;
+        status: number;
+        statusText?: string;
+        upstreamRequestId?: string;
+      }
+    | {
+        causeCode?: string;
+        causeName?: string;
+        durationMs: number;
+        errorCode?: string;
+        errorName: string;
+        kind: "network";
+      }
+  );
+
+interface SentryMcpToolCallState {
+  transport?: Omit<SentryMcpTransportDiagnostics, "toolName">;
+}
+
 class SentryMcpServer extends MCPServerStreamableHttp {
   constructor(
     options: ConstructorParameters<typeof MCPServerStreamableHttp>[0],
     private readonly context: SentryMcpRequestContext,
+    private readonly toolCallStorage: AsyncLocalStorage<SentryMcpToolCallState>,
   ) {
     super(options);
   }
@@ -23,8 +52,11 @@ class SentryMcpServer extends MCPServerStreamableHttp {
     ...args: Parameters<MCPServerStreamableHttp["callToolResult"]>
   ): ReturnType<MCPServerStreamableHttp["callToolResult"]> {
     const startedAt = performance.now();
+    const state: SentryMcpToolCallState = {};
     try {
-      return await super.callToolResult(...args);
+      return await this.toolCallStorage.run(state, () =>
+        super.callToolResult(...args),
+      );
     } catch (error) {
       console.error(
         JSON.stringify({
@@ -34,11 +66,34 @@ class SentryMcpServer extends MCPServerStreamableHttp {
           event: "sentry_mcp_tool_call_failed",
           investigationId: this.context.investigationId,
           toolName: args[0].slice(0, 100),
+          transport: state.transport,
         }),
       );
       throw error;
     }
   }
+}
+
+function recordTransportFailure(
+  context: SentryMcpRequestContext,
+  toolCallStorage: AsyncLocalStorage<SentryMcpToolCallState> | undefined,
+  event: "sentry_mcp_http_error" | "sentry_mcp_transport_error",
+  diagnostics: SentryMcpTransportDiagnostics,
+): void {
+  const state = toolCallStorage?.getStore();
+  if (state) {
+    const transport = { ...diagnostics };
+    delete transport.toolName;
+    state.transport = transport;
+    return;
+  }
+  console.error(
+    JSON.stringify({
+      ...diagnostics,
+      event,
+      investigationId: context.investigationId,
+    }),
+  );
 }
 
 function requestDetails(
@@ -101,6 +156,7 @@ function expectedUnsupportedRequest(
 export function createSentryMcpFetch(
   context: SentryMcpRequestContext,
   fetchImpl: typeof fetch = globalThis.fetch,
+  toolCallStorage?: AsyncLocalStorage<SentryMcpToolCallState>,
 ): typeof fetch {
   // The agent SDK redacts errors for every endpoint with a query string and
   // drops the original cause. Sentry intentionally uses `?skills=inspect`, so
@@ -111,20 +167,24 @@ export function createSentryMcpFetch(
     try {
       const response = await fetchImpl(input, init);
       if (!response.ok && !expectedUnsupportedRequest(details, response)) {
-        console.error(
-          JSON.stringify({
-            ...details,
+        recordTransportFailure(
+          context,
+          toolCallStorage,
+          "sentry_mcp_http_error",
+          {
             durationMs: Math.round(performance.now() - startedAt),
-            event: "sentry_mcp_http_error",
-            investigationId: context.investigationId,
+            kind: "http",
+            mcpMethod: details.mcpMethod,
+            method: details.method,
             retryAfter: response.headers.get("retry-after") ?? undefined,
             status: response.status,
             statusText: response.statusText.slice(0, 100) || undefined,
+            toolName: details.toolName,
             upstreamRequestId:
               response.headers.get("x-request-id") ??
               response.headers.get("x-sentry-request-id") ??
               undefined,
-          }),
+          },
         );
       }
       return response;
@@ -133,17 +193,21 @@ export function createSentryMcpFetch(
         error && typeof error === "object"
           ? (error as { cause?: unknown }).cause
           : undefined;
-      console.error(
-        JSON.stringify({
-          ...details,
+      recordTransportFailure(
+        context,
+        toolCallStorage,
+        "sentry_mcp_transport_error",
+        {
           causeCode: errorCode(cause),
           causeName: cause === undefined ? undefined : errorName(cause),
           durationMs: Math.round(performance.now() - startedAt),
           errorCode: errorCode(error),
           errorName: errorName(error),
-          event: "sentry_mcp_transport_error",
-          investigationId: context.investigationId,
-        }),
+          kind: "network",
+          mcpMethod: details.mcpMethod,
+          method: details.method,
+          toolName: details.toolName,
+        },
       );
       throw error;
     }
@@ -162,11 +226,12 @@ export function createSentryMcpServer(
   connection: RuntimeSentryConnection,
   context: SentryMcpRequestContext,
 ): MCPServerStreamableHttp {
+  const toolCallStorage = new AsyncLocalStorage<SentryMcpToolCallState>();
   return new SentryMcpServer(
     {
       cacheToolsList: true,
       clientSessionTimeoutSeconds: 300,
-      fetch: createSentryMcpFetch(context),
+      fetch: createSentryMcpFetch(context, globalThis.fetch, toolCallStorage),
       name: "sentry",
       requestInit: {
         headers: sentryMcpHeaders(connection),
@@ -176,5 +241,6 @@ export function createSentryMcpServer(
       useStructuredContent: true,
     },
     context,
+    toolCallStorage,
   );
 }

--- a/apps/worker/src/sentry.ts
+++ b/apps/worker/src/sentry.ts
@@ -36,7 +36,22 @@ type SentryMcpTransportDiagnostics = Pick<
   );
 
 interface SentryMcpToolCallState {
-  transport?: Omit<SentryMcpTransportDiagnostics, "toolName">;
+  transportFailureCount: number;
+  transportFailures: Array<Omit<SentryMcpTransportDiagnostics, "toolName">>;
+}
+
+const MAX_TRANSPORT_FAILURES_PER_TOOL_CALL = 5;
+
+function transportFailureFields(state: SentryMcpToolCallState): object {
+  return state.transportFailureCount === 0
+    ? {}
+    : {
+        transportFailureCount: state.transportFailureCount,
+        transportFailures: state.transportFailures,
+        transportFailuresTruncated:
+          state.transportFailureCount > state.transportFailures.length ||
+          undefined,
+      };
 }
 
 class SentryMcpServer extends MCPServerStreamableHttp {
@@ -52,11 +67,26 @@ class SentryMcpServer extends MCPServerStreamableHttp {
     ...args: Parameters<MCPServerStreamableHttp["callToolResult"]>
   ): ReturnType<MCPServerStreamableHttp["callToolResult"]> {
     const startedAt = performance.now();
-    const state: SentryMcpToolCallState = {};
+    const state: SentryMcpToolCallState = {
+      transportFailureCount: 0,
+      transportFailures: [],
+    };
     try {
-      return await this.toolCallStorage.run(state, () =>
+      const result = await this.toolCallStorage.run(state, () =>
         super.callToolResult(...args),
       );
+      if (state.transportFailureCount > 0) {
+        console.info(
+          JSON.stringify({
+            durationMs: Math.round(performance.now() - startedAt),
+            event: "sentry_mcp_tool_call_recovered",
+            investigationId: this.context.investigationId,
+            toolName: args[0].slice(0, 100),
+            ...transportFailureFields(state),
+          }),
+        );
+      }
+      return result;
     } catch (error) {
       console.error(
         JSON.stringify({
@@ -66,7 +96,7 @@ class SentryMcpServer extends MCPServerStreamableHttp {
           event: "sentry_mcp_tool_call_failed",
           investigationId: this.context.investigationId,
           toolName: args[0].slice(0, 100),
-          transport: state.transport,
+          ...transportFailureFields(state),
         }),
       );
       throw error;
@@ -84,7 +114,12 @@ function recordTransportFailure(
   if (state) {
     const transport = { ...diagnostics };
     delete transport.toolName;
-    state.transport = transport;
+    state.transportFailureCount += 1;
+    if (
+      state.transportFailures.length < MAX_TRANSPORT_FAILURES_PER_TOOL_CALL
+    ) {
+      state.transportFailures.push(transport);
+    }
     return;
   }
   console.error(


### PR DESCRIPTION
## Summary

- add investigation-aware logging for Sentry MCP tool failures
- record safe HTTP status, retry, request ID, duration, and network error codes before transport errors are sanitized
- exclude credentials, URLs, headers, tool arguments, and response bodies from diagnostics

## Validation

- pnpm typecheck
- pnpm lint
- pnpm test
- pnpm build