### PR TITLE
Add issue remediation workflows

### DIFF
--- a/apps/control-plane/package.json
+++ b/apps/control-plane/package.json
@@ -19,6 +19,7 @@
     "@daytona/sdk": "0.203.0",
     "@fontsource-variable/inter": "5.2.8",
     "@hono/node-server": "2.0.12",
+    "@pierre/diffs": "1.2.5",
     "@responder/core": "workspace:*",
     "@sentry/hono": "10.69.0",
     "@sentry/node": "10.69.0",

--- a/apps/control-plane/server/index.test.ts
+++ b/apps/control-plane/server/index.test.ts
@@ -1134,69 +1134,68 @@ describe("control-plane API", () => {
     });
   });
 
-  it("removes the create-pull-request button after queueing", () => {
-    expect(
-      slackPullRequestQueuedResponse({
-        text: "SEV-2 — Plant API returns HTTP 500",
-        blocks: [
-          {
-            type: "section",
-            text: { type: "mrkdwn", text: "*SEV-2 — Plant API*" },
-          },
-          {
-            type: "actions",
-            elements: [
-              {
-                type: "button",
-                action_id: "create_issue_pull_request",
-                value: "07070707-0707-4707-8707-070707070707",
-              },
-              {
-                type: "button",
-                action_id: "view_issue",
-                value: "07070707-0707-4707-8707-070707070707",
-              },
-            ],
-          },
-        ],
-      }),
-    ).toEqual({
-      replace_original: true,
-      text: "SEV-2 — Plant API returns HTTP 500",
-      blocks: [
-        {
-          type: "section",
-          text: { type: "mrkdwn", text: "*SEV-2 — Plant API*" },
-        },
-        {
-          type: "actions",
-          elements: [
-            {
-              type: "button",
-              action_id: "view_issue",
-              value: "07070707-0707-4707-8707-070707070707",
-            },
-          ],
-        },
-        {
-          type: "context",
-          elements: [
-            {
-              type: "mrkdwn",
-              text: "Pull request creation started. Follow progress in the issue.",
-            },
-          ],
-        },
-      ],
+  it("replaces the remediation picker with the selected remediation and PR cards", () => {
+    const response = slackPullRequestQueuedResponse({
+      failureReason: null,
+      issueId: "07070707-0707-4707-8707-070707070707",
+      issueSeverity: "SEV-2",
+      issueTitle: "Plant API returns HTTP 500",
+      pullRequestNumber: null,
+      pullRequestUrl: null,
+      repositoryFullName: null,
+      requestId: "23232323-2323-4323-8323-232323232323",
+      selectedRemediation: {
+        id: "24242424-2424-4424-8424-242424242424",
+        type: "code_change",
+        title: "Restore the plant guard",
+        description: "Handle plants without a configured color.",
+        diff: "diff --git a/a b/a\n--- a/a\n+++ b/a\n@@ -1 +1 @@\n-a\n+b",
+      },
+      status: "creating",
     });
+
+    expect(response.replace_original).toBe(true);
+    expect(response.text).toContain("Pull request: Creating");
+    expect(response.blocks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "header",
+          text: expect.objectContaining({ text: "Selected remediation" }),
+        }),
+        expect.objectContaining({
+          type: "header",
+          text: expect.objectContaining({ text: "Pull request" }),
+        }),
+      ]),
+    );
   });
 
   it("starts pull request creation from a signed Slack action", async () => {
     vi.stubEnv("SLACK_SIGNING_SECRET", "slack-signing-secret");
+    const remediationId = "24242424-2424-4424-8424-242424242424";
     vi.mocked(startSlackIssueRemediation).mockResolvedValue({
       ok: true,
       requestId: "23232323-2323-4323-8323-232323232323",
       sessionId: "session-1",
+      integrationAccountId: "25252525-2525-4525-8525-252525252525",
+      card: {
+        failureReason: null,
+        issueId: "07070707-0707-4707-8707-070707070707",
+        issueSeverity: "SEV-2",
+        issueTitle: "Plant API returns HTTP 500",
+        pullRequestNumber: null,
+        pullRequestUrl: null,
+        repositoryFullName: null,
+        requestId: "23232323-2323-4323-8323-232323232323",
+        selectedRemediation: {
+          id: remediationId,
+          type: "code_change",
+          title: "Restore the plant guard",
+          description: "Handle plants without a configured color.",
+          diff: "diff --git a/a b/a\n--- a/a\n+++ b/a\n@@ -1 +1 @@\n-a\n+b",
+        },
+        status: "creating",
+      },
     });
     const responseUrl =
       "https://hooks.slack.com/actions/T123/B123/response-token";
@@ -1216,7 +1215,7 @@ describe("control-plane API", () => {
               {
                 type: "button",
                 action_id: "create_issue_pull_request",
-                value: issueId,
+                value: JSON.stringify({ issueId, remediationId }),
               },
             ],
           },
@@ -1225,7 +1224,7 @@ describe("control-plane API", () => {
       actions: [
         {
           action_id: "create_issue_pull_request",
-          value: issueId,
+          value: JSON.stringify({ issueId, remediationId }),
         },
       ],
     });
@@ -1250,6 +1249,7 @@ describe("control-plane API", () => {
     expect(response.status).toBe(200);
     expect(startSlackIssueRemediation).toHaveBeenCalledWith({
       issueId,
+      remediationId,
       teamId: "T123",
     });
     expect(fetchMock).toHaveBeenCalledWith(

--- a/apps/control-plane/server/investigations/queue.ts
+++ b/apps/control-plane/server/investigations/queue.ts
@@ -261,6 +261,14 @@ export async function queueIssueRemediation(requestId: string) {
 export async function queuePullRequestReview(input: {
   installationId: number;
   pullRequestNumber: number;
+  reviewComment: {
+    author: string;
+    body: string;
+    id: number;
+    line: number | null;
+    path: string;
+    url: string;
+  };
   repositoryFullName: string;
 }) {
   return queuePullRequestReviewJob(

--- a/apps/control-plane/server/issues/remediation.ts
+++ b/apps/control-plane/server/issues/remediation.ts
@@ -4,6 +4,7 @@ import {
   queueManualIssuePullRequest,
 } from "../../../../packages/core/src/db/pull-requests.js";
 import { queueIssueRemediation } from "../investigations/queue.js";
+import type { SlackIssuePullRequestCard } from "../../../../packages/core/src/integrations/slack-remediations.js";
 
 export type IssueRemediationStartResult =
   | {
@@ -20,6 +21,7 @@ export type IssueRemediationStartResult =
 export async function startIssueRemediation(input: {
   issueId: string;
   organizationId: string;
+  remediationId: string;
 }): Promise<IssueRemediationStartResult> {
   const queued = await queueManualIssuePullRequest(input);
   try {
@@ -38,14 +40,51 @@ export async function startIssueRemediation(input: {
 
 export async function startSlackIssueRemediation(input: {
   issueId: string;
+  remediationId?: string;
   teamId: string;
-}): Promise<IssueRemediationStartResult> {
+}): Promise<
+  | Exclude<IssueRemediationStartResult, { ok: true }>
+  | (Extract<IssueRemediationStartResult, { ok: true }> & {
+      card: SlackIssuePullRequestCard;
+      integrationAccountId: string;
+    })
+> {
   const issue = await getIssueForSlackAction(input);
   if (!issue) {
     throw new IssuePullRequestError("Issue not found", "issue_not_found");
   }
-  return startIssueRemediation({
+  const remediation = issue.remediations.find(
+    (candidate) =>
+      candidate.type === "code_change" &&
+      (!input.remediationId || candidate.id === input.remediationId),
+  );
+  if (!remediation) {
+    throw new IssuePullRequestError(
+      "This issue does not have a code remediation",
+      "not_available",
+    );
+  }
+  const result = await startIssueRemediation({
     issueId: issue.id,
     organizationId: issue.organizationId,
+    remediationId: remediation.id,
   });
+  return result.ok
+    ? {
+        ...result,
+        integrationAccountId: issue.integrationAccountId,
+        card: {
+          failureReason: null,
+          issueId: issue.id,
+          issueSeverity: issue.severity,
+          issueTitle: issue.title,
+          pullRequestNumber: null,
+          pullRequestUrl: null,
+          repositoryFullName: null,
+          requestId: result.requestId,
+          selectedRemediation: remediation,
+          status: "creating",
+        },
+      }
+    : result;
 }

--- a/apps/control-plane/server/issues/routes.ts
+++ b/apps/control-plane/server/issues/routes.ts
@@ -10,6 +10,7 @@ import { getActiveTenant } from "../tenant.js";
 import { startIssueRemediation } from "./remediation.js";
 
 const updateIssueSchema = z.object({ archived: z.boolean() });
+const createPullRequestSchema = z.object({ remediationId: z.uuid() });
 
 export const issueRoutes = new Hono()
   .get("/", async (context) => {
@@ -42,11 +43,19 @@ export const issueRoutes = new Hono()
       return context.json({ error: tenant.error }, tenant.status);
     }
 
+    const parsed = createPullRequestSchema.safeParse(
+      await context.req.json().catch(() => null),
+    );
+    if (!parsed.success) {
+      return context.json({ error: "Invalid code remediation" }, 400);
+    }
+
     let result;
     try {
       result = await startIssueRemediation({
         issueId: context.req.param("issueId"),
         organizationId: tenant.organizationId,
+        remediationId: parsed.data.remediationId,
       });
     } catch (error) {
       if (error instanceof IssuePullRequestError) {

--- a/apps/control-plane/server/webhooks/github.test.ts
+++ b/apps/control-plane/server/webhooks/github.test.ts
@@ -3,6 +3,7 @@ import { Hono } from "hono";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { captureAnalyticsEvent } from "@responder/core/analytics";
 import { markIssuePullRequestMerged } from "@responder/core/db/pull-requests";
+import { refreshIssuePullRequestSlackMessages } from "@responder/core/integrations/slack-remediations";
 import { queuePullRequestReview } from "../investigations/queue.js";
 import { githubWebhookRoutes, verifyGitHubSignature } from "./github.js";
 
@@ -12,6 +13,10 @@ vi.mock("@responder/core/analytics", () => ({
 
 vi.mock("@responder/core/db/pull-requests", () => ({
   markIssuePullRequestMerged: vi.fn(),
+}));
+
+vi.mock("@responder/core/integrations/slack-remediations", () => ({
+  refreshIssuePullRequestSlackMessages: vi.fn(),
 }));
 
 vi.mock("../investigations/queue.js", () => ({
@@ -45,11 +50,18 @@ function reviewCommentEvent(overrides: {
   return JSON.stringify({
     action: overrides.action ?? "created",
     comment: {
+      body: "Use a null guard here.",
+      html_url: "https://github.com/acme/api/pull/42#discussion_r123",
       id: 123,
       ...(overrides.inReplyToId
         ? { in_reply_to_id: overrides.inReplyToId }
         : {}),
-      user: { type: overrides.authorType ?? "Bot" },
+      line: 17,
+      path: "src/route.ts",
+      user: {
+        login: "reviewer-bot",
+        type: overrides.authorType ?? "Bot",
+      },
     },
     installation: { id: 789 },
     pull_request: { number: 42 },
@@ -136,6 +148,7 @@ describe("GitHub pull request webhooks", () => {
       repositoryFullName: "acme/api",
       pullRequestNumber: 42,
     });
+    expect(refreshIssuePullRequestSlackMessages).toHaveBeenCalledWith("req-1");
     expect(captureAnalyticsEvent).toHaveBeenCalledWith(
       expect.objectContaining({
         event: "pr merged",
@@ -194,6 +207,14 @@ describe("GitHub pull request webhooks", () => {
     expect(queuePullRequestReview).toHaveBeenCalledWith({
       installationId: 789,
       pullRequestNumber: 42,
+      reviewComment: {
+        author: "reviewer-bot",
+        body: "Use a null guard here.",
+        id: 123,
+        line: 17,
+        path: "src/route.ts",
+        url: "https://github.com/acme/api/pull/42#discussion_r123",
+      },
       repositoryFullName: "acme/api",
     });
   });

--- a/apps/control-plane/server/webhooks/github.ts
+++ b/apps/control-plane/server/webhooks/github.ts
@@ -1,6 +1,7 @@
 import { createHmac, timingSafeEqual } from "node:crypto";
 import { captureAnalyticsEvent } from "@responder/core/analytics";
 import { markIssuePullRequestMerged } from "@responder/core/db/pull-requests";
+import { refreshIssuePullRequestSlackMessages } from "@responder/core/integrations/slack-remediations";
 import { Hono } from "hono";
 import { z } from "zod";
 import { queuePullRequestReview } from "../investigations/queue.js";
@@ -21,8 +22,16 @@ const pullRequestReviewCommentEventSchema = z.object({
   action: z.string(),
   comment: z.object({
     id: z.number().int().positive(),
+    body: z.string().max(65_536),
+    html_url: z.string().url(),
     in_reply_to_id: z.number().int().positive().optional(),
-    user: z.object({ type: z.string() }),
+    line: z.number().int().positive().nullable().optional(),
+    original_line: z.number().int().positive().nullable().optional(),
+    path: z.string().min(1).max(4_096),
+    user: z.object({
+      login: z.string().min(1),
+      type: z.string(),
+    }),
   }),
   installation: z.object({ id: z.number().int().positive() }),
   pull_request: z.object({ number: z.number().int().positive() }),
@@ -95,6 +104,15 @@ export const githubWebhookRoutes = new Hono().post("/", async (context) => {
     const queued = await queuePullRequestReview({
       installationId: parsed.data.installation.id,
       pullRequestNumber: parsed.data.pull_request.number,
+      reviewComment: {
+        author: parsed.data.comment.user.login,
+        body: parsed.data.comment.body,
+        id: parsed.data.comment.id,
+        line:
+          parsed.data.comment.line ?? parsed.data.comment.original_line ?? null,
+        path: parsed.data.comment.path,
+        url: parsed.data.comment.html_url,
+      },
       repositoryFullName: parsed.data.repository.full_name,
     });
     if (!queued.matched) {
@@ -138,6 +156,7 @@ export const githubWebhookRoutes = new Hono().post("/", async (context) => {
   if (!merged) {
     return context.json({ ok: true, matched: false });
   }
+  await refreshIssuePullRequestSlackMessages(merged.requestId);
 
   console.info(
     JSON.stringify({

--- a/apps/control-plane/server/webhooks/slack-actions.test.ts
+++ b/apps/control-plane/server/webhooks/slack-actions.test.ts
@@ -53,6 +53,13 @@ describe("Slack actions", () => {
       description: "The plants endpoint is failing.",
       severity: "SEV-2",
       remediation: "Handle missing plant records.",
+      remediations: [{
+        id: "09090909-0909-4909-8909-090909090909",
+        type: "code_change",
+        title: "Handle missing plant records",
+        description: "Guard missing plant records before using them.",
+        diff: "diff --git a/src/plants.ts b/src/plants.ts\n--- a/src/plants.ts\n+++ b/src/plants.ts\n@@ -1 +1 @@\n-old\n+new",
+      }],
       evidence: [],
       organizationId: "03030303-0303-4303-8303-030303030303",
       encryptedCredentials: "encrypted-slack-token",
@@ -121,6 +128,71 @@ describe("Slack actions", () => {
         channelId: "C123",
         threadTimestamp: undefined,
         userId: "U123",
+      }),
+    );
+  });
+
+  it("copies the prompt from the remediation card that was selected", async () => {
+    const issueId = "07070707-0707-4707-8707-070707070707";
+    const selectedRemediationId = "29292929-2929-4929-8929-292929292929";
+    mocks.getIssueForSlackAction.mockResolvedValue({
+      id: issueId,
+      title: "Plant API returns HTTP 500",
+      description: "The plants endpoint is failing.",
+      severity: "SEV-2",
+      remediation: "Update the palette.",
+      remediations: [
+        {
+          id: "28282828-2828-4828-8828-282828282828",
+          type: "external_action",
+          title: "Use silver",
+          description: "Update production to silver.",
+          agentPrompt: "Set petals to silver.",
+        },
+        {
+          id: selectedRemediationId,
+          type: "external_action",
+          title: "Use bronze",
+          description: "Update production to bronze.",
+          agentPrompt: "Set petals to bronze.",
+        },
+      ],
+      evidence: [],
+      organizationId: "03030303-0303-4303-8303-030303030303",
+      encryptedCredentials: "encrypted-slack-token",
+    });
+
+    const response = await signedActionRequest({
+      type: "block_actions",
+      team: { id: "T123" },
+      channel: { id: "C123" },
+      user: { id: "U123" },
+      response_url: "https://hooks.slack.com/actions/T123/B123/response-token",
+      message: {},
+      actions: [
+        {
+          action_id: "copy_issue_prompt",
+          value: JSON.stringify({
+            issueId,
+            remediationId: selectedRemediationId,
+          }),
+        },
+      ],
+    });
+
+    expect(response.status).toBe(200);
+    expect(mocks.postSlackEphemeralMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        blocks: expect.arrayContaining([
+          expect.objectContaining({ text: expect.stringContaining("bronze") }),
+        ]),
+      }),
+    );
+    expect(mocks.postSlackEphemeralMessage).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        blocks: expect.arrayContaining([
+          expect.objectContaining({ text: expect.stringContaining("silver") }),
+        ]),
       }),
     );
   });

--- a/apps/control-plane/server/webhooks/slack.ts
+++ b/apps/control-plane/server/webhooks/slack.ts
@@ -7,7 +7,10 @@ import { findAgentsForSlackEvent } from "../../../../packages/core/src/db/agents
 import { getSlackChannelConnection } from "../../../../packages/core/src/db/integrations.js";
 import { recordInvestigationSlackMessage } from "../../../../packages/core/src/db/investigations.js";
 import { getIssueForSlackAction } from "../../../../packages/core/src/db/issues.js";
-import { IssuePullRequestError } from "../../../../packages/core/src/db/pull-requests.js";
+import {
+  IssuePullRequestError,
+  registerIssuePullRequestSlackMessage,
+} from "../../../../packages/core/src/db/pull-requests.js";
 import { renderIssueFixPrompt } from "../../../../packages/core/src/investigations/report.js";
 import {
   addSlackReaction,
@@ -21,6 +24,12 @@ import {
   slackInvestigationCard,
 } from "../../../../packages/core/src/integrations/slack-live-card.js";
 import { reconcileCompletedInvestigationSlackCard } from "../../../../packages/core/src/integrations/slack-delivery.js";
+import {
+  parseSlackRemediationActionValue,
+  refreshIssuePullRequestSlackMessages,
+  slackIssuePullRequestMessage,
+  type SlackIssuePullRequestCard,
+} from "../../../../packages/core/src/integrations/slack-remediations.js";
 import { startSlackIssueRemediation } from "../issues/remediation.js";
 import { queueInvestigation } from "../investigations/queue.js";
 
@@ -90,6 +99,7 @@ const slackBlockActionsSchema = z.object({
     .object({
       blocks: z.array(z.unknown()).optional(),
       text: z.string().optional(),
+      ts: z.string().min(1).optional(),
       thread_ts: z.string().min(1).optional(),
     })
     .optional(),
@@ -625,64 +635,14 @@ export function slackCopyPromptResponse(prompt: string | null) {
   };
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
 export function slackPullRequestQueuedResponse(
-  message:
-    | {
-        blocks?: unknown[];
-        text?: string;
-      }
-    | undefined,
+  card: SlackIssuePullRequestCard,
 ) {
-  if (!message?.blocks) {
-    return {
-      response_type: "ephemeral" as const,
-      replace_original: false,
-      text: "Pull request creation started.",
-    };
-  }
-
-  let removedButton = false;
-  const blocks = message.blocks.flatMap((block) => {
-    if (!isRecord(block) || block.type !== "actions") return [block];
-    const elements = Array.isArray(block.elements)
-      ? block.elements.filter((element) => {
-          const isPullRequestButton =
-            isRecord(element) &&
-            element.action_id === "create_issue_pull_request";
-          removedButton ||= isPullRequestButton;
-          return !isPullRequestButton;
-        })
-      : [];
-    return elements.length > 0 ? [{ ...block, elements }] : [];
-  });
-
-  if (!removedButton) {
-    return {
-      response_type: "ephemeral" as const,
-      replace_original: false,
-      text: "Pull request creation started.",
-    };
-  }
-
+  const message = slackIssuePullRequestMessage(card);
   return {
     replace_original: true,
-    text: message.text ?? "Pull request creation started.",
-    blocks: [
-      ...blocks,
-      {
-        type: "context",
-        elements: [
-          {
-            type: "mrkdwn",
-            text: "Pull request creation started. Follow progress in the issue.",
-          },
-        ],
-      },
-    ],
+    text: message.text,
+    blocks: message.blocks,
   };
 }
 
@@ -935,18 +895,38 @@ export const slackWebhookRoutes = new Hono().post("/", async (context) => {
     (item) => item.action_id === "create_issue_pull_request",
   );
   if (pullRequestAction?.value) {
+    const selection = parseSlackRemediationActionValue(
+      pullRequestAction.value,
+    );
     try {
       const result = await startSlackIssueRemediation({
-        issueId: pullRequestAction.value,
+        issueId: selection?.issueId ?? pullRequestAction.value,
+        ...(selection ? { remediationId: selection.remediationId } : {}),
         teamId: action.data.team.id,
       });
       const response = result.ok === true
-        ? slackPullRequestQueuedResponse(action.data.message)
+        ? slackPullRequestQueuedResponse(result.card)
         : slackPullRequestErrorResponse(result.error);
       await sendSlackActionResponse(
         action.data.response_url,
         response,
       );
+      if (result.ok && action.data.message?.ts) {
+        try {
+          await registerIssuePullRequestSlackMessage({
+            channelId: action.data.channel.id,
+            integrationAccountId: result.integrationAccountId,
+            messageTimestamp: action.data.message.ts,
+            requestId: result.requestId,
+          });
+          await refreshIssuePullRequestSlackMessages(result.requestId);
+        } catch (error) {
+          console.error(
+            "Unable to register Slack pull request status card",
+            error,
+          );
+        }
+      }
     } catch (error) {
       const message =
         error instanceof IssuePullRequestError
@@ -966,8 +946,11 @@ export const slackWebhookRoutes = new Hono().post("/", async (context) => {
   );
   if (!copyAction?.value) return context.json({ ok: true });
 
+  const copySelection = parseSlackRemediationActionValue(copyAction.value);
+  const copyIssueId = copySelection?.issueId ?? copyAction.value;
+
   const issue = await getIssueForSlackAction({
-    issueId: copyAction.value,
+    issueId: copyIssueId,
     teamId: action.data.team.id,
   });
   await captureAnalyticsEvent({
@@ -978,12 +961,21 @@ export const slackWebhookRoutes = new Hono().post("/", async (context) => {
       $process_person_profile: false,
       channel_id: action.data.channel.id,
       issue_found: Boolean(issue),
-      issue_id: copyAction.value,
+      issue_id: copyIssueId,
       surface: "slack",
       team_id: action.data.team.id,
     },
   });
-  const prompt = issue ? renderIssueFixPrompt(issue) : null;
+  const externalRemediation = issue?.remediations?.find(
+    (remediation) =>
+      remediation.type === "external_action" &&
+      (!copySelection || remediation.id === copySelection.remediationId),
+  );
+  const prompt = issue
+    ? externalRemediation?.type === "external_action"
+      ? externalRemediation.agentPrompt
+      : renderIssueFixPrompt(issue)
+    : null;
   const promptResponse = slackCopyPromptResponse(prompt);
   if (
     issue?.encryptedCredentials &&

--- a/apps/control-plane/src/agents-api.ts
+++ b/apps/control-plane/src/agents-api.ts
@@ -210,6 +210,40 @@ export interface IssueEvidence {
   toolCallId?: string;
 }
 
+export type IssueRemediation =
+  | {
+      id: string;
+      type: "code_change";
+      title: string;
+      description: string;
+      diff: string;
+    }
+  | {
+      id: string;
+      type: "external_action";
+      title: string;
+      description: string;
+      agentPrompt: string;
+    };
+
+export interface IssuePullRequestActivity {
+  id: number;
+  event: {
+    type:
+      | "review.comment.received"
+      | "review.job.queued"
+      | "review.session.started"
+      | "review.trace"
+      | "review.commit.pushed"
+      | "review.threads.addressed"
+      | "review.session.completed"
+      | "review.session.failed";
+    data?: Record<string, unknown>;
+    meta: { at: string };
+  };
+  createdAt: string;
+}
+
 export interface IssueListItem {
   id: string;
   title: string;
@@ -218,6 +252,7 @@ export interface IssueListItem {
   timeline: Array<{ title: string; description: string }>;
   severity: "SEV-1" | "SEV-2" | "SEV-3";
   remediation: string;
+  remediations: IssueRemediation[];
   archivedAt: string | null;
   createdAt: string;
 }
@@ -257,8 +292,9 @@ export interface IssueDetailResponse {
     canCreate: boolean;
     requests: Array<{
       id: string;
+      remediationId: string | null;
       repositoryFullName: string | null;
-      status: "queued" | "creating" | "created" | "failed";
+      status: "queued" | "creating" | "created" | "merged" | "failed";
       branch: string | null;
       pullRequestNumber: number | null;
       pullRequestUrl: string | null;
@@ -266,6 +302,7 @@ export interface IssueDetailResponse {
       createdAt: string;
       updatedAt: string;
       completedAt: string | null;
+      activities: IssuePullRequestActivity[];
     }>;
   };
 }
@@ -444,10 +481,15 @@ export async function setIssueArchived(
 
 export async function createIssuePullRequest(
   issueId: string,
+  remediationId: string,
 ): Promise<{ requestId: string; sessionId: string | null }> {
   return apiJson<{ requestId: string; sessionId: string | null }>(
     `/api/issues/${encodeURIComponent(issueId)}/pull-requests`,
-    { method: "POST" },
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ remediationId }),
+    },
   );
 }
 

--- a/apps/control-plane/src/components/remediation-diff.tsx
+++ b/apps/control-plane/src/components/remediation-diff.tsx
@@ -1,0 +1,44 @@
+import { parsePatchFiles } from "@pierre/diffs";
+import { FileDiff } from "@pierre/diffs/react";
+import { useMemo } from "react";
+import type { IssueRemediation } from "../agents-api";
+
+export function RemediationDiff({
+  remediation,
+}: {
+  remediation: IssueRemediation & { type: "code_change" };
+}) {
+  const files = useMemo(() => {
+    try {
+      return parsePatchFiles(
+        remediation.diff,
+        `remediation-${remediation.id}`,
+        true,
+      ).flatMap((patch) => patch.files);
+    } catch {
+      return [];
+    }
+  }, [remediation]);
+
+  if (files.length === 0) {
+    return <pre className="remediationDiff__fallback">{remediation.diff}</pre>;
+  }
+
+  return (
+    <div className="remediationDiff">
+      {files.map((file, index) => (
+        <FileDiff
+          className="remediationDiff__file"
+          fileDiff={file}
+          key={`${remediation.id}-${index}`}
+          options={{
+            diffIndicators: "bars",
+            diffStyle: "unified",
+            overflow: "scroll",
+            themeType: "dark",
+          }}
+        />
+      ))}
+    </div>
+  );
+}

--- a/apps/control-plane/src/pages/issue-detail-presentation.test.ts
+++ b/apps/control-plane/src/pages/issue-detail-presentation.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from "vitest";
-import type { IssueDetailResponse, IssueEvidence } from "../agents-api";
+import type {
+  IssueDetailResponse,
+  IssueEvidence,
+  IssuePullRequestActivity,
+} from "../agents-api";
 import {
   evidenceSourceGlyph,
+  groupPullRequestActivities,
   rowStatusLabel,
   evidenceSourceLabel,
   investigationCountLabel,
@@ -11,6 +16,10 @@ import {
   issueRowDate,
   originatingAgentName,
   primaryEvidenceSource,
+  pullRequestActivityPresentation,
+  pullRequestReviewActivityPresentation,
+  pullRequestReviewIsActive,
+  pullRequestStateLabel,
   relationshipLabel,
 } from "./issue-detail-presentation";
 
@@ -32,6 +41,22 @@ function investigation(overrides: Partial<Investigation>): Investigation {
     createdAt: "2026-05-20T01:25:00.000Z",
     completedAt: null,
     ...overrides,
+  };
+}
+
+function activity(
+  type: IssuePullRequestActivity["event"]["type"],
+  data?: Record<string, unknown>,
+  id = 1,
+): IssuePullRequestActivity {
+  return {
+    id,
+    event: {
+      ...(data ? { data } : {}),
+      meta: { at: "2026-08-25T10:00:00.000Z" },
+      type,
+    },
+    createdAt: "2026-08-25T10:00:00.000Z",
   };
 }
 
@@ -184,5 +209,127 @@ describe("rowStatusLabel", () => {
     expect(rowStatusLabel("queued")).toBe("Queued");
     expect(rowStatusLabel("creating")).toBe("Creating");
     expect(rowStatusLabel("created")).toBe("Created");
+    expect(rowStatusLabel("merged")).toBe("Merged");
+  });
+});
+
+describe("pullRequestStateLabel", () => {
+  it("uses the GitHub-facing state after publication", () => {
+    expect(pullRequestStateLabel("created")).toBe("Open");
+    expect(pullRequestStateLabel("merged")).toBe("Merged");
+  });
+});
+
+describe("pullRequestActivityPresentation", () => {
+  it("presents an incoming comment as a single top-level event", () => {
+    expect(
+      pullRequestActivityPresentation(
+        activity("review.comment.received", {
+          author: "silver-bot",
+          body: "Petals need to be silver.",
+          line: 12,
+          path: "src/flower.ts",
+          url: "https://github.com/acme/app/pull/27#discussion_r1",
+        }),
+        "acme/app",
+      ),
+    ).toEqual({
+      detail: "“Petals need to be silver.”",
+      href: "https://github.com/acme/app/pull/27#discussion_r1",
+      title: "@silver-bot commented",
+      tone: "default",
+    });
+  });
+
+  it("links a pushed commit to its repository", () => {
+    expect(
+      pullRequestActivityPresentation(
+        activity("review.commit.pushed", {
+          files: ["src/flower.ts"],
+          message: "Use silver petals",
+          sha: "abc123",
+        }),
+        "acme/app",
+      ),
+    ).toEqual({
+      detail: "Use silver petals · 1 changed file",
+      href: "https://github.com/acme/app/commit/abc123",
+      title: "Committed",
+      tone: "success",
+    });
+  });
+
+  it("turns trace tool calls into compact activity labels", () => {
+    expect(
+      pullRequestActivityPresentation(
+        activity("review.trace", {
+          event: {
+            type: "actions.requested",
+            data: { actions: [{ toolName: "apply_patch" }] },
+          },
+        }),
+        "acme/app",
+      ).title,
+    ).toBe("Ran apply_patch");
+  });
+});
+
+describe("groupPullRequestActivities", () => {
+  it("collapses review lifecycle and trace events between comment and commit", () => {
+    const activities = [
+      activity("review.comment.received", { body: "Use bronze." }, 1),
+      activity("review.job.queued", { jobId: "job-1" }, 2),
+      activity("review.session.started", { jobId: "job-1" }, 3),
+      activity("review.trace", {
+        event: { type: "message.completed", data: { message: "Inspecting." } },
+        jobId: "job-1",
+      }, 4),
+      activity("review.commit.pushed", { sha: "abc123" }, 5),
+      activity("review.threads.addressed", { count: 1 }, 6),
+      activity("review.session.completed", { jobId: "job-1" }, 7),
+    ];
+
+    const timeline = groupPullRequestActivities(activities);
+
+    expect(timeline.map((item) => item.kind)).toEqual([
+      "activity",
+      "review",
+      "activity",
+    ]);
+    const review = timeline[1];
+    expect(review?.kind).toBe("review");
+    if (review?.kind !== "review") throw new Error("Expected review group");
+    expect(review.activities.map((item) => item.event.type)).toEqual([
+      "review.job.queued",
+      "review.session.started",
+      "review.trace",
+      "review.threads.addressed",
+      "review.session.completed",
+    ]);
+    expect(pullRequestReviewActivityPresentation(review.activities)).toEqual({
+      detail: null,
+      href: null,
+      title: "Review ran",
+      tone: "success",
+      traceCount: 1,
+    });
+  });
+});
+
+describe("pullRequestReviewIsActive", () => {
+  it("polls between queueing and a terminal review event", () => {
+    expect(pullRequestReviewIsActive([activity("review.job.queued")])).toBe(true);
+    expect(
+      pullRequestReviewIsActive([
+        activity("review.job.queued"),
+        activity("review.session.started", undefined, 2),
+      ]),
+    ).toBe(true);
+    expect(
+      pullRequestReviewIsActive([
+        activity("review.session.started"),
+        activity("review.session.completed", undefined, 2),
+      ]),
+    ).toBe(false);
   });
 });

--- a/apps/control-plane/src/pages/issue-detail-presentation.ts
+++ b/apps/control-plane/src/pages/issue-detail-presentation.ts
@@ -1,4 +1,8 @@
-import type { IssueDetailResponse, IssueEvidence } from "../agents-api";
+import type {
+  IssueDetailResponse,
+  IssueEvidence,
+  IssuePullRequestActivity,
+} from "../agents-api";
 import {
   providerDisplayName,
   providerGlyphs,
@@ -11,6 +15,8 @@ type RowStatus =
   | Investigation["status"]
   | IssueDetailResponse["pullRequestState"]["requests"][number]["status"]
   | IssueDetailResponse["linearTicketState"]["requests"][number]["status"];
+type PullRequestStatus =
+  IssueDetailResponse["pullRequestState"]["requests"][number]["status"];
 
 /** Labels that read better here than the shared provider name. */
 const evidenceSourceLabelOverrides: Partial<Record<EvidenceSource, string>> = {
@@ -64,6 +70,268 @@ export function investigationStatusTone(
  */
 export function rowStatusLabel(status: RowStatus): string {
   return `${status.charAt(0).toUpperCase()}${status.slice(1)}`;
+}
+
+export function pullRequestStateLabel(status: PullRequestStatus): string {
+  if (status === "created") return "Open";
+  return rowStatusLabel(status);
+}
+
+function activityData(
+  activity: IssuePullRequestActivity,
+): Record<string, unknown> {
+  return activity.event.data ?? {};
+}
+
+function record(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function stringValue(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value : null;
+}
+
+function numberValue(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+export interface PullRequestActivityPresentation {
+  detail: string | null;
+  href: string | null;
+  title: string;
+  tone: "default" | "success" | "failed";
+}
+
+export type PullRequestActivityTimelineItem =
+  | { activity: IssuePullRequestActivity; kind: "activity" }
+  | {
+      activities: IssuePullRequestActivity[];
+      anchor: IssuePullRequestActivity;
+      jobId: string;
+      kind: "review";
+    };
+
+const groupedReviewActivityTypes = new Set<
+  IssuePullRequestActivity["event"]["type"]
+>([
+  "review.job.queued",
+  "review.session.started",
+  "review.trace",
+  "review.session.completed",
+  "review.session.failed",
+]);
+
+export function groupPullRequestActivities(
+  activities: IssuePullRequestActivity[],
+): PullRequestActivityTimelineItem[] {
+  const timeline: PullRequestActivityTimelineItem[] = [];
+  const reviews = new Map<string, Extract<
+    PullRequestActivityTimelineItem,
+    { kind: "review" }
+  >>();
+  let latestReview: Extract<
+    PullRequestActivityTimelineItem,
+    { kind: "review" }
+  > | null = null;
+
+  for (const activity of activities) {
+    const data = activityData(activity);
+    if (groupedReviewActivityTypes.has(activity.event.type)) {
+      const jobId: string = stringValue(data.jobId) ?? latestReview?.jobId ??
+        `review-${activity.id}`;
+      let review = reviews.get(jobId);
+      if (!review) {
+        review = {
+          activities: [],
+          anchor: activity,
+          jobId,
+          kind: "review",
+        };
+        reviews.set(jobId, review);
+        timeline.push(review);
+      }
+      review.activities.push(activity);
+      latestReview = review;
+      continue;
+    }
+    if (activity.event.type === "review.threads.addressed" && latestReview) {
+      latestReview.activities.push(activity);
+      continue;
+    }
+    timeline.push({ activity, kind: "activity" });
+  }
+  return timeline;
+}
+
+export function pullRequestReviewActivityPresentation(
+  activities: IssuePullRequestActivity[],
+): PullRequestActivityPresentation & { traceCount: number } {
+  const terminal = [...activities].reverse().find((activity) =>
+    activity.event.type === "review.session.completed" ||
+    activity.event.type === "review.session.failed",
+  );
+  const started = activities.some(
+    (activity) => activity.event.type === "review.session.started",
+  );
+  const traceCount = activities.filter(
+    (activity) => activity.event.type === "review.trace",
+  ).length;
+  if (terminal?.event.type === "review.session.failed") {
+    return {
+      detail: stringValue(activityData(terminal).error),
+      href: null,
+      title: "Review failed",
+      tone: "failed",
+      traceCount,
+    };
+  }
+  if (terminal?.event.type === "review.session.completed") {
+    return {
+      detail: null,
+      href: null,
+      title: "Review ran",
+      tone: "success",
+      traceCount,
+    };
+  }
+  return {
+    detail: null,
+    href: null,
+    title: started ? "Review running" : "Review queued",
+    tone: "default",
+    traceCount,
+  };
+}
+
+export function pullRequestActivityPresentation(
+  activity: IssuePullRequestActivity,
+  repositoryFullName: string | null,
+): PullRequestActivityPresentation {
+  const data = activityData(activity);
+  switch (activity.event.type) {
+    case "review.comment.received": {
+      const author = stringValue(data.author);
+      const body = stringValue(data.body);
+      return {
+        detail: body ? `“${body}”` : null,
+        href: stringValue(data.url),
+        title: `${author ? `@${author}` : "A reviewer"} commented`,
+        tone: "default",
+      };
+    }
+    case "review.job.queued":
+      return {
+        detail: "The review follow-up was added to the queue.",
+        href: null,
+        title: "Review queued",
+        tone: "default",
+      };
+    case "review.session.started":
+      return {
+        detail: "Reviewing the latest feedback and pull request head.",
+        href: null,
+        title: "Review started",
+        tone: "default",
+      };
+    case "review.trace": {
+      const trace = record(data.event);
+      const traceData = record(trace?.data);
+      const traceType = stringValue(trace?.type);
+      if (traceType === "actions.requested") {
+        const actions = Array.isArray(traceData?.actions) ? traceData.actions : [];
+        const toolNames = actions
+          .map((action) => stringValue(record(action)?.toolName))
+          .filter((name): name is string => Boolean(name));
+        return {
+          detail: null,
+          href: null,
+          title: toolNames.length > 0
+            ? `Ran ${[...new Set(toolNames)].join(", ")}`
+            : "Ran a review action",
+          tone: "default",
+        };
+      }
+      if (traceType === "action.result") {
+        return {
+          detail: null,
+          href: null,
+          title: traceData?.status === "failed" ? "Review action failed" : "Review action completed",
+          tone: traceData?.status === "failed" ? "failed" : "default",
+        };
+      }
+      if (traceType === "message.completed") {
+        return {
+          detail: stringValue(traceData?.message),
+          href: null,
+          title: "Review update",
+          tone: "default",
+        };
+      }
+      return {
+        detail: null,
+        href: null,
+        title: traceType === "reasoning.completed" ? "Reviewed the feedback" : "Review progress",
+        tone: "default",
+      };
+    }
+    case "review.commit.pushed": {
+      const sha = stringValue(data.sha);
+      const files = Array.isArray(data.files) ? data.files.length : 0;
+      return {
+        detail: [
+          stringValue(data.message),
+          files > 0 ? `${files} changed ${files === 1 ? "file" : "files"}` : null,
+        ].filter(Boolean).join(" · ") || null,
+        href: repositoryFullName && sha
+          ? `https://github.com/${repositoryFullName}/commit/${sha}`
+          : null,
+        title: "Committed",
+        tone: "success",
+      };
+    }
+    case "review.threads.addressed": {
+      const count = numberValue(data.count) ?? 0;
+      return {
+        detail: `${count} review ${count === 1 ? "thread" : "threads"} replied to and resolved.`,
+        href: null,
+        title: "Review feedback addressed",
+        tone: "success",
+      };
+    }
+    case "review.session.completed":
+      return {
+        detail: null,
+        href: null,
+        title: "Review completed",
+        tone: "success",
+      };
+    case "review.session.failed":
+      return {
+        detail: stringValue(data.error),
+        href: null,
+        title: "Review failed",
+        tone: "failed",
+      };
+  }
+}
+
+export function pullRequestReviewIsActive(
+  activities: IssuePullRequestActivity[] = [],
+): boolean {
+  const latestLifecycleEvent = [...activities]
+    .reverse()
+    .find((activity) =>
+      [
+        "review.job.queued",
+        "review.session.started",
+        "review.session.completed",
+        "review.session.failed",
+      ].includes(activity.event.type),
+    );
+  return latestLifecycleEvent?.event.type === "review.job.queued" ||
+    latestLifecycleEvent?.event.type === "review.session.started";
 }
 
 export function evidenceSourceGlyph(

--- a/apps/control-plane/src/pages/issue-detail.tsx
+++ b/apps/control-plane/src/pages/issue-detail.tsx
@@ -1,11 +1,12 @@
-import { useEffect, useState } from "react";
-import { renderIssueFixPrompt } from "@responder/core/investigations/report";
-import { Link, Navigate, useParams } from "react-router-dom";
+import { Fragment, lazy, Suspense, useEffect, useState } from "react";
+import { Link, Navigate, useLocation, useParams } from "react-router-dom";
 import {
   createIssuePullRequest,
   fetchIssue,
   setIssueArchived,
+  type InvestigationTraceEvent,
   type IssueDetailResponse,
+  type IssuePullRequestActivity,
 } from "../agents-api";
 import { AppShell } from "../components/app-shell";
 import { EvidenceList, EvidenceSourceGlyph } from "../components/evidence-list";
@@ -22,18 +23,29 @@ import { Button } from "../design-system";
 import { useDocumentTitle } from "../use-document-title";
 import {
   evidenceSourceLabel,
+  groupPullRequestActivities,
   investigationCountLabel,
   investigationStatusTone,
   issueIdentifiedAt,
   issueParagraphs,
   issueRowDate,
   originatingAgentName,
+  pullRequestActivityPresentation,
+  pullRequestReviewActivityPresentation,
+  pullRequestReviewIsActive,
   primaryEvidenceSource,
+  pullRequestStateLabel,
   relationshipLabel,
   rowStatusLabel,
 } from "./issue-detail-presentation";
+import { toolInputSummary, traceEventText } from "./investigation-presentation";
 
 const severityBars = { "SEV-1": 3, "SEV-2": 2, "SEV-3": 1 } as const;
+const RemediationDiff = lazy(() =>
+  import("../components/remediation-diff").then((module) => ({
+    default: module.RemediationDiff,
+  })),
+);
 
 function formatDate(value: string | null): string {
   if (!value) return "—";
@@ -43,16 +55,277 @@ function formatDate(value: string | null): string {
   }).format(new Date(value));
 }
 
+type PullRequestRequest =
+  IssueDetailResponse["pullRequestState"]["requests"][number];
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function reviewTraceEvent(
+  activity: IssuePullRequestActivity,
+): InvestigationTraceEvent | null {
+  if (activity.event.type !== "review.trace") return null;
+  const event = asRecord(activity.event.data?.event);
+  if (typeof event?.type !== "string") return null;
+  const meta = asRecord(event.meta);
+  return {
+    ...(event.data === undefined ? {} : { data: event.data }),
+    ...(typeof meta?.at === "string" ? { meta: { at: meta.at } } : {}),
+    type: event.type,
+  };
+}
+
+function traceCallId(value: unknown): string | null {
+  const record = asRecord(value);
+  return typeof record?.callId === "string" ? record.callId : null;
+}
+
+function traceToolName(value: unknown): string {
+  const raw = typeof value === "string" && value ? value : "tool";
+  const label = raw
+    .replace(/^mcp_+/, "")
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .split(/[_./:-]+|\s+/)
+    .filter(Boolean)
+    .join(" ");
+  return label.charAt(0).toUpperCase() + label.slice(1);
+}
+
+function formatTraceTime(value: string | null): string {
+  if (!value) return "—";
+  return new Intl.DateTimeFormat(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+    second: "2-digit",
+  }).format(new Date(value));
+}
+
+function PullRequestReviewTrace({
+  activities,
+}: {
+  activities: IssuePullRequestActivity[];
+}) {
+  const events = activities
+    .map(reviewTraceEvent)
+    .filter((event): event is InvestigationTraceEvent => Boolean(event));
+  const toolResults = new Map<string, InvestigationTraceEvent>();
+  for (const event of events) {
+    if (event.type !== "action.result") continue;
+    const result = asRecord(asRecord(event.data)?.result);
+    if (typeof result?.callId === "string") {
+      toolResults.set(result.callId, event);
+    }
+  }
+
+  if (events.length === 0) {
+    return <p className="remediationReviewTrace__empty">No trace events recorded.</p>;
+  }
+  return (
+    <div className="remediationReviewTrace">
+      <header>
+        <strong>Trace</strong>
+        <span>{events.length} events</span>
+      </header>
+      <ol className="traceTimeline remediationReviewTrace__timeline">
+        {events.map((event, index) => {
+          if (event.type === "action.result") return null;
+          if (event.type === "actions.requested") {
+            const actions = asRecord(event.data)?.actions;
+            if (!Array.isArray(actions)) return null;
+            return (
+              <Fragment key={`${event.type}-${index}`}>
+                {actions.map((action, actionIndex) => {
+                  const request = asRecord(action);
+                  const callId = traceCallId(action);
+                  const resultEvent = callId ? toolResults.get(callId) : undefined;
+                  const resultData = asRecord(resultEvent?.data);
+                  const result = asRecord(resultData?.result);
+                  const failed = resultData?.status === "failed" ||
+                    resultData?.error !== undefined;
+                  const name = request?.toolName ?? request?.kind;
+                  const inputSummary = toolInputSummary(request?.input);
+                  return (
+                    <li
+                      className={`traceTool${failed ? " traceTool--failed" : ""}`}
+                      key={callId ?? `${index}-${actionIndex}`}
+                    >
+                      <details>
+                        <summary>
+                          <span aria-hidden="true" className="traceTool__icon">⌘</span>
+                          <span className="traceTool__label">
+                            <span>{traceToolName(name)}</span>
+                            {inputSummary ? <code>{inputSummary}</code> : null}
+                          </span>
+                        </summary>
+                        <div className="traceTool__data">
+                          <span>Input</span>
+                          <pre>{JSON.stringify(request?.input ?? {}, null, 2)}</pre>
+                          {resultEvent ? (
+                            <>
+                              <span>Output</span>
+                              <pre>
+                                {JSON.stringify(
+                                  result?.output ?? resultData?.error ?? result ?? {},
+                                  null,
+                                  2,
+                                )}
+                              </pre>
+                            </>
+                          ) : null}
+                        </div>
+                      </details>
+                    </li>
+                  );
+                })}
+              </Fragment>
+            );
+          }
+          const content = traceEventText(event);
+          if (!content) return null;
+          const reasoning = event.type === "reasoning.completed";
+          return (
+            <li
+              className={`traceMessage ${reasoning ? "traceMessage--runtime" : "traceMessage--assistant"}`}
+              key={`${event.type}-${index}`}
+            >
+              {reasoning ? (
+                <span aria-hidden="true" className="traceMessage__avatar">R</span>
+              ) : null}
+              <article>
+                <header>
+                  <span>
+                    <strong>{reasoning ? "Reasoning" : "Review agent"}</strong>
+                    <small>{reasoning ? "Thinking" : "Update"}</small>
+                  </span>
+                  <time>{formatTraceTime(event.meta?.at ?? null)}</time>
+                </header>
+                <div className="traceMessage__content">{content}</div>
+              </article>
+            </li>
+          );
+        })}
+      </ol>
+    </div>
+  );
+}
+
+function PullRequestActivity({ request }: { request: PullRequestRequest }) {
+  const activities = request.activities ?? [];
+  if (activities.length === 0) return null;
+  const timeline = groupPullRequestActivities(activities);
+  const latest = timeline.at(-1);
+  const latestPresentation = latest?.kind === "review"
+    ? pullRequestReviewActivityPresentation(latest.activities)
+    : latest
+      ? pullRequestActivityPresentation(
+          latest.activity,
+          request.repositoryFullName,
+        )
+      : null;
+
+  return (
+    <details
+      className="remediationActivity"
+      open={pullRequestReviewIsActive(activities)}
+    >
+      <summary>
+        <span>
+          <strong>Activity</strong>
+          {latestPresentation ? <small>{latestPresentation.title}</small> : null}
+        </span>
+        <span className="remediationActivity__count">
+          {timeline.length}
+        </span>
+      </summary>
+      <ol className="remediationActivity__list">
+        {timeline.map((item) => {
+          if (item.kind === "review") {
+            const presentation = pullRequestReviewActivityPresentation(
+              item.activities,
+            );
+            const reviewStartedActivity = item.activities.find(
+              (activity) => activity.event.type === "review.session.started",
+            ) ?? item.anchor;
+            const reviewActive = pullRequestReviewIsActive(item.activities);
+            return (
+              <li
+                className={`remediationActivity__item remediationActivity__item--${presentation.tone}`}
+                key={item.jobId}
+              >
+                <span className="remediationActivity__marker" aria-hidden="true" />
+                <details className="remediationReviewRun" open={reviewActive}>
+                  <summary>
+                    <span>
+                      <strong>{presentation.title}</strong>
+                      <small>
+                        {presentation.traceCount} trace {presentation.traceCount === 1 ? "event" : "events"}
+                      </small>
+                    </span>
+                    <time dateTime={reviewStartedActivity.event.meta.at}>
+                      {formatDate(reviewStartedActivity.event.meta.at)}
+                    </time>
+                  </summary>
+                  {presentation.detail ? <p>{presentation.detail}</p> : null}
+                  <PullRequestReviewTrace activities={item.activities} />
+                </details>
+              </li>
+            );
+          }
+          const { activity } = item;
+          const presentation = pullRequestActivityPresentation(
+            activity,
+            request.repositoryFullName,
+          );
+          return (
+            <li
+              className={`remediationActivity__item remediationActivity__item--${presentation.tone}`}
+              key={activity.id}
+            >
+              <span className="remediationActivity__marker" aria-hidden="true" />
+              <div>
+                <div className="remediationActivity__heading">
+                  {presentation.href ? (
+                    <a href={presentation.href} rel="noreferrer" target="_blank">
+                      {presentation.title}
+                    </a>
+                  ) : (
+                    <strong>{presentation.title}</strong>
+                  )}
+                  <time dateTime={activity.event.meta.at}>
+                    {formatDate(activity.event.meta.at)}
+                  </time>
+                </div>
+                {presentation.detail ? <p>{presentation.detail}</p> : null}
+              </div>
+            </li>
+          );
+        })}
+      </ol>
+    </details>
+  );
+}
+
 export function IssueDetailPage() {
   const { issueId } = useParams();
+  const location = useLocation();
   const [detail, setDetail] = useState<IssueDetailResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [notFound, setNotFound] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [archivePending, setArchivePending] = useState(false);
-  const [promptCopied, setPromptCopied] = useState(false);
-  const [pullRequestPending, setPullRequestPending] = useState(false);
+  const [copiedRemediationId, setCopiedRemediationId] = useState<string | null>(
+    null,
+  );
+  const [pullRequestPending, setPullRequestPending] = useState<string | null>(
+    null,
+  );
   useDocumentTitle(detail?.issue.title ?? "Issue");
+  const codeChangeRemediationId = new URLSearchParams(location.search).get(
+    "codeChange",
+  );
 
   useEffect(() => {
     if (!issueId) return;
@@ -79,24 +352,54 @@ export function IssueDetailPage() {
     detail?.pullRequestState.requests.some((request) =>
       request.status === "queued" || request.status === "creating",
     ) ?? false;
+  const hasActivePullRequestReview =
+    detail?.pullRequestState.requests.some((request) =>
+      pullRequestReviewIsActive(request.activities ?? []),
+    ) ?? false;
   const hasActiveLinearTicket =
     detail?.linearTicketState.requests.some((request) =>
       request.status === "pending" || request.status === "creating",
     ) ?? false;
 
   useEffect(() => {
-    if (!issueId || (!hasActivePullRequest && !hasActiveLinearTicket)) return;
+    if (
+      !issueId ||
+      (!hasActivePullRequest &&
+        !hasActivePullRequestReview &&
+        !hasActiveLinearTicket)
+    ) return;
     const interval = window.setInterval(() => {
       void fetchIssue(issueId).then(setDetail).catch(() => undefined);
     }, 3_000);
     return () => window.clearInterval(interval);
-  }, [hasActiveLinearTicket, hasActivePullRequest, issueId]);
+  }, [
+    hasActiveLinearTicket,
+    hasActivePullRequest,
+    hasActivePullRequestReview,
+    issueId,
+  ]);
 
   useEffect(() => {
-    if (!promptCopied) return;
-    const timeout = window.setTimeout(() => setPromptCopied(false), 1600);
+    if (!copiedRemediationId) return;
+    const timeout = window.setTimeout(() => setCopiedRemediationId(null), 1600);
     return () => window.clearTimeout(timeout);
-  }, [promptCopied]);
+  }, [copiedRemediationId]);
+
+  useEffect(() => {
+    if (!detail || !location.hash) return;
+    let remediationId: string;
+    try {
+      remediationId = decodeURIComponent(location.hash.slice(1));
+    } catch {
+      return;
+    }
+    window.requestAnimationFrame(() => {
+      document.getElementById(remediationId)?.scrollIntoView({
+        behavior: "smooth",
+        block: "center",
+      });
+    });
+  }, [detail, location.hash]);
 
   if (notFound || !issueId) return <Navigate replace to="/issues" />;
   if (loading) {
@@ -149,12 +452,12 @@ export function IssueDetailPage() {
     }
   }
 
-  async function createPullRequest() {
+  async function createPullRequest(remediationId: string) {
     if (!issueId || pullRequestPending) return;
-    setPullRequestPending(true);
+    setPullRequestPending(remediationId);
     setError(null);
     try {
-      await createIssuePullRequest(issueId);
+      await createIssuePullRequest(issueId, remediationId);
       setDetail(await fetchIssue(issueId));
     } catch (caught: unknown) {
       setError(
@@ -163,18 +466,18 @@ export function IssueDetailPage() {
           : "Unable to create pull request",
       );
     } finally {
-      setPullRequestPending(false);
+      setPullRequestPending(null);
     }
   }
 
-  async function copyPrompt() {
+  async function copyPrompt(remediationId: string, prompt: string) {
     setError(null);
     try {
-      await copyToClipboard(renderIssueFixPrompt(issue));
-      setPromptCopied(true);
+      await copyToClipboard(prompt);
+      setCopiedRemediationId(remediationId);
     } catch {
-      setPromptCopied(false);
-      setError("Unable to copy the issue prompt");
+      setCopiedRemediationId(null);
+      setError("Unable to copy the remediation prompt");
     }
   }
 
@@ -231,9 +534,135 @@ export function IssueDetailPage() {
             )}
           </section>
 
-          <section className="issueCallout">
-            <h2>Remediation</h2>
-            <p>{issue.remediation}</p>
+          <section className="issueSection">
+            <h2 className="issueSection__title">Remediations</h2>
+            <div className="remediationList">
+              {issue.remediations.map((remediation) => {
+                const request = pullRequests.find(
+                  (candidate) => candidate.remediationId === remediation.id,
+                );
+                const publishedPullRequest =
+                  request?.pullRequestUrl &&
+                  (request.status === "created" || request.status === "merged")
+                    ? request
+                    : null;
+                return (
+                  <article
+                    className="remediationCard"
+                    id={`remediation-${remediation.id}`}
+                    key={remediation.id}
+                  >
+                    <header className="remediationCard__header">
+                      <span
+                        className={`remediationCard__kind remediationCard__kind--${remediation.type}`}
+                      >
+                        {remediation.type === "code_change"
+                          ? "Code change"
+                          : "External action"}
+                      </span>
+                      <h3>{remediation.title}</h3>
+                    </header>
+                    <p className="remediationCard__description">
+                      {remediation.description}
+                    </p>
+                    {remediation.type === "code_change" && publishedPullRequest ? (
+                      <>
+                        <a
+                          className="remediationPullRequest"
+                          href={publishedPullRequest.pullRequestUrl ?? undefined}
+                          rel="noreferrer"
+                          target="_blank"
+                        >
+                          <span
+                            className={`remediationPullRequest__icon remediationPullRequest__icon--${publishedPullRequest.status}`}
+                          >
+                            <PullRequestIcon />
+                          </span>
+                          <span className="remediationPullRequest__body">
+                            <strong>
+                              Pull request #{publishedPullRequest.pullRequestNumber}
+                            </strong>
+                            <small>{publishedPullRequest.repositoryFullName}</small>
+                          </span>
+                          <span
+                            className={`remediationPullRequest__state remediationPullRequest__state--${publishedPullRequest.status}`}
+                          >
+                            {pullRequestStateLabel(publishedPullRequest.status)}
+                          </span>
+                          <ArrowIcon />
+                        </a>
+                        <PullRequestActivity request={publishedPullRequest} />
+                        {codeChangeRemediationId === remediation.id ? (
+                          <Suspense
+                            fallback={
+                              <div className="remediationDiff__loading">
+                                Loading proposed diff…
+                              </div>
+                            }
+                          >
+                            <RemediationDiff remediation={remediation} />
+                          </Suspense>
+                        ) : null}
+                      </>
+                    ) : remediation.type === "code_change" ? (
+                      <Suspense
+                        fallback={
+                          <div className="remediationDiff__loading">
+                            Loading proposed diff…
+                          </div>
+                        }
+                      >
+                        <RemediationDiff remediation={remediation} />
+                      </Suspense>
+                    ) : (
+                      <div className="remediationPrompt">
+                        <span>Prompt for your agent</span>
+                        <pre>{remediation.agentPrompt}</pre>
+                      </div>
+                    )}
+                    {remediation.type === "code_change" && publishedPullRequest ? null : (
+                      <div className="remediationCard__actions">
+                        {remediation.type === "code_change" ? (
+                          request &&
+                          ["queued", "creating"].includes(request.status) ? (
+                            <span className="remediationCard__status">
+                              Opening pull request…
+                            </span>
+                          ) : detail.pullRequestState.canCreate ? (
+                            <Button
+                              loading={pullRequestPending === remediation.id}
+                              onClick={() => void createPullRequest(remediation.id)}
+                              size="small"
+                              variant="primary"
+                            >
+                              {pullRequestPending === remediation.id
+                                ? "Starting…"
+                                : "Open pull request"}
+                            </Button>
+                          ) : null
+                        ) : (
+                          <Button
+                            aria-live="polite"
+                            onClick={() =>
+                              void copyPrompt(
+                                remediation.id,
+                                remediation.agentPrompt,
+                              )
+                            }
+                            size="small"
+                            variant="secondary"
+                          >
+                            {copiedRemediationId === remediation.id
+                              ? "Copied"
+                              : "Copy prompt"}
+                          </Button>
+                        )}
+                      </div>
+                    )}
+                  </article>
+                );
+              })}
+            </div>
           </section>
 
           <section className="issueSection">
@@ -283,7 +712,7 @@ export function IssueDetailPage() {
                   <span
                     aria-label={rowStatusLabel(request.status)}
                     className={`issueLine__status issueLine__status--${
-                      request.status === "created"
+                      request.status === "created" || request.status === "merged"
                         ? "resolved"
                         : request.status === "failed"
                           ? "failed"
@@ -295,14 +724,15 @@ export function IssueDetailPage() {
                   </span>
                   <span className="issueLine__body">
                     <strong>
-                      {request.status === "created"
+                      {request.status === "created" || request.status === "merged"
                         ? `#${request.pullRequestNumber} in ${request.repositoryFullName}`
                         : request.status === "failed"
                           ? "Pull request failed"
                           : "Creating pull request…"}
                     </strong>
                     <small>
-                      {request.failureReason ?? formatDate(request.createdAt)}
+                      {request.failureReason ??
+                        `${pullRequestStateLabel(request.status)} · ${formatDate(request.createdAt)}`}
                     </small>
                   </span>
                   {request.pullRequestUrl ? (
@@ -388,24 +818,6 @@ export function IssueDetailPage() {
           </div>
 
           <div className="issueRail__actions">
-            {detail.pullRequestState.canCreate ? (
-              <Button
-                loading={pullRequestPending}
-                onClick={() => void createPullRequest()}
-                size="small"
-                variant="primary"
-              >
-                {pullRequestPending ? "Starting…" : "Create pull request"}
-              </Button>
-            ) : null}
-            <Button
-              aria-live="polite"
-              onClick={() => void copyPrompt()}
-              size="small"
-              variant="secondary"
-            >
-              {promptCopied ? "Copied" : "Copy prompt"}
-            </Button>
             <Button
               disabled={archivePending}
               loading={archivePending}

--- a/apps/control-plane/src/styles.css
+++ b/apps/control-plane/src/styles.css
@@ -7647,6 +7647,511 @@ body:has(.appShell--create) {
   white-space: pre-wrap;
 }
 
+.remediationList {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.remediationCard {
+  min-width: 0;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  border: 1px solid #292a2e;
+  border-radius: 8px;
+  background: #161617;
+}
+
+.remediationCard__header {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 9px;
+}
+
+.remediationCard__header h3 {
+  margin: 0;
+  color: var(--issueText);
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 20px;
+}
+
+.remediationCard__kind {
+  padding: 3px 7px;
+  border-radius: 4px;
+  background: #25262a;
+  color: #aeb1b8;
+  font-size: 10px;
+  font-weight: 650;
+  line-height: 14px;
+  letter-spacing: 0.035em;
+  text-transform: uppercase;
+}
+
+.remediationCard__kind--code_change {
+  background: #173224;
+  color: #74c991;
+}
+
+.remediationCard__kind--external_action {
+  background: #2d2940;
+  color: #aaa0e8;
+}
+
+.remediationCard__description {
+  margin: 0;
+  color: var(--issueBody);
+  font-size: 14px;
+  line-height: 22px;
+  white-space: pre-wrap;
+}
+
+.remediationPullRequest {
+  min-width: 0;
+  padding: 13px 14px;
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  border: 1px solid #303136;
+  border-radius: 6px;
+  background: #101011;
+  color: var(--issueText);
+  text-decoration: none;
+  transition:
+    border-color 120ms ease,
+    background 120ms ease;
+}
+
+.remediationPullRequest:hover {
+  border-color: #45474e;
+  background: #141415;
+}
+
+.remediationPullRequest__icon {
+  width: 28px;
+  height: 28px;
+  flex: 0 0 auto;
+  display: grid;
+  place-items: center;
+  border-radius: 6px;
+  background: #203127;
+  color: #74c991;
+}
+
+.remediationPullRequest__icon svg {
+  width: 15px;
+  height: 15px;
+}
+
+.remediationPullRequest__icon--merged {
+  background: #2d2940;
+  color: #aaa0e8;
+}
+
+.remediationPullRequest__body {
+  min-width: 0;
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.remediationPullRequest__body strong,
+.remediationPullRequest__body small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.remediationPullRequest__body strong {
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 18px;
+}
+
+.remediationPullRequest__body small {
+  color: var(--issueMuted);
+  font-size: 11px;
+  line-height: 16px;
+}
+
+.remediationPullRequest__state {
+  padding: 3px 7px;
+  border-radius: 999px;
+  background: #173224;
+  color: #74c991;
+  font-size: 10px;
+  font-weight: 650;
+  line-height: 14px;
+  text-transform: uppercase;
+}
+
+.remediationPullRequest__state--merged {
+  background: #2d2940;
+  color: #aaa0e8;
+}
+
+.remediationPullRequest > svg {
+  width: 13px;
+  height: 13px;
+  flex: 0 0 auto;
+  color: var(--issueMuted);
+}
+
+.remediationActivity {
+  overflow: hidden;
+  border: 1px solid #292a2e;
+  border-radius: 6px;
+  background: #121213;
+}
+
+.remediationActivity > summary {
+  padding: 10px 12px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: var(--issueText);
+  cursor: pointer;
+  list-style: none;
+}
+
+.remediationActivity > summary::-webkit-details-marker {
+  display: none;
+}
+
+.remediationActivity > summary::before {
+  width: 5px;
+  height: 5px;
+  flex: 0 0 auto;
+  border-right: 1px solid var(--issueMuted);
+  border-bottom: 1px solid var(--issueMuted);
+  content: "";
+  transform: rotate(-45deg);
+  transition: transform 120ms ease;
+}
+
+.remediationActivity[open] > summary::before {
+  transform: rotate(45deg) translate(-1px, -1px);
+}
+
+.remediationActivity > summary > span:first-of-type {
+  min-width: 0;
+  display: flex;
+  flex: 1;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.remediationActivity > summary strong {
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.remediationActivity > summary small {
+  overflow: hidden;
+  color: var(--issueMuted);
+  font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.remediationActivity__count {
+  min-width: 20px;
+  padding: 1px 5px;
+  border-radius: 999px;
+  background: #25262a;
+  color: #aeb1b8;
+  font-size: 10px;
+  line-height: 16px;
+  text-align: center;
+}
+
+.remediationActivity__list {
+  margin: 0;
+  padding: 4px 12px 12px;
+  list-style: none;
+}
+
+.remediationActivity__item {
+  position: relative;
+  padding: 8px 0 8px 20px;
+  color: var(--issueBody);
+}
+
+.remediationActivity__item > div,
+.remediationActivity__item > details {
+  min-width: 0;
+}
+
+.remediationActivity__item:not(:last-child)::before {
+  position: absolute;
+  top: 17px;
+  bottom: -9px;
+  left: 4px;
+  width: 1px;
+  background: #303136;
+  content: "";
+}
+
+.remediationActivity__marker {
+  position: absolute;
+  top: 13px;
+  left: 0;
+  width: 9px;
+  height: 9px;
+  border: 2px solid #5d6068;
+  border-radius: 50%;
+  background: #121213;
+}
+
+.remediationActivity__item--success .remediationActivity__marker {
+  border-color: #74c991;
+}
+
+.remediationActivity__item--failed .remediationActivity__marker {
+  border-color: #e47878;
+}
+
+.remediationActivity__heading {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.remediationActivity__heading strong,
+.remediationActivity__heading a {
+  color: var(--issueText);
+  font-size: 12px;
+  font-weight: 550;
+  line-height: 18px;
+}
+
+.remediationActivity__heading a:hover {
+  color: #d8dae0;
+}
+
+.remediationActivity__heading time {
+  flex: 0 0 auto;
+  color: var(--issueMuted);
+  font-size: 10px;
+  line-height: 16px;
+}
+
+.remediationActivity__item p {
+  margin: 2px 0 0;
+  overflow-wrap: anywhere;
+  color: var(--issueMuted);
+  font-size: 11px;
+  line-height: 17px;
+  white-space: pre-wrap;
+}
+
+.remediationReviewRun > summary {
+  display: grid;
+  grid-template-columns: 8px minmax(0, 1fr) auto;
+  align-items: baseline;
+  gap: 8px;
+  cursor: pointer;
+  list-style: none;
+}
+
+.remediationReviewRun > summary::-webkit-details-marker {
+  display: none;
+}
+
+.remediationReviewRun > summary::before {
+  width: 5px;
+  height: 5px;
+  border-right: 1px solid var(--issueMuted);
+  border-bottom: 1px solid var(--issueMuted);
+  content: "";
+  transform: rotate(-45deg);
+  transition: transform 120ms ease;
+}
+
+.remediationReviewRun[open] > summary::before {
+  transform: rotate(45deg) translate(-1px, -1px);
+}
+
+.remediationReviewRun > summary > span {
+  min-width: 0;
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.remediationReviewRun > summary strong {
+  color: var(--issueText);
+  font-size: 12px;
+  font-weight: 550;
+  line-height: 18px;
+}
+
+.remediationReviewRun > summary small {
+  color: var(--issueMuted);
+  font-size: 10px;
+  line-height: 16px;
+}
+
+.remediationReviewRun > summary time {
+  color: var(--issueMuted);
+  font-size: 10px;
+  line-height: 16px;
+  white-space: nowrap;
+}
+
+.remediationReviewTrace {
+  margin-top: 10px;
+  overflow: hidden;
+  border: 1px solid var(--ds-border-default);
+  border-radius: 8px;
+  background: var(--ds-surface-base);
+}
+
+.remediationReviewTrace > header {
+  min-height: 36px;
+  padding: 8px 12px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 1px solid var(--ds-border-default);
+}
+
+.remediationReviewTrace > header strong {
+  color: var(--ds-text-primary);
+  font-family: var(--ds-font-mono);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.remediationReviewTrace > header span {
+  color: var(--ds-text-disabled);
+  font-family: var(--ds-font-mono);
+  font-size: 9px;
+}
+
+.remediationReviewTrace__timeline {
+  max-height: min(560px, 70vh);
+  padding: 7px;
+  overflow-y: auto;
+}
+
+.remediationReviewTrace__timeline > li {
+  flex: 0 0 auto;
+}
+
+.remediationReviewTrace__timeline .traceTool > details > summary {
+  border-radius: 6px;
+}
+
+.remediationReviewTrace__timeline .traceTool__data {
+  margin: 4px 10px 12px 42px;
+}
+
+.remediationReviewTrace__timeline .traceTool__data pre {
+  border-radius: 6px;
+  background: #0d0d0e;
+}
+
+.remediationReviewTrace__timeline .traceMessage {
+  min-height: 0;
+  padding: 9px 10px;
+  border-radius: 6px;
+}
+
+.remediationReviewTrace__timeline .traceMessage--assistant {
+  border: 1px solid #292a2e;
+  background: #141415;
+}
+
+.remediationReviewTrace__timeline .traceMessage--assistant .traceMessage__content {
+  font-size: 11px;
+  line-height: 18px;
+}
+
+.remediationReviewTrace__empty {
+  margin: 10px 12px 12px;
+  color: var(--issueMuted);
+  font-family: var(--ds-font-mono);
+  font-size: 10px;
+}
+
+.remediationDiff {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.remediationDiff__file {
+  max-height: 420px;
+  display: block;
+  overflow: auto;
+  border: 1px solid #303136;
+  border-radius: 6px;
+  background: #101011;
+  font-size: 12px;
+}
+
+.remediationDiff__loading {
+  min-height: 92px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid #303136;
+  border-radius: 6px;
+  background: #101011;
+  color: var(--issueMuted);
+  font-size: 12px;
+}
+
+.remediationDiff__fallback,
+.remediationPrompt pre {
+  max-height: 360px;
+  margin: 0;
+  padding: 13px 14px;
+  overflow: auto;
+  border: 1px solid #303136;
+  border-radius: 6px;
+  background: #101011;
+  color: #c8cbd1;
+  font: 12px/19px var(--mono);
+  white-space: pre;
+}
+
+.remediationPrompt {
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+}
+
+.remediationPrompt > span {
+  color: var(--issueMuted);
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 14px;
+  text-transform: uppercase;
+}
+
+.remediationCard__actions {
+  min-height: 30px;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+}
+
+.remediationCard__status {
+  color: var(--issueMuted);
+  font-size: 12px;
+  line-height: 16px;
+}
+
 .issueSection {
   display: flex;
   flex-direction: column;

--- a/apps/worker/src/investigate.ts
+++ b/apps/worker/src/investigate.ts
@@ -276,6 +276,7 @@ export function investigationInstructions(input: {
     "Do not expose credentials or secret values.",
     workspaceSecretUsageInstructions(workspaceSecrets),
     "For every distinct problem you find, call search_existing_issues before deciding whether it is a new issue or a recurrence. Use an existing issue ID when the evidence matches; this attaches the investigation to that issue instead of creating a duplicate.",
+    "For every new issue, submit one or more concrete remediation options with the report. A code_change must include a complete unified git diff based on files you inspected. Use external_action for work outside the attached repositories, describe the action for a human, and include a self-contained prompt they can pass to an agent with access to that system. Do not claim that a proposed diff has been applied.",
     "Do not include actions performed by Responder during the investigation in an issue timeline; include only events in the incident's causal sequence.",
     "Before your final response, you must call submit_investigation_report exactly once with the structured result. That action saves or attaches the issues and posts the report to Slack.",
     "After submitting, return a concise Markdown report with: Summary, Evidence, Impact, and Recommended next step.",

--- a/apps/worker/src/issue-embeddings.test.ts
+++ b/apps/worker/src/issue-embeddings.test.ts
@@ -117,7 +117,10 @@ describe("issue embeddings", () => {
           {
             title: "Broken route",
             description: "The route throws.",
-            remediation: "Handle the missing value.",
+            remediations: [{
+              title: "Handle the missing value",
+              description: "Handle the missing value.",
+            }],
           },
         ],
         { OPENAI_API_KEY: "test-key" },

--- a/apps/worker/src/issue-embeddings.ts
+++ b/apps/worker/src/issue-embeddings.ts
@@ -169,7 +169,7 @@ export async function embedNewIssues(
   issues: Array<{
     title: string;
     description: string;
-    remediation: string;
+    remediations: Array<{ title: string; description: string }>;
   }>,
   environment: NodeJS.ProcessEnv = process.env,
   dependencies: IssueEmbeddingDependencies = defaultDependencies,
@@ -177,7 +177,14 @@ export async function embedNewIssues(
   if (issues.length === 0) return [];
   try {
     const { model, vectors } = await createEmbeddings(
-      issues.map(issueEmbeddingText),
+      issues.map((issue) =>
+        issueEmbeddingText({
+          ...issue,
+          remediation: issue.remediations
+            .map((remediation) => `${remediation.title}: ${remediation.description}`)
+            .join("\n\n"),
+        }),
+      ),
       environment,
       dependencies,
     );

--- a/apps/worker/src/pull-request-review-job.test.ts
+++ b/apps/worker/src/pull-request-review-job.test.ts
@@ -1,0 +1,140 @@
+import type { PullRequestReviewJob } from "@responder/core/jobs";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { processPullRequestReviewJob } from "./pull-request-review-job.js";
+
+const mocks = vi.hoisted(() => ({
+  appendActivity: vi.fn(),
+  captureAnalytics: vi.fn(),
+  reportException: vi.fn(),
+  runAgent: vi.fn(),
+}));
+
+vi.mock("@responder/core/analytics", () => ({
+  captureAnalyticsEvent: mocks.captureAnalytics,
+}));
+
+vi.mock("@responder/core/db/pull-requests", () => ({
+  appendIssuePullRequestActivity: mocks.appendActivity,
+  pullRequestActivityEvent: (
+    type: string,
+    data?: Record<string, unknown>,
+  ) => ({ data, meta: { at: "2026-08-25T10:00:00.000Z" }, type }),
+}));
+
+vi.mock("./monitoring.js", () => ({
+  reportWorkerException: mocks.reportException,
+}));
+
+vi.mock("./review-pull-request.js", () => ({
+  runPullRequestReviewAgent: mocks.runAgent,
+}));
+
+const payload: PullRequestReviewJob = {
+  kind: "pull_request_review",
+  config: {
+    agentId: "13131313-1313-4313-8313-131313131313",
+    id: "08080808-0808-4808-8808-080808080808",
+    model: "instance/default",
+    organizationId: "15151515-1515-4515-8515-151515151515",
+    prMode: "manual",
+    prompt: "Fix carefully.",
+  },
+  installationId: 123,
+  investigationId: "16161616-1616-4616-8616-161616161616",
+  issue: {
+    description: "The route throws.",
+    evidence: [],
+    id: "10101010-1010-4010-8010-101010101010",
+    remediation: "Handle the missing value.",
+    rootCause: "A value is missing.",
+    severity: "SEV-2",
+    timeline: [],
+    title: "Broken route",
+  },
+  pullRequest: {
+    branch: "fix/broken-route",
+    number: 42,
+    repository: "acme/app",
+  },
+  queuedAt: "2026-08-25T09:59:00.000Z",
+  requestId: "05050505-0505-4505-8505-050505050505",
+  runtimeProfileId: "19191919-1919-4919-8919-191919191919",
+};
+
+describe("pull request review activity", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.appendActivity.mockResolvedValue(undefined);
+    mocks.captureAnalytics.mockResolvedValue(undefined);
+    mocks.reportException.mockResolvedValue(undefined);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  it("records traces, the pushed commit, addressed threads, and completion", async () => {
+    mocks.runAgent.mockImplementation(
+      async (
+        _payload: PullRequestReviewJob,
+        _environment: NodeJS.ProcessEnv,
+        onTrace: (event: Record<string, unknown>) => Promise<void>,
+      ) => {
+        await onTrace({
+          data: { actions: [{ toolName: "apply_patch" }] },
+          meta: { at: "2026-08-25T10:01:00.000Z" },
+          type: "actions.requested",
+        });
+        return {
+          addressedThreads: 1,
+          changedFiles: ["src/route.ts"],
+          commitMessage: "Address review feedback",
+          headSha: "abc123",
+          responses: [{ body: "Fixed in abc123.", threadId: "thread-1" }],
+        };
+      },
+    );
+
+    await expect(
+      processPullRequestReviewJob("job-1", payload, {}),
+    ).resolves.toEqual({ requestId: payload.requestId });
+
+    expect(mocks.appendActivity).toHaveBeenCalledTimes(5);
+    expect(mocks.appendActivity.mock.calls.map(([input]) => input.event.type)).toEqual([
+      "review.session.started",
+      "review.trace",
+      "review.commit.pushed",
+      "review.threads.addressed",
+      "review.session.completed",
+    ]);
+    expect(mocks.appendActivity).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({
+        event: expect.objectContaining({
+          data: expect.objectContaining({
+            files: ["src/route.ts"],
+            message: "Address review feedback",
+            sha: "abc123",
+          }),
+        }),
+        externalKey: "review-job:job-1:commit:abc123",
+      }),
+    );
+  });
+
+  it("records a terminal activity when the review fails", async () => {
+    const failure = new Error("review failed");
+    mocks.runAgent.mockRejectedValue(failure);
+
+    await expect(
+      processPullRequestReviewJob("job-2", payload, {}),
+    ).rejects.toThrow("review failed");
+
+    expect(mocks.appendActivity.mock.calls.map(([input]) => input.event.type)).toEqual([
+      "review.session.started",
+      "review.session.failed",
+    ]);
+    expect(mocks.reportException).toHaveBeenCalledWith(
+      failure,
+      expect.objectContaining({ jobId: "job-2", requestId: payload.requestId }),
+    );
+  });
+});

--- a/apps/worker/src/pull-request-review-job.ts
+++ b/apps/worker/src/pull-request-review-job.ts
@@ -1,4 +1,8 @@
 import { captureAnalyticsEvent } from "@responder/core/analytics";
+import {
+  appendIssuePullRequestActivity,
+  pullRequestActivityEvent,
+} from "@responder/core/db/pull-requests";
 import type { PullRequestReviewJob } from "@responder/core/jobs";
 import { safeInvestigationError } from "./investigate.js";
 import { reportWorkerException } from "./monitoring.js";
@@ -10,7 +14,54 @@ export async function processPullRequestReviewJob(
   environment: NodeJS.ProcessEnv = process.env,
 ): Promise<{ requestId: string }> {
   try {
-    const result = await runPullRequestReviewAgent(payload, environment);
+    await appendIssuePullRequestActivity({
+      event: pullRequestActivityEvent("review.session.started", { jobId }),
+      externalKey: `review-job:${jobId}:started`,
+      requestId: payload.requestId,
+    });
+    let traceIndex = 0;
+    const result = await runPullRequestReviewAgent(
+      payload,
+      environment,
+      async (event) => {
+        const index = traceIndex++;
+        await appendIssuePullRequestActivity({
+          event: pullRequestActivityEvent("review.trace", { event, jobId }),
+          externalKey: `review-job:${jobId}:trace:${index}`,
+          requestId: payload.requestId,
+        });
+      },
+    );
+    if (result.changedFiles.length > 0) {
+      await appendIssuePullRequestActivity({
+        event: pullRequestActivityEvent("review.commit.pushed", {
+          files: result.changedFiles,
+          message: result.commitMessage,
+          sha: result.headSha,
+        }),
+        externalKey: `review-job:${jobId}:commit:${result.headSha}`,
+        requestId: payload.requestId,
+      });
+    }
+    if (result.addressedThreads > 0) {
+      await appendIssuePullRequestActivity({
+        event: pullRequestActivityEvent("review.threads.addressed", {
+          count: result.addressedThreads,
+          responses: result.responses,
+        }),
+        externalKey: `review-job:${jobId}:threads-addressed`,
+        requestId: payload.requestId,
+      });
+    }
+    await appendIssuePullRequestActivity({
+      event: pullRequestActivityEvent("review.session.completed", {
+        addressedThreads: result.addressedThreads,
+        changedFiles: result.changedFiles.length,
+        jobId,
+      }),
+      externalKey: `review-job:${jobId}:completed`,
+      requestId: payload.requestId,
+    });
     await captureAnalyticsEvent({
       distinctId: `investigation:${payload.investigationId}`,
       event: "pr review addressed",
@@ -37,9 +88,29 @@ export async function processPullRequestReviewJob(
     );
     return { requestId: payload.requestId };
   } catch (error) {
+    const safeError = safeInvestigationError(error, environment);
+    try {
+      await appendIssuePullRequestActivity({
+        event: pullRequestActivityEvent("review.session.failed", {
+          error: safeError,
+          jobId,
+        }),
+        externalKey: `review-job:${jobId}:failed`,
+        requestId: payload.requestId,
+      });
+    } catch (activityError) {
+      console.error(
+        JSON.stringify({
+          error: safeInvestigationError(activityError, environment),
+          event: "pull_request_review_activity_failed",
+          jobId,
+          requestId: payload.requestId,
+        }),
+      );
+    }
     console.error(
       JSON.stringify({
-        error: safeInvestigationError(error, environment),
+        error: safeError,
         event: "pull_request_review_job_failed",
         jobId,
         requestId: payload.requestId,

--- a/apps/worker/src/pull-request-review-tool.ts
+++ b/apps/worker/src/pull-request-review-tool.ts
@@ -16,7 +16,9 @@ import type { CheckedOutRepository } from "./repositories.js";
 export interface AddressedReviewResult {
   addressedThreadIds: string[];
   changedFiles: string[];
+  commitMessage: string;
   headSha: string;
+  responses: Array<{ body: string; threadId: string }>;
 }
 
 export function createPullRequestReviewTool(input: {
@@ -88,7 +90,9 @@ export function createPullRequestReviewTool(input: {
         result = {
           addressedThreadIds: responseIds,
           changedFiles: published.changedFiles,
+          commitMessage: request.commitMessage,
           headSha: published.headSha,
+          responses: request.responses,
         };
         return result;
       },

--- a/apps/worker/src/pull-request.test.ts
+++ b/apps/worker/src/pull-request.test.ts
@@ -69,6 +69,9 @@ describe("pull request tool", () => {
         },
       ],
       issueRemediation: "Handle the missing value.",
+      issueRemediations: [],
+      remediationId: null,
+      selectedRemediation: undefined,
       investigationInput: {
         provider: "slack",
         externalEventId: "thread-1",

--- a/apps/worker/src/pull-request.ts
+++ b/apps/worker/src/pull-request.ts
@@ -10,6 +10,7 @@ import {
 } from "@responder/core/db/pull-requests";
 import type { InvestigationInput } from "@responder/core/db/schema";
 import type { IssueEvidence } from "@responder/core/investigations/report";
+import { refreshIssuePullRequestSlackMessages } from "@responder/core/integrations/slack-remediations";
 import { responderIssueUrl as buildResponderIssueUrl } from "@responder/core/responder-urls";
 import { z } from "zod";
 import {
@@ -101,6 +102,7 @@ export function createPullRequestTool(input: {
           : {}),
       });
       await markIssuePullRequestStarted(request.requestId);
+      await refreshIssuePullRequestSlackMessages(request.requestId);
       let published = false;
 
       try {
@@ -143,7 +145,7 @@ export function createPullRequestTool(input: {
             repository: repository.fullName,
             repositoryPath: checkout.path,
             requestId: request.requestId,
-            title: `Fix: ${request.issueTitle}`.slice(0, 240),
+            title: `Fix: ${request.selectedRemediation?.title ?? request.issueTitle}`.slice(0, 240),
             workspaceBaseSha: checkout.workspaceBaseSha,
           },
           input.session,
@@ -156,6 +158,7 @@ export function createPullRequestTool(input: {
           pullRequestNumber: result.number,
           pullRequestUrl: result.url,
         });
+        await refreshIssuePullRequestSlackMessages(request.requestId);
         await captureAnalyticsEvent({
           distinctId: `investigation:${input.investigationId}`,
           event: "pr opened",
@@ -182,6 +185,7 @@ export function createPullRequestTool(input: {
             request.requestId,
             error instanceof Error ? error.message : "Unable to create pull request",
           );
+          await refreshIssuePullRequestSlackMessages(request.requestId);
         }
         throw error;
       }

--- a/apps/worker/src/remediate.ts
+++ b/apps/worker/src/remediate.ts
@@ -210,14 +210,16 @@ export async function runRemediationAgent(
       instructions: [
         runtimeProfile?.systemPrompt,
         job.config.prompt,
-        renderIssueFixPrompt(job.issue),
+        renderIssueFixPrompt(job.issue, job.selectedRemediation),
         "The selected repositories are already checked out:",
         ...repositories.map(
           (repository) =>
             `- ${repository.repository}: ${repository.path} (${repository.branch} at ${repository.sha})`,
         ),
         remediationApplyPatchPathInstruction,
-        "Inspect the relevant code, make the smallest safe fix in exactly one selected repository, and run the narrowest useful checks.",
+        job.selectedRemediation?.type === "code_change"
+          ? "Use the proposed diff as the starting point. Verify it against the current checkout, adjust it when needed, make the smallest safe fix in exactly one selected repository, and run the narrowest useful checks."
+          : "Inspect the relevant code, make the smallest safe fix in exactly one selected repository, and run the narrowest useful checks.",
         remediationFailureMechanismInstruction,
         `Then call create_pull_request with issue ID ${job.issue.id}. Do not finish without creating the pull request or clearly explaining why no safe code fix is possible.`,
         "Do not expose credentials or secret values. The pull request is the only allowed external change.",
@@ -228,10 +230,14 @@ export async function runRemediationAgent(
       capabilities: Capabilities.default(),
       tools: [pullRequestTool],
     });
-    const result = await run(agent, renderIssueFixPrompt(job.issue), {
-      maxTurns: remediationMaxTurns,
-      sandbox: { session },
-    });
+    const result = await run(
+      agent,
+      renderIssueFixPrompt(job.issue, job.selectedRemediation),
+      {
+        maxTurns: remediationMaxTurns,
+        sandbox: { session },
+      },
+    );
     if (typeof result.finalOutput !== "string" || !result.finalOutput.trim()) {
       throw new Error("OpenAI agent returned an empty remediation result");
     }

--- a/apps/worker/src/remediation-job.ts
+++ b/apps/worker/src/remediation-job.ts
@@ -1,5 +1,6 @@
 import { failIssuePullRequest } from "@responder/core/db/pull-requests";
 import type { RemediationJob } from "@responder/core/jobs";
+import { refreshIssuePullRequestSlackMessages } from "@responder/core/integrations/slack-remediations";
 import {
   remediationRunDiagnostics,
   runRemediationAgent,
@@ -10,6 +11,7 @@ import { reportWorkerException } from "./monitoring.js";
 interface RemediationJobDependencies {
   failRequest: typeof failIssuePullRequest;
   reportException: typeof reportWorkerException;
+  refreshSlack?: typeof refreshIssuePullRequestSlackMessages;
   runDiagnostics: typeof remediationRunDiagnostics;
   runAgent: typeof runRemediationAgent;
 }
@@ -17,6 +19,7 @@ interface RemediationJobDependencies {
 const defaultDependencies: RemediationJobDependencies = {
   failRequest: failIssuePullRequest,
   reportException: reportWorkerException,
+  refreshSlack: refreshIssuePullRequestSlackMessages,
   runDiagnostics: remediationRunDiagnostics,
   runAgent: runRemediationAgent,
 };
@@ -113,6 +116,8 @@ export async function processRemediationJob(
       "Unable to record remediation failure",
     );
   }
+
+  await dependencies.refreshSlack?.(payload.remediationRequestId);
 
   if (!reportFailure) {
     console.log(

--- a/apps/worker/src/report.test.ts
+++ b/apps/worker/src/report.test.ts
@@ -53,6 +53,7 @@ describe("investigation report submission", () => {
           }],
           severity: "SEV-2",
           remediation: "Handle the missing value.",
+          remediations: [],
         },
       ],
       markdown: "saved markdown",
@@ -83,7 +84,12 @@ describe("investigation report submission", () => {
             description: "The request reached the route without the required value.",
           }],
           severity: "SEV-2" as const,
-          remediation: "Handle the missing value.",
+          remediations: [{
+            type: "external_action" as const,
+            title: "Handle the missing value",
+            description: "Handle the missing value.",
+            agentPrompt: "Update the route to handle the missing value safely.",
+          }],
           evidence: [
             {
               source: "github" as const,
@@ -383,7 +389,12 @@ describe("investigation report submission", () => {
             description: "The request reached the new path with unchecked input.",
           }],
           severity: "SEV-2" as const,
-          remediation: "Handle the new path.",
+          remediations: [{
+            type: "external_action" as const,
+            title: "Handle the new path",
+            description: "Handle the new path.",
+            agentPrompt: "Update the new path to validate its input.",
+          }],
           evidence: [
             {
               source: "github" as const,

--- a/apps/worker/src/review-pull-request.ts
+++ b/apps/worker/src/review-pull-request.ts
@@ -9,6 +9,7 @@ import {
   type DaytonaSandboxSession,
 } from "@openai/agents-extensions/sandbox/daytona";
 import { getRuntimeProfile } from "@responder/core/db/runtime-profiles";
+import type { InvestigationTraceEvent } from "@responder/core/db/schema";
 import { getRuntimeWorkspaceSecrets } from "@responder/core/db/workspace-secrets";
 import { daytonaClientOptions } from "@responder/core/daytona-config";
 import type { PullRequestReviewJob } from "@responder/core/jobs";
@@ -26,6 +27,7 @@ import {
   prepareDaytonaSandbox,
 } from "./sandbox.js";
 import { workspaceSecretUsageInstructions } from "./secret-safety.js";
+import { investigationTraceEventFromStream } from "./trace.js";
 
 export const pullRequestReviewMaxTurns = 40;
 
@@ -46,14 +48,27 @@ function renderReviewThreads(threads: BotReviewThread[]): string {
 export async function runPullRequestReviewAgent(
   job: PullRequestReviewJob,
   environment: NodeJS.ProcessEnv = process.env,
-): Promise<{ addressedThreads: number; changedFiles: string[] }> {
+  onTraceEvent: (event: InvestigationTraceEvent) => Promise<void> = async () => {},
+): Promise<{
+  addressedThreads: number;
+  changedFiles: string[];
+  commitMessage: string | null;
+  headSha: string;
+  responses: Array<{ body: string; threadId: string }>;
+}> {
   const review = await listUnresolvedBotReviewThreads({
     installationId: job.installationId,
     pullRequestNumber: job.pullRequest.number,
     repository: job.pullRequest.repository,
   });
   if (review.threads.length === 0) {
-    return { addressedThreads: 0, changedFiles: [] };
+    return {
+      addressedThreads: 0,
+      changedFiles: [],
+      commitMessage: null,
+      headSha: review.headSha,
+      responses: [],
+    };
   }
   if (review.branch !== job.pullRequest.branch) {
     throw new Error("Pull request branch no longer matches the created request");
@@ -124,10 +139,24 @@ export async function runPullRequestReviewAgent(
       capabilities: Capabilities.default(),
       tools: [reviewTool.tool],
     });
-    await run(agent, `Address these review threads:\n\n${renderReviewThreads(review.threads)}`, {
-      maxTurns: pullRequestReviewMaxTurns,
-      sandbox: { session },
-    });
+    const runResult = await run(
+      agent,
+      `Address these review threads:\n\n${renderReviewThreads(review.threads)}`,
+      {
+        maxTurns: pullRequestReviewMaxTurns,
+        sandbox: { session },
+        stream: true,
+      },
+    );
+    for await (const streamEvent of runResult) {
+      const event = investigationTraceEventFromStream(
+        streamEvent,
+        environment,
+        new Date(),
+      );
+      if (event) await onTraceEvent(event);
+    }
+    await runResult.completed;
     const result = reviewTool.getResult();
     if (!result) {
       throw new Error("Pull request review finished without addressing its threads");
@@ -135,6 +164,9 @@ export async function runPullRequestReviewAgent(
     return {
       addressedThreads: result.addressedThreadIds.length,
       changedFiles: result.changedFiles,
+      commitMessage: result.commitMessage,
+      headSha: result.headSha,
+      responses: result.responses,
     };
   } finally {
     if (session) {

--- a/drizzle/0028_melted_hercules.sql
+++ b/drizzle/0028_melted_hercules.sql
@@ -1,0 +1,18 @@
+ALTER TABLE "issue_pull_requests" ADD COLUMN "remediation_id" uuid;--> statement-breakpoint
+ALTER TABLE "issues" ADD COLUMN "remediations" jsonb DEFAULT '[]'::jsonb NOT NULL;--> statement-breakpoint
+UPDATE "issues"
+SET "remediations" = jsonb_build_array(
+  jsonb_build_object(
+    'id', gen_random_uuid()::text,
+    'type', 'external_action',
+    'title', 'Recommended remediation',
+    'description', "remediation",
+    'agentPrompt', concat(
+      'Address this issue in the appropriate external system.', E'\n\n',
+      'Issue: ', "title", E'\n',
+      'Description: ', "description", E'\n',
+      'Recommended action: ', "remediation"
+    )
+  )
+)
+WHERE jsonb_array_length("remediations") = 0;

--- a/drizzle/0029_round_venom.sql
+++ b/drizzle/0029_round_venom.sql
@@ -1,0 +1,11 @@
+CREATE TABLE "issue_pull_request_activities" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"request_id" uuid NOT NULL,
+	"external_key" text,
+	"event" jsonb NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "issue_pull_request_activities" ADD CONSTRAINT "issue_pull_request_activities_request_id_issue_pull_requests_id_fk" FOREIGN KEY ("request_id") REFERENCES "public"."issue_pull_requests"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "issue_pull_request_activities_request_idx" ON "issue_pull_request_activities" USING btree ("request_id","id");--> statement-breakpoint
+CREATE UNIQUE INDEX "issue_pull_request_activities_external_key_idx" ON "issue_pull_request_activities" USING btree ("request_id","external_key") WHERE "issue_pull_request_activities"."external_key" is not null;

--- a/drizzle/0030_low_cerebro.sql
+++ b/drizzle/0030_low_cerebro.sql
@@ -1,0 +1,13 @@
+CREATE TABLE "issue_pull_request_slack_messages" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"request_id" uuid NOT NULL,
+	"integration_account_id" uuid NOT NULL,
+	"channel_id" text NOT NULL,
+	"message_timestamp" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "issue_pull_request_slack_messages" ADD CONSTRAINT "issue_pull_request_slack_messages_request_id_issue_pull_requests_id_fk" FOREIGN KEY ("request_id") REFERENCES "public"."issue_pull_requests"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "issue_pull_request_slack_messages" ADD CONSTRAINT "issue_pull_request_slack_messages_integration_account_id_integration_accounts_id_fk" FOREIGN KEY ("integration_account_id") REFERENCES "public"."integration_accounts"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "issue_pull_request_slack_messages_message_idx" ON "issue_pull_request_slack_messages" USING btree ("request_id","integration_account_id","channel_id","message_timestamp");--> statement-breakpoint
+CREATE INDEX "issue_pull_request_slack_messages_request_idx" ON "issue_pull_request_slack_messages" USING btree ("request_id");

--- a/drizzle/meta/0028_snapshot.json
+++ b/drizzle/meta/0028_snapshot.json
@@ -1,0 +1,3562 @@
+{
+  "id": "328ca0db-8381-4fc7-b391-f7520a93e000",
+  "prevId": "a4875668-b4dd-4c93-a1c0-0f0d8c4ce2a4",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "invitation_organizationId_idx": {
+          "name": "invitation_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_email_idx": {
+          "name": "invitation_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "member_organizationId_idx": {
+          "name": "member_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_userId_idx": {
+          "name": "member_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'user'"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_organization_id": {
+          "name": "last_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_config_versions": {
+      "name": "agent_config_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "trigger_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_config": {
+          "name": "trigger_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "report_config": {
+          "name": "report_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context_account_ids": {
+          "name": "context_account_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "context_resource_ids": {
+          "name": "context_resource_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "pr_mode": {
+          "name": "pr_mode",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pr_mode_policy": {
+          "name": "pr_mode_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'disabled'"
+        },
+        "create_linear_tickets": {
+          "name": "create_linear_tickets",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "linear_issue_template": {
+          "name": "linear_issue_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'## Responder issue\n[{{issue_id}}]({{issue_url}})\n\n## Description\n{{description}}\n\n## Evidence\n{{evidence}}\n\n## Recommended remediation\n{{remediation}}'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_config_versions_agent_version_idx": {
+          "name": "agent_config_versions_agent_version_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_config_versions_agent_idx": {
+          "name": "agent_config_versions_agent_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_config_versions_agent_id_agents_id_fk": {
+          "name": "agent_config_versions_agent_id_agents_id_fk",
+          "tableFrom": "agent_config_versions",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_config_versions_created_by_user_id_fk": {
+          "name": "agent_config_versions_created_by_user_id_fk",
+          "tableFrom": "agent_config_versions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_version_repositories": {
+      "name": "agent_version_repositories",
+      "schema": "",
+      "columns": {
+        "agent_config_version_id": {
+          "name": "agent_config_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_version_repositories_agent_config_version_id_agent_config_versions_id_fk": {
+          "name": "agent_version_repositories_agent_config_version_id_agent_config_versions_id_fk",
+          "tableFrom": "agent_version_repositories",
+          "tableTo": "agent_config_versions",
+          "columnsFrom": [
+            "agent_config_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_version_repositories_repository_id_repositories_id_fk": {
+          "name": "agent_version_repositories_repository_id_repositories_id_fk",
+          "tableFrom": "agent_version_repositories",
+          "tableTo": "repositories",
+          "columnsFrom": [
+            "repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_version_repositories_agent_config_version_id_repository_id_pk": {
+          "name": "agent_version_repositories_agent_config_version_id_repository_id_pk",
+          "columns": [
+            "agent_config_version_id",
+            "repository_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_version_secrets": {
+      "name": "agent_version_secrets",
+      "schema": "",
+      "columns": {
+        "agent_config_version_id": {
+          "name": "agent_config_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_secret_id": {
+          "name": "workspace_secret_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_version_secrets_agent_config_version_id_agent_config_versions_id_fk": {
+          "name": "agent_version_secrets_agent_config_version_id_agent_config_versions_id_fk",
+          "tableFrom": "agent_version_secrets",
+          "tableTo": "agent_config_versions",
+          "columnsFrom": [
+            "agent_config_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_version_secrets_workspace_secret_id_workspace_secrets_id_fk": {
+          "name": "agent_version_secrets_workspace_secret_id_workspace_secrets_id_fk",
+          "tableFrom": "agent_version_secrets",
+          "tableTo": "workspace_secrets",
+          "columnsFrom": [
+            "workspace_secret_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_version_secrets_agent_config_version_id_workspace_secret_id_pk": {
+          "name": "agent_version_secrets_agent_config_version_id_workspace_secret_id_pk",
+          "columns": [
+            "agent_config_version_id",
+            "workspace_secret_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "active_version_id": {
+          "name": "active_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agents_organization_idx": {
+          "name": "agents_organization_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agents_organization_id_organization_id_fk": {
+          "name": "agents_organization_id_organization_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.billing_notification_deliveries": {
+      "name": "billing_notification_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integration_account_id": {
+          "name": "integration_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_key": {
+          "name": "period_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination": {
+          "name": "destination",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "billing_notification_delivery_target_idx": {
+          "name": "billing_notification_delivery_target_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "integration_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "destination",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "billing_notification_delivery_status_idx": {
+          "name": "billing_notification_delivery_status_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "billing_notification_deliveries_organization_id_organization_id_fk": {
+          "name": "billing_notification_deliveries_organization_id_organization_id_fk",
+          "tableFrom": "billing_notification_deliveries",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "billing_notification_deliveries_integration_account_id_integration_accounts_id_fk": {
+          "name": "billing_notification_deliveries_integration_account_id_integration_accounts_id_fk",
+          "tableFrom": "billing_notification_deliveries",
+          "tableTo": "integration_accounts",
+          "columnsFrom": [
+            "integration_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.delivery_attempts": {
+      "name": "delivery_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "investigation_id": {
+          "name": "investigation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination": {
+          "name": "destination",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "delivery_attempts_idempotency_idx": {
+          "name": "delivery_attempts_idempotency_idx",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_attempts_investigation_idx": {
+          "name": "delivery_attempts_investigation_idx",
+          "columns": [
+            {
+              "expression": "investigation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "delivery_attempts_investigation_id_investigations_id_fk": {
+          "name": "delivery_attempts_investigation_id_investigations_id_fk",
+          "tableFrom": "delivery_attempts",
+          "tableTo": "investigations",
+          "columnsFrom": [
+            "investigation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instance_configuration": {
+      "name": "instance_configuration",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "active_runtime_profile_id": {
+          "name": "active_runtime_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "instance_configuration_active_runtime_profile_id_runtime_profiles_id_fk": {
+          "name": "instance_configuration_active_runtime_profile_id_runtime_profiles_id_fk",
+          "tableFrom": "instance_configuration",
+          "tableTo": "runtime_profiles",
+          "columnsFrom": [
+            "active_runtime_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_accounts": {
+      "name": "integration_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "integration_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_account_id": {
+          "name": "external_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'connected'"
+        },
+        "encrypted_credentials": {
+          "name": "encrypted_credentials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_key_version": {
+          "name": "credential_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "integration_accounts_organization_provider_external_idx": {
+          "name": "integration_accounts_organization_provider_external_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_accounts_organization_idx": {
+          "name": "integration_accounts_organization_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_accounts_organization_id_organization_id_fk": {
+          "name": "integration_accounts_organization_id_organization_id_fk",
+          "tableFrom": "integration_accounts",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_connection_states": {
+      "name": "integration_connection_states",
+      "schema": "",
+      "columns": {
+        "state_hash": {
+          "name": "state_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "integration_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_verifier": {
+          "name": "code_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "return_to": {
+          "name": "return_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'/settings'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "integration_connection_states_expires_idx": {
+          "name": "integration_connection_states_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_connection_states_organization_idx": {
+          "name": "integration_connection_states_organization_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_connection_states_owner_provider_idx": {
+          "name": "integration_connection_states_owner_provider_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_connection_states_organization_id_organization_id_fk": {
+          "name": "integration_connection_states_organization_id_organization_id_fk",
+          "tableFrom": "integration_connection_states",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "integration_connection_states_user_id_user_id_fk": {
+          "name": "integration_connection_states_user_id_user_id_fk",
+          "tableFrom": "integration_connection_states",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_resources": {
+      "name": "integration_resources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "integration_account_id": {
+          "name": "integration_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "integration_resource_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "available": {
+          "name": "available",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "integration_resources_account_kind_external_idx": {
+          "name": "integration_resources_account_kind_external_idx",
+          "columns": [
+            {
+              "expression": "integration_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_resources_account_idx": {
+          "name": "integration_resources_account_idx",
+          "columns": [
+            {
+              "expression": "integration_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_resources_integration_account_id_integration_accounts_id_fk": {
+          "name": "integration_resources_integration_account_id_integration_accounts_id_fk",
+          "tableFrom": "integration_resources",
+          "tableTo": "integration_accounts",
+          "columnsFrom": [
+            "integration_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.investigation_issues": {
+      "name": "investigation_issues",
+      "schema": "",
+      "columns": {
+        "investigation_id": {
+          "name": "investigation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relationship": {
+          "name": "relationship",
+          "type": "issue_relationship",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "investigation_issues_issue_idx": {
+          "name": "investigation_issues_issue_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "investigation_issues_investigation_id_investigations_id_fk": {
+          "name": "investigation_issues_investigation_id_investigations_id_fk",
+          "tableFrom": "investigation_issues",
+          "tableTo": "investigations",
+          "columnsFrom": [
+            "investigation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "investigation_issues_issue_id_issues_id_fk": {
+          "name": "investigation_issues_issue_id_issues_id_fk",
+          "tableFrom": "investigation_issues",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "investigation_issues_investigation_id_issue_id_pk": {
+          "name": "investigation_issues_investigation_id_issue_id_pk",
+          "columns": [
+            "investigation_id",
+            "issue_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.investigation_replay_requests": {
+      "name": "investigation_replay_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source_investigation_id": {
+          "name": "source_investigation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "replay_investigation_id": {
+          "name": "replay_investigation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_by": {
+          "name": "requested_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "investigation_replay_request_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "processing_started_at": {
+          "name": "processing_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "queued_at": {
+          "name": "queued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "investigation_replay_requests_replay_idx": {
+          "name": "investigation_replay_requests_replay_idx",
+          "columns": [
+            {
+              "expression": "replay_investigation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "investigation_replay_requests_claim_idx": {
+          "name": "investigation_replay_requests_claim_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "investigation_replay_requests_source_idx": {
+          "name": "investigation_replay_requests_source_idx",
+          "columns": [
+            {
+              "expression": "source_investigation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "investigation_replay_requests_source_investigation_id_investigations_id_fk": {
+          "name": "investigation_replay_requests_source_investigation_id_investigations_id_fk",
+          "tableFrom": "investigation_replay_requests",
+          "tableTo": "investigations",
+          "columnsFrom": [
+            "source_investigation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.investigation_trace_events": {
+      "name": "investigation_trace_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "investigation_id": {
+          "name": "investigation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event": {
+          "name": "event",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "investigation_trace_events_investigation_id_idx": {
+          "name": "investigation_trace_events_investigation_id_idx",
+          "columns": [
+            {
+              "expression": "investigation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "investigation_trace_events_investigation_id_investigations_id_fk": {
+          "name": "investigation_trace_events_investigation_id_investigations_id_fk",
+          "tableFrom": "investigation_trace_events",
+          "tableTo": "investigations",
+          "columnsFrom": [
+            "investigation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.investigations": {
+      "name": "investigations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_config_version_id": {
+          "name": "agent_config_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime_profile_id": {
+          "name": "runtime_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "investigation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finding": {
+          "name": "finding",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "structured_report": {
+          "name": "structured_report",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replay_report": {
+          "name": "replay_report",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "report_markdown": {
+          "name": "report_markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_replay": {
+          "name": "is_replay",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "replay_of_investigation_id": {
+          "name": "replay_of_investigation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eve_session_id": {
+          "name": "eve_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_message_timestamp": {
+          "name": "slack_message_timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_trace_items": {
+          "name": "slack_trace_items",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "investigations_organization_created_idx": {
+          "name": "investigations_organization_created_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "investigations_agent_created_idx": {
+          "name": "investigations_agent_created_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "investigations_replay_source_idx": {
+          "name": "investigations_replay_source_idx",
+          "columns": [
+            {
+              "expression": "replay_of_investigation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "investigations_organization_id_organization_id_fk": {
+          "name": "investigations_organization_id_organization_id_fk",
+          "tableFrom": "investigations",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "investigations_agent_id_agents_id_fk": {
+          "name": "investigations_agent_id_agents_id_fk",
+          "tableFrom": "investigations",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "investigations_agent_config_version_id_agent_config_versions_id_fk": {
+          "name": "investigations_agent_config_version_id_agent_config_versions_id_fk",
+          "tableFrom": "investigations",
+          "tableTo": "agent_config_versions",
+          "columnsFrom": [
+            "agent_config_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "investigations_runtime_profile_id_runtime_profiles_id_fk": {
+          "name": "investigations_runtime_profile_id_runtime_profiles_id_fk",
+          "tableFrom": "investigations",
+          "tableTo": "runtime_profiles",
+          "columnsFrom": [
+            "runtime_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "investigations_replay_source_fk": {
+          "name": "investigations_replay_source_fk",
+          "tableFrom": "investigations",
+          "tableTo": "investigations",
+          "columnsFrom": [
+            "replay_of_investigation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_linear_tickets": {
+      "name": "issue_linear_tickets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "investigation_id": {
+          "name": "investigation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_config_version_id": {
+          "name": "agent_config_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integration_account_id": {
+          "name": "integration_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linear_issue_id": {
+          "name": "linear_issue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linear_identifier": {
+          "name": "linear_identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linear_issue_url": {
+          "name": "linear_issue_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "issue_linear_tickets_issue_idx": {
+          "name": "issue_linear_tickets_issue_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_linear_tickets_investigation_idx": {
+          "name": "issue_linear_tickets_investigation_idx",
+          "columns": [
+            {
+              "expression": "investigation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_linear_tickets_status_created_idx": {
+          "name": "issue_linear_tickets_status_created_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_linear_tickets_issue_id_issues_id_fk": {
+          "name": "issue_linear_tickets_issue_id_issues_id_fk",
+          "tableFrom": "issue_linear_tickets",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_linear_tickets_investigation_id_investigations_id_fk": {
+          "name": "issue_linear_tickets_investigation_id_investigations_id_fk",
+          "tableFrom": "issue_linear_tickets",
+          "tableTo": "investigations",
+          "columnsFrom": [
+            "investigation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_linear_tickets_agent_config_version_id_agent_config_versions_id_fk": {
+          "name": "issue_linear_tickets_agent_config_version_id_agent_config_versions_id_fk",
+          "tableFrom": "issue_linear_tickets",
+          "tableTo": "agent_config_versions",
+          "columnsFrom": [
+            "agent_config_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "issue_linear_tickets_integration_account_id_integration_accounts_id_fk": {
+          "name": "issue_linear_tickets_integration_account_id_integration_accounts_id_fk",
+          "tableFrom": "issue_linear_tickets",
+          "tableTo": "integration_accounts",
+          "columnsFrom": [
+            "integration_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_pull_requests": {
+      "name": "issue_pull_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "investigation_id": {
+          "name": "investigation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_config_version_id": {
+          "name": "agent_config_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "remediation_id": {
+          "name": "remediation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_full_name": {
+          "name": "repository_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pull_request_number": {
+          "name": "pull_request_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pull_request_url": {
+          "name": "pull_request_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eve_session_id": {
+          "name": "eve_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "issue_pull_requests_active_issue_idx": {
+          "name": "issue_pull_requests_active_issue_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"status\" in ('queued', 'creating', 'created')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_pull_requests_issue_created_idx": {
+          "name": "issue_pull_requests_issue_created_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_pull_requests_investigation_idx": {
+          "name": "issue_pull_requests_investigation_idx",
+          "columns": [
+            {
+              "expression": "investigation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_pull_requests_issue_id_issues_id_fk": {
+          "name": "issue_pull_requests_issue_id_issues_id_fk",
+          "tableFrom": "issue_pull_requests",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_pull_requests_investigation_id_investigations_id_fk": {
+          "name": "issue_pull_requests_investigation_id_investigations_id_fk",
+          "tableFrom": "issue_pull_requests",
+          "tableTo": "investigations",
+          "columnsFrom": [
+            "investigation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_pull_requests_agent_config_version_id_agent_config_versions_id_fk": {
+          "name": "issue_pull_requests_agent_config_version_id_agent_config_versions_id_fk",
+          "tableFrom": "issue_pull_requests",
+          "tableTo": "agent_config_versions",
+          "columnsFrom": [
+            "agent_config_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issues": {
+      "name": "issues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root_cause": {
+          "name": "root_cause",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "timeline": {
+          "name": "timeline",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "severity": {
+          "name": "severity",
+          "type": "severity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "remediation": {
+          "name": "remediation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "remediations": {
+          "name": "remediations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_model": {
+          "name": "embedding_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issues_organization_created_idx": {
+          "name": "issues_organization_created_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issues_organization_id_organization_id_fk": {
+          "name": "issues_organization_id_organization_id_fk",
+          "tableFrom": "issues",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.repositories": {
+      "name": "repositories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "integration_account_id": {
+          "name": "integration_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'main'"
+        },
+        "private": {
+          "name": "private",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "available": {
+          "name": "available",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "repositories_installation_external_idx": {
+          "name": "repositories_installation_external_idx",
+          "columns": [
+            {
+              "expression": "integration_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "repositories_integration_account_id_integration_accounts_id_fk": {
+          "name": "repositories_integration_account_id_integration_accounts_id_fk",
+          "tableFrom": "repositories",
+          "tableTo": "integration_accounts",
+          "columnsFrom": [
+            "integration_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runtime_profiles": {
+      "name": "runtime_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "version": {
+          "name": "version",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_options": {
+          "name": "model_options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "runtime_profiles_version_idx": {
+          "name": "runtime_profiles_version_idx",
+          "columns": [
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_receipts": {
+      "name": "webhook_receipts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_event_id": {
+          "name": "external_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "investigation_id": {
+          "name": "investigation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_hash": {
+          "name": "payload_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_receipts_provider_event_idx": {
+          "name": "webhook_receipts_provider_event_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_receipts_organization_id_organization_id_fk": {
+          "name": "webhook_receipts_organization_id_organization_id_fk",
+          "tableFrom": "webhook_receipts",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_secrets": {
+      "name": "workspace_secrets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "daytona_secret_id": {
+          "name": "daytona_secret_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "daytona_secret_name": {
+          "name": "daytona_secret_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allowed_hosts": {
+          "name": "allowed_hosts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workspace_secrets_organization_name_idx": {
+          "name": "workspace_secrets_organization_name_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_secrets_daytona_id_idx": {
+          "name": "workspace_secrets_daytona_id_idx",
+          "columns": [
+            {
+              "expression": "daytona_secret_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_secrets_daytona_name_idx": {
+          "name": "workspace_secrets_daytona_name_idx",
+          "columns": [
+            {
+              "expression": "daytona_secret_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_secrets_organization_id_organization_id_fk": {
+          "name": "workspace_secrets_organization_id_organization_id_fk",
+          "tableFrom": "workspace_secrets",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "workspace_secrets_created_by_user_id_fk": {
+          "name": "workspace_secrets_created_by_user_id_fk",
+          "tableFrom": "workspace_secrets",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.integration_provider": {
+      "name": "integration_provider",
+      "schema": "public",
+      "values": [
+        "aws",
+        "github",
+        "slack",
+        "sentry",
+        "datadog",
+        "axiom",
+        "clickstack",
+        "upstash",
+        "langfuse",
+        "vercel",
+        "custom_mcp",
+        "linear"
+      ]
+    },
+    "public.integration_resource_kind": {
+      "name": "integration_resource_kind",
+      "schema": "public",
+      "values": [
+        "slack_channel",
+        "sentry_project",
+        "datadog_monitor",
+        "vercel_project"
+      ]
+    },
+    "public.investigation_replay_request_status": {
+      "name": "investigation_replay_request_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "queued",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.investigation_status": {
+      "name": "investigation_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "investigating",
+        "resolved",
+        "failed"
+      ]
+    },
+    "public.issue_relationship": {
+      "name": "issue_relationship",
+      "schema": "public",
+      "values": [
+        "new",
+        "recurrence"
+      ]
+    },
+    "public.severity": {
+      "name": "severity",
+      "schema": "public",
+      "values": [
+        "SEV-1",
+        "SEV-2",
+        "SEV-3"
+      ]
+    },
+    "public.trigger_kind": {
+      "name": "trigger_kind",
+      "schema": "public",
+      "values": [
+        "sentry_issue",
+        "datadog_monitor",
+        "slack_channel",
+        "slack_mention"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/0029_snapshot.json
+++ b/drizzle/meta/0029_snapshot.json
@@ -1,0 +1,3664 @@
+{
+  "id": "f5c87696-873d-43dc-9677-17ef0be51e66",
+  "prevId": "328ca0db-8381-4fc7-b391-f7520a93e000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "invitation_organizationId_idx": {
+          "name": "invitation_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_email_idx": {
+          "name": "invitation_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "member_organizationId_idx": {
+          "name": "member_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_userId_idx": {
+          "name": "member_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'user'"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_organization_id": {
+          "name": "last_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_config_versions": {
+      "name": "agent_config_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "trigger_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_config": {
+          "name": "trigger_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "report_config": {
+          "name": "report_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context_account_ids": {
+          "name": "context_account_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "context_resource_ids": {
+          "name": "context_resource_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "pr_mode": {
+          "name": "pr_mode",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pr_mode_policy": {
+          "name": "pr_mode_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'disabled'"
+        },
+        "create_linear_tickets": {
+          "name": "create_linear_tickets",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "linear_issue_template": {
+          "name": "linear_issue_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'## Responder issue\n[{{issue_id}}]({{issue_url}})\n\n## Description\n{{description}}\n\n## Evidence\n{{evidence}}\n\n## Recommended remediation\n{{remediation}}'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_config_versions_agent_version_idx": {
+          "name": "agent_config_versions_agent_version_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_config_versions_agent_idx": {
+          "name": "agent_config_versions_agent_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_config_versions_agent_id_agents_id_fk": {
+          "name": "agent_config_versions_agent_id_agents_id_fk",
+          "tableFrom": "agent_config_versions",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_config_versions_created_by_user_id_fk": {
+          "name": "agent_config_versions_created_by_user_id_fk",
+          "tableFrom": "agent_config_versions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_version_repositories": {
+      "name": "agent_version_repositories",
+      "schema": "",
+      "columns": {
+        "agent_config_version_id": {
+          "name": "agent_config_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_version_repositories_agent_config_version_id_agent_config_versions_id_fk": {
+          "name": "agent_version_repositories_agent_config_version_id_agent_config_versions_id_fk",
+          "tableFrom": "agent_version_repositories",
+          "tableTo": "agent_config_versions",
+          "columnsFrom": [
+            "agent_config_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_version_repositories_repository_id_repositories_id_fk": {
+          "name": "agent_version_repositories_repository_id_repositories_id_fk",
+          "tableFrom": "agent_version_repositories",
+          "tableTo": "repositories",
+          "columnsFrom": [
+            "repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_version_repositories_agent_config_version_id_repository_id_pk": {
+          "name": "agent_version_repositories_agent_config_version_id_repository_id_pk",
+          "columns": [
+            "agent_config_version_id",
+            "repository_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_version_secrets": {
+      "name": "agent_version_secrets",
+      "schema": "",
+      "columns": {
+        "agent_config_version_id": {
+          "name": "agent_config_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_secret_id": {
+          "name": "workspace_secret_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_version_secrets_agent_config_version_id_agent_config_versions_id_fk": {
+          "name": "agent_version_secrets_agent_config_version_id_agent_config_versions_id_fk",
+          "tableFrom": "agent_version_secrets",
+          "tableTo": "agent_config_versions",
+          "columnsFrom": [
+            "agent_config_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_version_secrets_workspace_secret_id_workspace_secrets_id_fk": {
+          "name": "agent_version_secrets_workspace_secret_id_workspace_secrets_id_fk",
+          "tableFrom": "agent_version_secrets",
+          "tableTo": "workspace_secrets",
+          "columnsFrom": [
+            "workspace_secret_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_version_secrets_agent_config_version_id_workspace_secret_id_pk": {
+          "name": "agent_version_secrets_agent_config_version_id_workspace_secret_id_pk",
+          "columns": [
+            "agent_config_version_id",
+            "workspace_secret_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "active_version_id": {
+          "name": "active_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agents_organization_idx": {
+          "name": "agents_organization_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agents_organization_id_organization_id_fk": {
+          "name": "agents_organization_id_organization_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.billing_notification_deliveries": {
+      "name": "billing_notification_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integration_account_id": {
+          "name": "integration_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_key": {
+          "name": "period_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination": {
+          "name": "destination",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "billing_notification_delivery_target_idx": {
+          "name": "billing_notification_delivery_target_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "integration_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "destination",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "billing_notification_delivery_status_idx": {
+          "name": "billing_notification_delivery_status_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "billing_notification_deliveries_organization_id_organization_id_fk": {
+          "name": "billing_notification_deliveries_organization_id_organization_id_fk",
+          "tableFrom": "billing_notification_deliveries",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "billing_notification_deliveries_integration_account_id_integration_accounts_id_fk": {
+          "name": "billing_notification_deliveries_integration_account_id_integration_accounts_id_fk",
+          "tableFrom": "billing_notification_deliveries",
+          "tableTo": "integration_accounts",
+          "columnsFrom": [
+            "integration_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.delivery_attempts": {
+      "name": "delivery_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "investigation_id": {
+          "name": "investigation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination": {
+          "name": "destination",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "delivery_attempts_idempotency_idx": {
+          "name": "delivery_attempts_idempotency_idx",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_attempts_investigation_idx": {
+          "name": "delivery_attempts_investigation_idx",
+          "columns": [
+            {
+              "expression": "investigation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "delivery_attempts_investigation_id_investigations_id_fk": {
+          "name": "delivery_attempts_investigation_id_investigations_id_fk",
+          "tableFrom": "delivery_attempts",
+          "tableTo": "investigations",
+          "columnsFrom": [
+            "investigation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instance_configuration": {
+      "name": "instance_configuration",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "active_runtime_profile_id": {
+          "name": "active_runtime_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "instance_configuration_active_runtime_profile_id_runtime_profiles_id_fk": {
+          "name": "instance_configuration_active_runtime_profile_id_runtime_profiles_id_fk",
+          "tableFrom": "instance_configuration",
+          "tableTo": "runtime_profiles",
+          "columnsFrom": [
+            "active_runtime_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_accounts": {
+      "name": "integration_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "integration_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_account_id": {
+          "name": "external_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'connected'"
+        },
+        "encrypted_credentials": {
+          "name": "encrypted_credentials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_key_version": {
+          "name": "credential_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "integration_accounts_organization_provider_external_idx": {
+          "name": "integration_accounts_organization_provider_external_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_accounts_organization_idx": {
+          "name": "integration_accounts_organization_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_accounts_organization_id_organization_id_fk": {
+          "name": "integration_accounts_organization_id_organization_id_fk",
+          "tableFrom": "integration_accounts",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_connection_states": {
+      "name": "integration_connection_states",
+      "schema": "",
+      "columns": {
+        "state_hash": {
+          "name": "state_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "integration_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_verifier": {
+          "name": "code_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "return_to": {
+          "name": "return_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'/settings'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "integration_connection_states_expires_idx": {
+          "name": "integration_connection_states_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_connection_states_organization_idx": {
+          "name": "integration_connection_states_organization_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_connection_states_owner_provider_idx": {
+          "name": "integration_connection_states_owner_provider_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_connection_states_organization_id_organization_id_fk": {
+          "name": "integration_connection_states_organization_id_organization_id_fk",
+          "tableFrom": "integration_connection_states",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "integration_connection_states_user_id_user_id_fk": {
+          "name": "integration_connection_states_user_id_user_id_fk",
+          "tableFrom": "integration_connection_states",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_resources": {
+      "name": "integration_resources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "integration_account_id": {
+          "name": "integration_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "integration_resource_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "available": {
+          "name": "available",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "integration_resources_account_kind_external_idx": {
+          "name": "integration_resources_account_kind_external_idx",
+          "columns": [
+            {
+              "expression": "integration_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_resources_account_idx": {
+          "name": "integration_resources_account_idx",
+          "columns": [
+            {
+              "expression": "integration_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_resources_integration_account_id_integration_accounts_id_fk": {
+          "name": "integration_resources_integration_account_id_integration_accounts_id_fk",
+          "tableFrom": "integration_resources",
+          "tableTo": "integration_accounts",
+          "columnsFrom": [
+            "integration_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.investigation_issues": {
+      "name": "investigation_issues",
+      "schema": "",
+      "columns": {
+        "investigation_id": {
+          "name": "investigation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relationship": {
+          "name": "relationship",
+          "type": "issue_relationship",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "investigation_issues_issue_idx": {
+          "name": "investigation_issues_issue_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "investigation_issues_investigation_id_investigations_id_fk": {
+          "name": "investigation_issues_investigation_id_investigations_id_fk",
+          "tableFrom": "investigation_issues",
+          "tableTo": "investigations",
+          "columnsFrom": [
+            "investigation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "investigation_issues_issue_id_issues_id_fk": {
+          "name": "investigation_issues_issue_id_issues_id_fk",
+          "tableFrom": "investigation_issues",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "investigation_issues_investigation_id_issue_id_pk": {
+          "name": "investigation_issues_investigation_id_issue_id_pk",
+          "columns": [
+            "investigation_id",
+            "issue_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.investigation_replay_requests": {
+      "name": "investigation_replay_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source_investigation_id": {
+          "name": "source_investigation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "replay_investigation_id": {
+          "name": "replay_investigation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_by": {
+          "name": "requested_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "investigation_replay_request_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "processing_started_at": {
+          "name": "processing_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "queued_at": {
+          "name": "queued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "investigation_replay_requests_replay_idx": {
+          "name": "investigation_replay_requests_replay_idx",
+          "columns": [
+            {
+              "expression": "replay_investigation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "investigation_replay_requests_claim_idx": {
+          "name": "investigation_replay_requests_claim_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "investigation_replay_requests_source_idx": {
+          "name": "investigation_replay_requests_source_idx",
+          "columns": [
+            {
+              "expression": "source_investigation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "investigation_replay_requests_source_investigation_id_investigations_id_fk": {
+          "name": "investigation_replay_requests_source_investigation_id_investigations_id_fk",
+          "tableFrom": "investigation_replay_requests",
+          "tableTo": "investigations",
+          "columnsFrom": [
+            "source_investigation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.investigation_trace_events": {
+      "name": "investigation_trace_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "investigation_id": {
+          "name": "investigation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event": {
+          "name": "event",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "investigation_trace_events_investigation_id_idx": {
+          "name": "investigation_trace_events_investigation_id_idx",
+          "columns": [
+            {
+              "expression": "investigation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "investigation_trace_events_investigation_id_investigations_id_fk": {
+          "name": "investigation_trace_events_investigation_id_investigations_id_fk",
+          "tableFrom": "investigation_trace_events",
+          "tableTo": "investigations",
+          "columnsFrom": [
+            "investigation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.investigations": {
+      "name": "investigations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_config_version_id": {
+          "name": "agent_config_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime_profile_id": {
+          "name": "runtime_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "investigation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finding": {
+          "name": "finding",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "structured_report": {
+          "name": "structured_report",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replay_report": {
+          "name": "replay_report",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "report_markdown": {
+          "name": "report_markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_replay": {
+          "name": "is_replay",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "replay_of_investigation_id": {
+          "name": "replay_of_investigation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eve_session_id": {
+          "name": "eve_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_message_timestamp": {
+          "name": "slack_message_timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_trace_items": {
+          "name": "slack_trace_items",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "investigations_organization_created_idx": {
+          "name": "investigations_organization_created_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "investigations_agent_created_idx": {
+          "name": "investigations_agent_created_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "investigations_replay_source_idx": {
+          "name": "investigations_replay_source_idx",
+          "columns": [
+            {
+              "expression": "replay_of_investigation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "investigations_organization_id_organization_id_fk": {
+          "name": "investigations_organization_id_organization_id_fk",
+          "tableFrom": "investigations",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "investigations_agent_id_agents_id_fk": {
+          "name": "investigations_agent_id_agents_id_fk",
+          "tableFrom": "investigations",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "investigations_agent_config_version_id_agent_config_versions_id_fk": {
+          "name": "investigations_agent_config_version_id_agent_config_versions_id_fk",
+          "tableFrom": "investigations",
+          "tableTo": "agent_config_versions",
+          "columnsFrom": [
+            "agent_config_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "investigations_runtime_profile_id_runtime_profiles_id_fk": {
+          "name": "investigations_runtime_profile_id_runtime_profiles_id_fk",
+          "tableFrom": "investigations",
+          "tableTo": "runtime_profiles",
+          "columnsFrom": [
+            "runtime_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "investigations_replay_source_fk": {
+          "name": "investigations_replay_source_fk",
+          "tableFrom": "investigations",
+          "tableTo": "investigations",
+          "columnsFrom": [
+            "replay_of_investigation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_linear_tickets": {
+      "name": "issue_linear_tickets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "investigation_id": {
+          "name": "investigation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_config_version_id": {
+          "name": "agent_config_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integration_account_id": {
+          "name": "integration_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linear_issue_id": {
+          "name": "linear_issue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linear_identifier": {
+          "name": "linear_identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linear_issue_url": {
+          "name": "linear_issue_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "issue_linear_tickets_issue_idx": {
+          "name": "issue_linear_tickets_issue_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_linear_tickets_investigation_idx": {
+          "name": "issue_linear_tickets_investigation_idx",
+          "columns": [
+            {
+              "expression": "investigation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_linear_tickets_status_created_idx": {
+          "name": "issue_linear_tickets_status_created_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_linear_tickets_issue_id_issues_id_fk": {
+          "name": "issue_linear_tickets_issue_id_issues_id_fk",
+          "tableFrom": "issue_linear_tickets",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_linear_tickets_investigation_id_investigations_id_fk": {
+          "name": "issue_linear_tickets_investigation_id_investigations_id_fk",
+          "tableFrom": "issue_linear_tickets",
+          "tableTo": "investigations",
+          "columnsFrom": [
+            "investigation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_linear_tickets_agent_config_version_id_agent_config_versions_id_fk": {
+          "name": "issue_linear_tickets_agent_config_version_id_agent_config_versions_id_fk",
+          "tableFrom": "issue_linear_tickets",
+          "tableTo": "agent_config_versions",
+          "columnsFrom": [
+            "agent_config_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "issue_linear_tickets_integration_account_id_integration_accounts_id_fk": {
+          "name": "issue_linear_tickets_integration_account_id_integration_accounts_id_fk",
+          "tableFrom": "issue_linear_tickets",
+          "tableTo": "integration_accounts",
+          "columnsFrom": [
+            "integration_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_pull_request_activities": {
+      "name": "issue_pull_request_activities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_key": {
+          "name": "external_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event": {
+          "name": "event",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_pull_request_activities_request_idx": {
+          "name": "issue_pull_request_activities_request_idx",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_pull_request_activities_external_key_idx": {
+          "name": "issue_pull_request_activities_external_key_idx",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"issue_pull_request_activities\".\"external_key\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_pull_request_activities_request_id_issue_pull_requests_id_fk": {
+          "name": "issue_pull_request_activities_request_id_issue_pull_requests_id_fk",
+          "tableFrom": "issue_pull_request_activities",
+          "tableTo": "issue_pull_requests",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_pull_requests": {
+      "name": "issue_pull_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "investigation_id": {
+          "name": "investigation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_config_version_id": {
+          "name": "agent_config_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "remediation_id": {
+          "name": "remediation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_full_name": {
+          "name": "repository_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pull_request_number": {
+          "name": "pull_request_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pull_request_url": {
+          "name": "pull_request_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eve_session_id": {
+          "name": "eve_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "issue_pull_requests_active_issue_idx": {
+          "name": "issue_pull_requests_active_issue_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"status\" in ('queued', 'creating', 'created')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_pull_requests_issue_created_idx": {
+          "name": "issue_pull_requests_issue_created_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_pull_requests_investigation_idx": {
+          "name": "issue_pull_requests_investigation_idx",
+          "columns": [
+            {
+              "expression": "investigation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_pull_requests_issue_id_issues_id_fk": {
+          "name": "issue_pull_requests_issue_id_issues_id_fk",
+          "tableFrom": "issue_pull_requests",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_pull_requests_investigation_id_investigations_id_fk": {
+          "name": "issue_pull_requests_investigation_id_investigations_id_fk",
+          "tableFrom": "issue_pull_requests",
+          "tableTo": "investigations",
+          "columnsFrom": [
+            "investigation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_pull_requests_agent_config_version_id_agent_config_versions_id_fk": {
+          "name": "issue_pull_requests_agent_config_version_id_agent_config_versions_id_fk",
+          "tableFrom": "issue_pull_requests",
+          "tableTo": "agent_config_versions",
+          "columnsFrom": [
+            "agent_config_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issues": {
+      "name": "issues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root_cause": {
+          "name": "root_cause",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "timeline": {
+          "name": "timeline",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "severity": {
+          "name": "severity",
+          "type": "severity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "remediation": {
+          "name": "remediation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "remediations": {
+          "name": "remediations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_model": {
+          "name": "embedding_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issues_organization_created_idx": {
+          "name": "issues_organization_created_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issues_organization_id_organization_id_fk": {
+          "name": "issues_organization_id_organization_id_fk",
+          "tableFrom": "issues",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.repositories": {
+      "name": "repositories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "integration_account_id": {
+          "name": "integration_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'main'"
+        },
+        "private": {
+          "name": "private",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "available": {
+          "name": "available",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "repositories_installation_external_idx": {
+          "name": "repositories_installation_external_idx",
+          "columns": [
+            {
+              "expression": "integration_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "repositories_integration_account_id_integration_accounts_id_fk": {
+          "name": "repositories_integration_account_id_integration_accounts_id_fk",
+          "tableFrom": "repositories",
+          "tableTo": "integration_accounts",
+          "columnsFrom": [
+            "integration_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runtime_profiles": {
+      "name": "runtime_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "version": {
+          "name": "version",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_options": {
+          "name": "model_options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "runtime_profiles_version_idx": {
+          "name": "runtime_profiles_version_idx",
+          "columns": [
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_receipts": {
+      "name": "webhook_receipts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_event_id": {
+          "name": "external_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "investigation_id": {
+          "name": "investigation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_hash": {
+          "name": "payload_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_receipts_provider_event_idx": {
+          "name": "webhook_receipts_provider_event_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_receipts_organization_id_organization_id_fk": {
+          "name": "webhook_receipts_organization_id_organization_id_fk",
+          "tableFrom": "webhook_receipts",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_secrets": {
+      "name": "workspace_secrets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "daytona_secret_id": {
+          "name": "daytona_secret_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "daytona_secret_name": {
+          "name": "daytona_secret_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allowed_hosts": {
+          "name": "allowed_hosts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workspace_secrets_organization_name_idx": {
+          "name": "workspace_secrets_organization_name_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_secrets_daytona_id_idx": {
+          "name": "workspace_secrets_daytona_id_idx",
+          "columns": [
+            {
+              "expression": "daytona_secret_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_secrets_daytona_name_idx": {
+          "name": "workspace_secrets_daytona_name_idx",
+          "columns": [
+            {
+              "expression": "daytona_secret_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_secrets_organization_id_organization_id_fk": {
+          "name": "workspace_secrets_organization_id_organization_id_fk",
+          "tableFrom": "workspace_secrets",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "workspace_secrets_created_by_user_id_fk": {
+          "name": "workspace_secrets_created_by_user_id_fk",
+          "tableFrom": "workspace_secrets",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.integration_provider": {
+      "name": "integration_provider",
+      "schema": "public",
+      "values": [
+        "aws",
+        "github",
+        "slack",
+        "sentry",
+        "datadog",
+        "axiom",
+        "clickstack",
+        "upstash",
+        "langfuse",
+        "vercel",
+        "custom_mcp",
+        "linear"
+      ]
+    },
+    "public.integration_resource_kind": {
+      "name": "integration_resource_kind",
+      "schema": "public",
+      "values": [
+        "slack_channel",
+        "sentry_project",
+        "datadog_monitor",
+        "vercel_project"
+      ]
+    },
+    "public.investigation_replay_request_status": {
+      "name": "investigation_replay_request_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "queued",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.investigation_status": {
+      "name": "investigation_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "investigating",
+        "resolved",
+        "failed"
+      ]
+    },
+    "public.issue_relationship": {
+      "name": "issue_relationship",
+      "schema": "public",
+      "values": [
+        "new",
+        "recurrence"
+      ]
+    },
+    "public.severity": {
+      "name": "severity",
+      "schema": "public",
+      "values": [
+        "SEV-1",
+        "SEV-2",
+        "SEV-3"
+      ]
+    },
+    "public.trigger_kind": {
+      "name": "trigger_kind",
+      "schema": "public",
+      "values": [
+        "sentry_issue",
+        "datadog_monitor",
+        "slack_channel",
+        "slack_mention"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/0030_snapshot.json
+++ b/drizzle/meta/0030_snapshot.json
@@ -1,0 +1,3790 @@
+{
+  "id": "9364de86-d941-4d9e-9eed-0c3d618f7e2f",
+  "prevId": "f5c87696-873d-43dc-9677-17ef0be51e66",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "invitation_organizationId_idx": {
+          "name": "invitation_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_email_idx": {
+          "name": "invitation_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "member_organizationId_idx": {
+          "name": "member_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_userId_idx": {
+          "name": "member_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'user'"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_organization_id": {
+          "name": "last_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_config_versions": {
+      "name": "agent_config_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "trigger_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_config": {
+          "name": "trigger_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "report_config": {
+          "name": "report_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context_account_ids": {
+          "name": "context_account_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "context_resource_ids": {
+          "name": "context_resource_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "pr_mode": {
+          "name": "pr_mode",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pr_mode_policy": {
+          "name": "pr_mode_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'disabled'"
+        },
+        "create_linear_tickets": {
+          "name": "create_linear_tickets",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "linear_issue_template": {
+          "name": "linear_issue_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'## Responder issue\n[{{issue_id}}]({{issue_url}})\n\n## Description\n{{description}}\n\n## Evidence\n{{evidence}}\n\n## Recommended remediation\n{{remediation}}'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_config_versions_agent_version_idx": {
+          "name": "agent_config_versions_agent_version_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_config_versions_agent_idx": {
+          "name": "agent_config_versions_agent_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_config_versions_agent_id_agents_id_fk": {
+          "name": "agent_config_versions_agent_id_agents_id_fk",
+          "tableFrom": "agent_config_versions",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_config_versions_created_by_user_id_fk": {
+          "name": "agent_config_versions_created_by_user_id_fk",
+          "tableFrom": "agent_config_versions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_version_repositories": {
+      "name": "agent_version_repositories",
+      "schema": "",
+      "columns": {
+        "agent_config_version_id": {
+          "name": "agent_config_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_version_repositories_agent_config_version_id_agent_config_versions_id_fk": {
+          "name": "agent_version_repositories_agent_config_version_id_agent_config_versions_id_fk",
+          "tableFrom": "agent_version_repositories",
+          "tableTo": "agent_config_versions",
+          "columnsFrom": [
+            "agent_config_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_version_repositories_repository_id_repositories_id_fk": {
+          "name": "agent_version_repositories_repository_id_repositories_id_fk",
+          "tableFrom": "agent_version_repositories",
+          "tableTo": "repositories",
+          "columnsFrom": [
+            "repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_version_repositories_agent_config_version_id_repository_id_pk": {
+          "name": "agent_version_repositories_agent_config_version_id_repository_id_pk",
+          "columns": [
+            "agent_config_version_id",
+            "repository_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_version_secrets": {
+      "name": "agent_version_secrets",
+      "schema": "",
+      "columns": {
+        "agent_config_version_id": {
+          "name": "agent_config_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_secret_id": {
+          "name": "workspace_secret_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_version_secrets_agent_config_version_id_agent_config_versions_id_fk": {
+          "name": "agent_version_secrets_agent_config_version_id_agent_config_versions_id_fk",
+          "tableFrom": "agent_version_secrets",
+          "tableTo": "agent_config_versions",
+          "columnsFrom": [
+            "agent_config_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_version_secrets_workspace_secret_id_workspace_secrets_id_fk": {
+          "name": "agent_version_secrets_workspace_secret_id_workspace_secrets_id_fk",
+          "tableFrom": "agent_version_secrets",
+          "tableTo": "workspace_secrets",
+          "columnsFrom": [
+            "workspace_secret_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_version_secrets_agent_config_version_id_workspace_secret_id_pk": {
+          "name": "agent_version_secrets_agent_config_version_id_workspace_secret_id_pk",
+          "columns": [
+            "agent_config_version_id",
+            "workspace_secret_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "active_version_id": {
+          "name": "active_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agents_organization_idx": {
+          "name": "agents_organization_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agents_organization_id_organization_id_fk": {
+          "name": "agents_organization_id_organization_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.billing_notification_deliveries": {
+      "name": "billing_notification_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integration_account_id": {
+          "name": "integration_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_key": {
+          "name": "period_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination": {
+          "name": "destination",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "billing_notification_delivery_target_idx": {
+          "name": "billing_notification_delivery_target_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "integration_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "destination",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "billing_notification_delivery_status_idx": {
+          "name": "billing_notification_delivery_status_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "billing_notification_deliveries_organization_id_organization_id_fk": {
+          "name": "billing_notification_deliveries_organization_id_organization_id_fk",
+          "tableFrom": "billing_notification_deliveries",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "billing_notification_deliveries_integration_account_id_integration_accounts_id_fk": {
+          "name": "billing_notification_deliveries_integration_account_id_integration_accounts_id_fk",
+          "tableFrom": "billing_notification_deliveries",
+          "tableTo": "integration_accounts",
+          "columnsFrom": [
+            "integration_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.delivery_attempts": {
+      "name": "delivery_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "investigation_id": {
+          "name": "investigation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination": {
+          "name": "destination",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "delivery_attempts_idempotency_idx": {
+          "name": "delivery_attempts_idempotency_idx",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_attempts_investigation_idx": {
+          "name": "delivery_attempts_investigation_idx",
+          "columns": [
+            {
+              "expression": "investigation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "delivery_attempts_investigation_id_investigations_id_fk": {
+          "name": "delivery_attempts_investigation_id_investigations_id_fk",
+          "tableFrom": "delivery_attempts",
+          "tableTo": "investigations",
+          "columnsFrom": [
+            "investigation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instance_configuration": {
+      "name": "instance_configuration",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "active_runtime_profile_id": {
+          "name": "active_runtime_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "instance_configuration_active_runtime_profile_id_runtime_profiles_id_fk": {
+          "name": "instance_configuration_active_runtime_profile_id_runtime_profiles_id_fk",
+          "tableFrom": "instance_configuration",
+          "tableTo": "runtime_profiles",
+          "columnsFrom": [
+            "active_runtime_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_accounts": {
+      "name": "integration_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "integration_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_account_id": {
+          "name": "external_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'connected'"
+        },
+        "encrypted_credentials": {
+          "name": "encrypted_credentials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_key_version": {
+          "name": "credential_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "integration_accounts_organization_provider_external_idx": {
+          "name": "integration_accounts_organization_provider_external_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_accounts_organization_idx": {
+          "name": "integration_accounts_organization_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_accounts_organization_id_organization_id_fk": {
+          "name": "integration_accounts_organization_id_organization_id_fk",
+          "tableFrom": "integration_accounts",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_connection_states": {
+      "name": "integration_connection_states",
+      "schema": "",
+      "columns": {
+        "state_hash": {
+          "name": "state_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "integration_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_verifier": {
+          "name": "code_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "return_to": {
+          "name": "return_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'/settings'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "integration_connection_states_expires_idx": {
+          "name": "integration_connection_states_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_connection_states_organization_idx": {
+          "name": "integration_connection_states_organization_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_connection_states_owner_provider_idx": {
+          "name": "integration_connection_states_owner_provider_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_connection_states_organization_id_organization_id_fk": {
+          "name": "integration_connection_states_organization_id_organization_id_fk",
+          "tableFrom": "integration_connection_states",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "integration_connection_states_user_id_user_id_fk": {
+          "name": "integration_connection_states_user_id_user_id_fk",
+          "tableFrom": "integration_connection_states",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_resources": {
+      "name": "integration_resources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "integration_account_id": {
+          "name": "integration_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "integration_resource_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "available": {
+          "name": "available",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "integration_resources_account_kind_external_idx": {
+          "name": "integration_resources_account_kind_external_idx",
+          "columns": [
+            {
+              "expression": "integration_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_resources_account_idx": {
+          "name": "integration_resources_account_idx",
+          "columns": [
+            {
+              "expression": "integration_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_resources_integration_account_id_integration_accounts_id_fk": {
+          "name": "integration_resources_integration_account_id_integration_accounts_id_fk",
+          "tableFrom": "integration_resources",
+          "tableTo": "integration_accounts",
+          "columnsFrom": [
+            "integration_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.investigation_issues": {
+      "name": "investigation_issues",
+      "schema": "",
+      "columns": {
+        "investigation_id": {
+          "name": "investigation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relationship": {
+          "name": "relationship",
+          "type": "issue_relationship",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "investigation_issues_issue_idx": {
+          "name": "investigation_issues_issue_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "investigation_issues_investigation_id_investigations_id_fk": {
+          "name": "investigation_issues_investigation_id_investigations_id_fk",
+          "tableFrom": "investigation_issues",
+          "tableTo": "investigations",
+          "columnsFrom": [
+            "investigation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "investigation_issues_issue_id_issues_id_fk": {
+          "name": "investigation_issues_issue_id_issues_id_fk",
+          "tableFrom": "investigation_issues",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "investigation_issues_investigation_id_issue_id_pk": {
+          "name": "investigation_issues_investigation_id_issue_id_pk",
+          "columns": [
+            "investigation_id",
+            "issue_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.investigation_replay_requests": {
+      "name": "investigation_replay_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source_investigation_id": {
+          "name": "source_investigation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "replay_investigation_id": {
+          "name": "replay_investigation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_by": {
+          "name": "requested_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "investigation_replay_request_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "processing_started_at": {
+          "name": "processing_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "queued_at": {
+          "name": "queued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "investigation_replay_requests_replay_idx": {
+          "name": "investigation_replay_requests_replay_idx",
+          "columns": [
+            {
+              "expression": "replay_investigation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "investigation_replay_requests_claim_idx": {
+          "name": "investigation_replay_requests_claim_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "investigation_replay_requests_source_idx": {
+          "name": "investigation_replay_requests_source_idx",
+          "columns": [
+            {
+              "expression": "source_investigation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "investigation_replay_requests_source_investigation_id_investigations_id_fk": {
+          "name": "investigation_replay_requests_source_investigation_id_investigations_id_fk",
+          "tableFrom": "investigation_replay_requests",
+          "tableTo": "investigations",
+          "columnsFrom": [
+            "source_investigation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.investigation_trace_events": {
+      "name": "investigation_trace_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "investigation_id": {
+          "name": "investigation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event": {
+          "name": "event",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "investigation_trace_events_investigation_id_idx": {
+          "name": "investigation_trace_events_investigation_id_idx",
+          "columns": [
+            {
+              "expression": "investigation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "investigation_trace_events_investigation_id_investigations_id_fk": {
+          "name": "investigation_trace_events_investigation_id_investigations_id_fk",
+          "tableFrom": "investigation_trace_events",
+          "tableTo": "investigations",
+          "columnsFrom": [
+            "investigation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.investigations": {
+      "name": "investigations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_config_version_id": {
+          "name": "agent_config_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime_profile_id": {
+          "name": "runtime_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "investigation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finding": {
+          "name": "finding",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "structured_report": {
+          "name": "structured_report",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replay_report": {
+          "name": "replay_report",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "report_markdown": {
+          "name": "report_markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_replay": {
+          "name": "is_replay",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "replay_of_investigation_id": {
+          "name": "replay_of_investigation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eve_session_id": {
+          "name": "eve_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_message_timestamp": {
+          "name": "slack_message_timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_trace_items": {
+          "name": "slack_trace_items",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "investigations_organization_created_idx": {
+          "name": "investigations_organization_created_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "investigations_agent_created_idx": {
+          "name": "investigations_agent_created_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "investigations_replay_source_idx": {
+          "name": "investigations_replay_source_idx",
+          "columns": [
+            {
+              "expression": "replay_of_investigation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "investigations_organization_id_organization_id_fk": {
+          "name": "investigations_organization_id_organization_id_fk",
+          "tableFrom": "investigations",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "investigations_agent_id_agents_id_fk": {
+          "name": "investigations_agent_id_agents_id_fk",
+          "tableFrom": "investigations",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "investigations_agent_config_version_id_agent_config_versions_id_fk": {
+          "name": "investigations_agent_config_version_id_agent_config_versions_id_fk",
+          "tableFrom": "investigations",
+          "tableTo": "agent_config_versions",
+          "columnsFrom": [
+            "agent_config_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "investigations_runtime_profile_id_runtime_profiles_id_fk": {
+          "name": "investigations_runtime_profile_id_runtime_profiles_id_fk",
+          "tableFrom": "investigations",
+          "tableTo": "runtime_profiles",
+          "columnsFrom": [
+            "runtime_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "investigations_replay_source_fk": {
+          "name": "investigations_replay_source_fk",
+          "tableFrom": "investigations",
+          "tableTo": "investigations",
+          "columnsFrom": [
+            "replay_of_investigation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_linear_tickets": {
+      "name": "issue_linear_tickets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "investigation_id": {
+          "name": "investigation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_config_version_id": {
+          "name": "agent_config_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integration_account_id": {
+          "name": "integration_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linear_issue_id": {
+          "name": "linear_issue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linear_identifier": {
+          "name": "linear_identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linear_issue_url": {
+          "name": "linear_issue_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "issue_linear_tickets_issue_idx": {
+          "name": "issue_linear_tickets_issue_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_linear_tickets_investigation_idx": {
+          "name": "issue_linear_tickets_investigation_idx",
+          "columns": [
+            {
+              "expression": "investigation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_linear_tickets_status_created_idx": {
+          "name": "issue_linear_tickets_status_created_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_linear_tickets_issue_id_issues_id_fk": {
+          "name": "issue_linear_tickets_issue_id_issues_id_fk",
+          "tableFrom": "issue_linear_tickets",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_linear_tickets_investigation_id_investigations_id_fk": {
+          "name": "issue_linear_tickets_investigation_id_investigations_id_fk",
+          "tableFrom": "issue_linear_tickets",
+          "tableTo": "investigations",
+          "columnsFrom": [
+            "investigation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_linear_tickets_agent_config_version_id_agent_config_versions_id_fk": {
+          "name": "issue_linear_tickets_agent_config_version_id_agent_config_versions_id_fk",
+          "tableFrom": "issue_linear_tickets",
+          "tableTo": "agent_config_versions",
+          "columnsFrom": [
+            "agent_config_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "issue_linear_tickets_integration_account_id_integration_accounts_id_fk": {
+          "name": "issue_linear_tickets_integration_account_id_integration_accounts_id_fk",
+          "tableFrom": "issue_linear_tickets",
+          "tableTo": "integration_accounts",
+          "columnsFrom": [
+            "integration_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_pull_request_activities": {
+      "name": "issue_pull_request_activities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_key": {
+          "name": "external_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event": {
+          "name": "event",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_pull_request_activities_request_idx": {
+          "name": "issue_pull_request_activities_request_idx",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_pull_request_activities_external_key_idx": {
+          "name": "issue_pull_request_activities_external_key_idx",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"issue_pull_request_activities\".\"external_key\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_pull_request_activities_request_id_issue_pull_requests_id_fk": {
+          "name": "issue_pull_request_activities_request_id_issue_pull_requests_id_fk",
+          "tableFrom": "issue_pull_request_activities",
+          "tableTo": "issue_pull_requests",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_pull_request_slack_messages": {
+      "name": "issue_pull_request_slack_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integration_account_id": {
+          "name": "integration_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_timestamp": {
+          "name": "message_timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_pull_request_slack_messages_message_idx": {
+          "name": "issue_pull_request_slack_messages_message_idx",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "integration_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "message_timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_pull_request_slack_messages_request_idx": {
+          "name": "issue_pull_request_slack_messages_request_idx",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_pull_request_slack_messages_request_id_issue_pull_requests_id_fk": {
+          "name": "issue_pull_request_slack_messages_request_id_issue_pull_requests_id_fk",
+          "tableFrom": "issue_pull_request_slack_messages",
+          "tableTo": "issue_pull_requests",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_pull_request_slack_messages_integration_account_id_integration_accounts_id_fk": {
+          "name": "issue_pull_request_slack_messages_integration_account_id_integration_accounts_id_fk",
+          "tableFrom": "issue_pull_request_slack_messages",
+          "tableTo": "integration_accounts",
+          "columnsFrom": [
+            "integration_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_pull_requests": {
+      "name": "issue_pull_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "investigation_id": {
+          "name": "investigation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_config_version_id": {
+          "name": "agent_config_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "remediation_id": {
+          "name": "remediation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_full_name": {
+          "name": "repository_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pull_request_number": {
+          "name": "pull_request_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pull_request_url": {
+          "name": "pull_request_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eve_session_id": {
+          "name": "eve_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "issue_pull_requests_active_issue_idx": {
+          "name": "issue_pull_requests_active_issue_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"status\" in ('queued', 'creating', 'created')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_pull_requests_issue_created_idx": {
+          "name": "issue_pull_requests_issue_created_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_pull_requests_investigation_idx": {
+          "name": "issue_pull_requests_investigation_idx",
+          "columns": [
+            {
+              "expression": "investigation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_pull_requests_issue_id_issues_id_fk": {
+          "name": "issue_pull_requests_issue_id_issues_id_fk",
+          "tableFrom": "issue_pull_requests",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_pull_requests_investigation_id_investigations_id_fk": {
+          "name": "issue_pull_requests_investigation_id_investigations_id_fk",
+          "tableFrom": "issue_pull_requests",
+          "tableTo": "investigations",
+          "columnsFrom": [
+            "investigation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_pull_requests_agent_config_version_id_agent_config_versions_id_fk": {
+          "name": "issue_pull_requests_agent_config_version_id_agent_config_versions_id_fk",
+          "tableFrom": "issue_pull_requests",
+          "tableTo": "agent_config_versions",
+          "columnsFrom": [
+            "agent_config_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issues": {
+      "name": "issues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root_cause": {
+          "name": "root_cause",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "timeline": {
+          "name": "timeline",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "severity": {
+          "name": "severity",
+          "type": "severity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "remediation": {
+          "name": "remediation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "remediations": {
+          "name": "remediations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_model": {
+          "name": "embedding_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issues_organization_created_idx": {
+          "name": "issues_organization_created_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issues_organization_id_organization_id_fk": {
+          "name": "issues_organization_id_organization_id_fk",
+          "tableFrom": "issues",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.repositories": {
+      "name": "repositories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "integration_account_id": {
+          "name": "integration_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'main'"
+        },
+        "private": {
+          "name": "private",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "available": {
+          "name": "available",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "repositories_installation_external_idx": {
+          "name": "repositories_installation_external_idx",
+          "columns": [
+            {
+              "expression": "integration_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "repositories_integration_account_id_integration_accounts_id_fk": {
+          "name": "repositories_integration_account_id_integration_accounts_id_fk",
+          "tableFrom": "repositories",
+          "tableTo": "integration_accounts",
+          "columnsFrom": [
+            "integration_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runtime_profiles": {
+      "name": "runtime_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "version": {
+          "name": "version",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_options": {
+          "name": "model_options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "runtime_profiles_version_idx": {
+          "name": "runtime_profiles_version_idx",
+          "columns": [
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_receipts": {
+      "name": "webhook_receipts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_event_id": {
+          "name": "external_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "investigation_id": {
+          "name": "investigation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_hash": {
+          "name": "payload_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_receipts_provider_event_idx": {
+          "name": "webhook_receipts_provider_event_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_receipts_organization_id_organization_id_fk": {
+          "name": "webhook_receipts_organization_id_organization_id_fk",
+          "tableFrom": "webhook_receipts",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_secrets": {
+      "name": "workspace_secrets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "daytona_secret_id": {
+          "name": "daytona_secret_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "daytona_secret_name": {
+          "name": "daytona_secret_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allowed_hosts": {
+          "name": "allowed_hosts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workspace_secrets_organization_name_idx": {
+          "name": "workspace_secrets_organization_name_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_secrets_daytona_id_idx": {
+          "name": "workspace_secrets_daytona_id_idx",
+          "columns": [
+            {
+              "expression": "daytona_secret_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_secrets_daytona_name_idx": {
+          "name": "workspace_secrets_daytona_name_idx",
+          "columns": [
+            {
+              "expression": "daytona_secret_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_secrets_organization_id_organization_id_fk": {
+          "name": "workspace_secrets_organization_id_organization_id_fk",
+          "tableFrom": "workspace_secrets",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "workspace_secrets_created_by_user_id_fk": {
+          "name": "workspace_secrets_created_by_user_id_fk",
+          "tableFrom": "workspace_secrets",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.integration_provider": {
+      "name": "integration_provider",
+      "schema": "public",
+      "values": [
+        "aws",
+        "github",
+        "slack",
+        "sentry",
+        "datadog",
+        "axiom",
+        "clickstack",
+        "upstash",
+        "langfuse",
+        "vercel",
+        "custom_mcp",
+        "linear"
+      ]
+    },
+    "public.integration_resource_kind": {
+      "name": "integration_resource_kind",
+      "schema": "public",
+      "values": [
+        "slack_channel",
+        "sentry_project",
+        "datadog_monitor",
+        "vercel_project"
+      ]
+    },
+    "public.investigation_replay_request_status": {
+      "name": "investigation_replay_request_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "queued",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.investigation_status": {
+      "name": "investigation_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "investigating",
+        "resolved",
+        "failed"
+      ]
+    },
+    "public.issue_relationship": {
+      "name": "issue_relationship",
+      "schema": "public",
+      "values": [
+        "new",
+        "recurrence"
+      ]
+    },
+    "public.severity": {
+      "name": "severity",
+      "schema": "public",
+      "values": [
+        "SEV-1",
+        "SEV-2",
+        "SEV-3"
+      ]
+    },
+    "public.trigger_kind": {
+      "name": "trigger_kind",
+      "schema": "public",
+      "values": [
+        "sentry_issue",
+        "datadog_monitor",
+        "slack_channel",
+        "slack_mention"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -197,6 +197,27 @@
       "when": 1787574839793,
       "tag": "0027_late_the_executioner",
       "breakpoints": true
+    },
+    {
+      "idx": 28,
+      "version": "7",
+      "when": 1787667437446,
+      "tag": "0028_melted_hercules",
+      "breakpoints": true
+    },
+    {
+      "idx": 29,
+      "version": "7",
+      "when": 1787672618277,
+      "tag": "0029_round_venom",
+      "breakpoints": true
+    },
+    {
+      "idx": 30,
+      "version": "7",
+      "when": 1787680535295,
+      "tag": "0030_low_cerebro",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/src/db/issues.test.ts
+++ b/packages/core/src/db/issues.test.ts
@@ -19,6 +19,8 @@ const organizationId = "15151515-1515-4515-8515-151515151515";
 const agentConfigVersionId = "08080808-0808-4808-8808-080808080808";
 const firstIssueId = "10101010-1010-4010-8010-101010101010";
 const secondIssueId = "20202020-2020-4020-8020-202020202020";
+const firstRemediationId = "11111111-1111-4111-8111-111111111111";
+const secondRemediationId = "22222222-2222-4222-8222-222222222222";
 
 function databaseDouble(status = "investigating") {
   const forUpdate = vi.fn().mockResolvedValue([{
@@ -42,6 +44,13 @@ function databaseDouble(status = "investigating") {
       description: "First issue description",
       severity: "SEV-2",
       remediation: "Fix the first issue",
+      remediations: [{
+        id: firstRemediationId,
+        type: "code_change",
+        title: "Fix the first issue",
+        description: "Fix the first issue",
+        diff: "diff --git a/first.ts b/first.ts\n--- a/first.ts\n+++ b/first.ts\n@@ -1 +1 @@\n-old\n+new",
+      }],
     },
     {
       id: secondIssueId,
@@ -49,6 +58,13 @@ function databaseDouble(status = "investigating") {
       description: "Second issue description",
       severity: "SEV-3",
       remediation: "Fix the second issue",
+      remediations: [{
+        id: secondRemediationId,
+        type: "code_change",
+        title: "Fix the second issue",
+        description: "Fix the second issue",
+        diff: "diff --git a/second.ts b/second.ts\n--- a/second.ts\n+++ b/second.ts\n@@ -1 +1 @@\n-old\n+new",
+      }],
     },
   ]);
   const select = vi
@@ -117,7 +133,10 @@ describe("automatic pull requests from investigation reports", () => {
     expect(queueAutomaticIssuePullRequests).toHaveBeenCalledWith(tx, {
       agentConfigVersionId,
       investigationId,
-      issueIds: [firstIssueId, secondIssueId],
+      remediations: [
+        { issueId: firstIssueId, remediationId: firstRemediationId },
+        { issueId: secondIssueId, remediationId: secondRemediationId },
+      ],
     });
     expect(result.automaticPullRequestIssueIds).toEqual([secondIssueId]);
     expect(result.automaticPullRequestRequestIds).toEqual([requestId]);

--- a/packages/core/src/db/issues.ts
+++ b/packages/core/src/db/issues.ts
@@ -12,9 +12,13 @@ import {
 import type {
   InvestigationReportSubmission,
   IssueEvidence,
+  IssueRemediation,
   StructuredInvestigationReport,
 } from "../investigations/report.js";
-import { renderInvestigationReportMarkdown } from "../investigations/report.js";
+import {
+  remediationSummary,
+  renderInvestigationReportMarkdown,
+} from "../investigations/report.js";
 import { getDatabase } from "./client.js";
 import {
   agentConfigVersions,
@@ -23,6 +27,7 @@ import {
   investigationIssues,
   investigations,
   issueLinearTickets,
+  issuePullRequests,
   issues,
   type AgentPrMode,
   type InvestigationSlackTraceItem,
@@ -127,6 +132,13 @@ export async function searchIssuesByText(
               or timeline_entry->>'description' ilike ${pattern}
           )`,
           ilike(issues.remediation, pattern),
+          sql`exists (
+            select 1
+            from jsonb_array_elements(${issues.remediations}) as remediation_option
+            where remediation_option->>'title' ilike ${pattern}
+              or remediation_option->>'description' ilike ${pattern}
+              or remediation_option->>'agentPrompt' ilike ${pattern}
+          )`,
         ),
       ),
     )
@@ -232,6 +244,9 @@ export async function submitInvestigationReport(input: {
       const embedding = input.submission.newIssueEmbeddings[newIssueIndex] ?? null;
       newIssueIndex += 1;
       const issueId = randomUUID();
+      const remediations: IssueRemediation[] = submittedIssue.remediations.map(
+        (remediation) => ({ ...remediation, id: randomUUID() }),
+      );
       const inserted = await tx
         .insert(issues)
         .values({
@@ -242,7 +257,8 @@ export async function submitInvestigationReport(input: {
           rootCause: submittedIssue.rootCause,
           timeline: submittedIssue.timeline,
           severity: submittedIssue.severity,
-          remediation: submittedIssue.remediation,
+          remediation: remediationSummary(remediations),
+          remediations,
           evidence: submittedIssue.evidence,
           embedding: embedding?.vector ?? null,
           embeddingModel: embedding?.model ?? null,
@@ -278,16 +294,21 @@ export async function submitInvestigationReport(input: {
         })),
       );
     }
-    const candidatePullRequestIssueIds = references.map(
-      (reference) => reference.issueId,
-    );
+    const candidateCodeRemediations = reportIssues.flatMap((issue) => {
+      const remediation = issue.remediations.find(
+        (candidate) => candidate.type === "code_change",
+      );
+      return remediation
+        ? [{ issueId: issue.id, remediationId: remediation.id }]
+        : [];
+    });
     const automaticPullRequestRequests =
       investigation.prMode === "always" &&
-      candidatePullRequestIssueIds.length > 0
+      candidateCodeRemediations.length > 0
         ? await queueAutomaticIssuePullRequests(tx, {
             agentConfigVersionId: investigation.agentConfigVersionId,
             investigationId: input.investigationId,
-            issueIds: candidatePullRequestIssueIds,
+            remediations: candidateCodeRemediations,
           })
         : [];
     const newIssueIds = references.flatMap((reference) =>
@@ -337,6 +358,7 @@ export async function submitInvestigationReport(input: {
         timeline: issue.timeline,
         severity: issue.severity,
         remediation: issue.remediation,
+        remediations: issue.remediations,
       })),
       newIssues: references.flatMap((reference) => {
         if (reference.relationship !== "new") return [];
@@ -350,6 +372,7 @@ export async function submitInvestigationReport(input: {
               timeline: issue.timeline,
               severity: issue.severity,
               remediation: issue.remediation,
+              remediations: issue.remediations,
               evidence: issue.evidence,
             }]
           : [];
@@ -392,6 +415,7 @@ export async function listIssues(
       timeline: issues.timeline,
       severity: issues.severity,
       remediation: issues.remediation,
+      remediations: issues.remediations,
       archivedAt: issues.archivedAt,
       createdAt: issues.createdAt,
     })
@@ -421,6 +445,7 @@ export async function getIssueDetail(
       timeline: issues.timeline,
       severity: issues.severity,
       remediation: issues.remediation,
+      remediations: issues.remediations,
       evidence: issues.evidence,
       archivedAt: issues.archivedAt,
       createdAt: issues.createdAt,
@@ -520,8 +545,10 @@ export async function getIssueForSlackAction(input: {
       timeline: issues.timeline,
       severity: issues.severity,
       remediation: issues.remediation,
+      remediations: issues.remediations,
       evidence: issues.evidence,
       organizationId: issues.organizationId,
+      integrationAccountId: integrationAccounts.id,
       encryptedCredentials: integrationAccounts.encryptedCredentials,
     })
     .from(issues)
@@ -549,6 +576,7 @@ export async function getInvestigationIssueDetails(investigationId: string) {
       timeline: issues.timeline,
       severity: issues.severity,
       remediation: issues.remediation,
+      remediations: issues.remediations,
       relationship: investigationIssues.relationship,
       evidence: investigationIssues.evidence,
       createdAt: issues.createdAt,
@@ -574,12 +602,23 @@ export interface SlackInvestigationDeliveryContext {
     timeline: Array<{ title: string; description: string }>;
     severity: "SEV-1" | "SEV-2" | "SEV-3";
     remediation: string;
+    remediations: IssueRemediation[];
     relationship: "new" | "recurrence";
     evidence: IssueEvidence[];
+    pullRequest: {
+      id: string;
+      remediationId: string | null;
+      repositoryFullName: string | null;
+      status: "queued" | "creating" | "created" | "merged" | "failed";
+      pullRequestNumber: number | null;
+      pullRequestUrl: string | null;
+      failureReason: string | null;
+    } | null;
   }>;
   source: {
     channelId: string;
     encryptedCredentials: string;
+    integrationAccountId: string;
     messageTimestamp: string | null;
     reactionTimestamp: string;
     threadTimestamp: string;
@@ -587,6 +626,7 @@ export interface SlackInvestigationDeliveryContext {
   output: {
     channelId: string;
     encryptedCredentials: string;
+    integrationAccountId: string;
     severities: Array<"SEV-1" | "SEV-2" | "SEV-3"> | null;
   } | null;
 }
@@ -761,6 +801,27 @@ export async function getSlackInvestigationDeliveryContext(
   const outputCredentials = outputConfig
     ? credentialsByAccount.get(outputConfig.integrationAccountId)
     : null;
+  const issueDetails = await getInvestigationIssueDetails(investigation.id);
+  const pullRequestRows = await db
+    .select({
+      id: issuePullRequests.id,
+      issueId: issuePullRequests.issueId,
+      remediationId: issuePullRequests.remediationId,
+      repositoryFullName: issuePullRequests.repositoryFullName,
+      status: issuePullRequests.status,
+      pullRequestNumber: issuePullRequests.pullRequestNumber,
+      pullRequestUrl: issuePullRequests.pullRequestUrl,
+      failureReason: issuePullRequests.failureReason,
+    })
+    .from(issuePullRequests)
+    .where(eq(issuePullRequests.investigationId, investigation.id))
+    .orderBy(desc(issuePullRequests.createdAt));
+  const pullRequestByIssueId = new Map<string, (typeof pullRequestRows)[number]>();
+  for (const request of pullRequestRows) {
+    if (!pullRequestByIssueId.has(request.issueId)) {
+      pullRequestByIssueId.set(request.issueId, request);
+    }
+  }
 
   return {
     agentId: investigation.agentId,
@@ -769,15 +830,20 @@ export async function getSlackInvestigationDeliveryContext(
     report: investigation.report,
     title: investigation.title,
     traceItems: investigation.traceItems,
-    issues: await getInvestigationIssueDetails(investigation.id),
+    issues: issueDetails.map((issue) => ({
+      ...issue,
+      pullRequest: pullRequestByIssueId.get(issue.id) ?? null,
+    })),
     source:
       typeof sourceChannelId === "string" &&
       typeof sourceReactionTimestamp === "string" &&
       typeof sourceTimestamp === "string" &&
+      sourceAccountId &&
       sourceCredentials
         ? {
             channelId: sourceChannelId,
             encryptedCredentials: sourceCredentials,
+            integrationAccountId: sourceAccountId,
             messageTimestamp: investigation.messageTimestamp,
             reactionTimestamp: sourceReactionTimestamp,
             threadTimestamp: sourceTimestamp,
@@ -788,6 +854,7 @@ export async function getSlackInvestigationDeliveryContext(
         ? {
             channelId: outputConfig.outputChannelId,
             encryptedCredentials: outputCredentials,
+            integrationAccountId: outputConfig.integrationAccountId,
             severities: outputConfig.severities ?? null,
           }
         : null,

--- a/packages/core/src/db/pull-requests.test.ts
+++ b/packages/core/src/db/pull-requests.test.ts
@@ -5,12 +5,14 @@ import {
   claimIssuePullRequestForRemediation,
   listStaleCreatingIssuePullRequests,
   markIssuePullRequestStarted,
+  pullRequestActivityEvent,
   queueAutomaticIssuePullRequests,
   queueManualIssuePullRequest,
   recoverAbandonedIssuePullRequest,
 } from "./pull-requests.js";
 import {
   activeIssuePullRequestIndexPredicate,
+  issuePullRequestActivities,
   issuePullRequests,
 } from "./schema.js";
 
@@ -22,6 +24,14 @@ const issueId = "10101010-1010-4010-8010-101010101010";
 const organizationId = "15151515-1515-4515-8515-151515151515";
 const investigationId = "16161616-1616-4616-8616-161616161616";
 const agentConfigVersionId = "08080808-0808-4808-8808-080808080808";
+const remediationId = "09090909-0909-4909-8909-090909090909";
+const codeRemediation = {
+  id: remediationId,
+  type: "code_change" as const,
+  title: "Handle the missing value",
+  description: "Guard the optional value before using it.",
+  diff: "diff --git a/src/route.ts b/src/route.ts\n--- a/src/route.ts\n+++ b/src/route.ts\n@@ -1 +1 @@\n-old\n+new",
+};
 
 function simpleSelect(
   rows: unknown[],
@@ -65,7 +75,9 @@ function databaseDouble(
   const transaction = vi.fn(async (callback) => {
     const select = vi
       .fn()
-      .mockReturnValueOnce(simpleSelect([{ id: issueId }]))
+      .mockReturnValueOnce(
+        simpleSelect([{ id: issueId, remediations: [codeRemediation] }]),
+      )
       .mockReturnValueOnce(simpleSelect(options.existing ?? [], existingLimit))
       .mockReturnValueOnce(
         joinedSelect([{ investigationId, agentConfigVersionId }]),
@@ -83,6 +95,39 @@ function databaseDouble(
 function compiledSql(statement: unknown) {
   return new PgDialect().sqlToQuery(statement as never);
 }
+
+describe("pull request activity storage", () => {
+  it("deduplicates externally sourced activity within a request", () => {
+    const index = getTableConfig(issuePullRequestActivities).indexes.find(
+      (candidate) =>
+        candidate.config.name === "issue_pull_request_activities_external_key_idx",
+    );
+
+    expect(index?.config.unique).toBe(true);
+    expect(
+      index?.config.columns.map((column) =>
+        "name" in column ? column.name : undefined,
+      ),
+    ).toEqual(["request_id", "external_key"]);
+    expect(new PgDialect().sqlToQuery(index?.config.where as never).sql).toBe(
+      '"issue_pull_request_activities"."external_key" is not null',
+    );
+  });
+
+  it("timestamps activity at the event source", () => {
+    expect(
+      pullRequestActivityEvent(
+        "review.comment.received",
+        { body: "Please use silver petals." },
+        new Date("2026-08-25T10:00:00.000Z"),
+      ),
+    ).toEqual({
+      data: { body: "Please use silver petals." },
+      meta: { at: "2026-08-25T10:00:00.000Z" },
+      type: "review.comment.received",
+    });
+  });
+});
 
 describe("manual pull request uniqueness", () => {
   afterEach(() => {
@@ -112,7 +157,7 @@ describe("manual pull request uniqueness", () => {
     const { execute, onConflictDoNothing } = databaseDouble([{ id: requestId }]);
 
     await expect(
-      queueManualIssuePullRequest({ issueId, organizationId }),
+      queueManualIssuePullRequest({ issueId, organizationId, remediationId }),
     ).resolves.toEqual({ id: requestId });
     expect(execute).toHaveBeenCalledOnce();
     expect(compiledSql(execute.mock.calls[0]![0])).toMatchObject({
@@ -131,7 +176,7 @@ describe("manual pull request uniqueness", () => {
     databaseDouble([]);
 
     await expect(
-      queueManualIssuePullRequest({ issueId, organizationId }),
+      queueManualIssuePullRequest({ issueId, organizationId, remediationId }),
     ).rejects.toMatchObject({
       code: "already_requested",
       message: "A pull request has already been requested for this issue",
@@ -148,7 +193,7 @@ describe("manual pull request uniqueness", () => {
     } = databaseDouble([{ id: requestId }], { activeIndexAvailable: false });
 
     await expect(
-      queueManualIssuePullRequest({ issueId, organizationId }),
+      queueManualIssuePullRequest({ issueId, organizationId, remediationId }),
     ).resolves.toEqual({ id: requestId });
 
     expect(execute).toHaveBeenCalledTimes(2);
@@ -170,7 +215,7 @@ describe("manual pull request uniqueness", () => {
     });
 
     await expect(
-      queueManualIssuePullRequest({ issueId, organizationId }),
+      queueManualIssuePullRequest({ issueId, organizationId, remediationId }),
     ).rejects.toMatchObject({
       code: "already_requested",
       message: "A pull request has already been requested for this issue",
@@ -350,13 +395,16 @@ describe("automatic pull request uniqueness", () => {
       queueAutomaticIssuePullRequests(tx as never, {
         agentConfigVersionId,
         investigationId,
-        issueIds: [issueId, secondIssueId],
+        remediations: [
+          { issueId, remediationId },
+          { issueId: secondIssueId, remediationId },
+        ],
       }),
     ).resolves.toEqual([winningRequest]);
 
     expect(values).toHaveBeenCalledWith([
-      { agentConfigVersionId, investigationId, issueId },
-      { agentConfigVersionId, investigationId, issueId: secondIssueId },
+      { agentConfigVersionId, investigationId, issueId, remediationId },
+      { agentConfigVersionId, investigationId, issueId: secondIssueId, remediationId },
     ]);
     expect(onConflictDoNothing).toHaveBeenCalledWith({
       target: issuePullRequests.issueId,
@@ -395,7 +443,10 @@ describe("automatic pull request uniqueness", () => {
       queueAutomaticIssuePullRequests(tx as never, {
         agentConfigVersionId,
         investigationId,
-        issueIds: [issueId, secondIssueId],
+        remediations: [
+          { issueId, remediationId },
+          { issueId: secondIssueId, remediationId },
+        ],
       }),
     ).resolves.toEqual(inserted);
 
@@ -407,7 +458,7 @@ describe("automatic pull request uniqueness", () => {
       existingWhere.mock.invocationCallOrder[0]!,
     );
     expect(values).toHaveBeenCalledWith([
-      { agentConfigVersionId, investigationId, issueId: secondIssueId },
+      { agentConfigVersionId, investigationId, issueId: secondIssueId, remediationId },
     ]);
     expect(onConflictDoNothing).not.toHaveBeenCalled();
   });

--- a/packages/core/src/db/pull-requests.ts
+++ b/packages/core/src/db/pull-requests.ts
@@ -1,12 +1,16 @@
-import { and, desc, eq, inArray, lt, sql } from "drizzle-orm";
+import { and, asc, desc, eq, inArray, lt, sql } from "drizzle-orm";
+import type { IssuePullRequestActivityEvent } from "./schema.js";
 import { getDatabase } from "./client.js";
 import {
   activeIssuePullRequestIndexPredicate,
   agentConfigVersions,
   agents,
   instanceConfiguration,
+  integrationAccounts,
   investigationIssues,
   investigations,
+  issuePullRequestActivities,
+  issuePullRequestSlackMessages,
   issuePullRequests,
   issues,
   runtimeProfiles,
@@ -28,6 +32,7 @@ export class IssuePullRequestError extends Error {
     public readonly code:
       | "issue_not_found"
       | "not_available"
+      | "remediation_not_found"
       | "already_requested"
       | "request_not_found",
   ) {
@@ -70,10 +75,20 @@ export async function queueAutomaticIssuePullRequests(
   input: {
     agentConfigVersionId: string;
     investigationId: string;
-    issueIds: string[];
+    remediations: Array<{ issueId: string; remediationId: string }>;
   },
 ) {
-  const uniqueIssueIds = [...new Set(input.issueIds)];
+  const uniqueRemediations = [
+    ...new Map(
+      input.remediations.map((remediation) => [
+        remediation.issueId,
+        remediation,
+      ]),
+    ).values(),
+  ];
+  const uniqueIssueIds = uniqueRemediations.map(
+    (remediation) => remediation.issueId,
+  );
   if (uniqueIssueIds.length === 0) return [];
 
   const activeIndexAvailable = await prepareIssuePullRequestWrite(tx);
@@ -87,16 +102,17 @@ export async function queueAutomaticIssuePullRequests(
       ),
     );
   const existingIssueIds = new Set(existing.map((request) => request.issueId));
-  const requestedIssueIds = uniqueIssueIds.filter(
-    (issueId) => !existingIssueIds.has(issueId),
+  const requestedRemediations = uniqueRemediations.filter(
+    (remediation) => !existingIssueIds.has(remediation.issueId),
   );
-  if (requestedIssueIds.length === 0) return [];
+  if (requestedRemediations.length === 0) return [];
 
   const insert = tx.insert(issuePullRequests).values(
-    requestedIssueIds.map((issueId) => ({
-      issueId,
+    requestedRemediations.map((remediation) => ({
+      issueId: remediation.issueId,
       investigationId: input.investigationId,
       agentConfigVersionId: input.agentConfigVersionId,
+      remediationId: remediation.remediationId,
     })),
   );
   return activeIndexAvailable
@@ -121,6 +137,7 @@ export async function getIssuePullRequestState(
     db
       .select({
         id: issuePullRequests.id,
+        remediationId: issuePullRequests.remediationId,
         repositoryFullName: issuePullRequests.repositoryFullName,
         status: issuePullRequests.status,
         branch: issuePullRequests.branch,
@@ -166,23 +183,159 @@ export async function getIssuePullRequestState(
       .limit(1),
   ]);
 
+  const activityRows = requests.length > 0
+    ? await db
+        .select({
+          id: issuePullRequestActivities.id,
+          requestId: issuePullRequestActivities.requestId,
+          event: issuePullRequestActivities.event,
+          createdAt: issuePullRequestActivities.createdAt,
+        })
+        .from(issuePullRequestActivities)
+        .where(
+          inArray(
+            issuePullRequestActivities.requestId,
+            requests.map((request) => request.id),
+          ),
+        )
+        .orderBy(asc(issuePullRequestActivities.id))
+    : [];
+  const activitiesByRequest = Map.groupBy(
+    activityRows,
+    (activity) => activity.requestId,
+  );
+  const requestsWithActivities = requests.map((request) => ({
+    ...request,
+    activities: activitiesByRequest.get(request.id) ?? [],
+  }));
   const activeRequest = requests.find((request) =>
     ["queued", "creating", "created", "merged"].includes(request.status),
   );
   return {
     canCreate: eligibleInvestigations.length > 0 && !activeRequest,
-    requests,
+    requests: requestsWithActivities,
   };
+}
+
+export function pullRequestActivityEvent(
+  type: IssuePullRequestActivityEvent["type"],
+  data?: Record<string, unknown>,
+  at = new Date(),
+): IssuePullRequestActivityEvent {
+  return {
+    ...(data ? { data } : {}),
+    meta: { at: at.toISOString() },
+    type,
+  };
+}
+
+export async function appendIssuePullRequestActivity(input: {
+  event: IssuePullRequestActivityEvent;
+  externalKey?: string;
+  requestId: string;
+}): Promise<void> {
+  const insert = getDatabase()
+    .insert(issuePullRequestActivities)
+    .values({
+      event: input.event,
+      externalKey: input.externalKey,
+      requestId: input.requestId,
+    });
+  if (input.externalKey) {
+    await insert.onConflictDoNothing({
+      target: [
+        issuePullRequestActivities.requestId,
+        issuePullRequestActivities.externalKey,
+      ],
+      where: sql`${issuePullRequestActivities.externalKey} is not null`,
+    });
+    return;
+  }
+  await insert;
+}
+
+export async function registerIssuePullRequestSlackMessage(input: {
+  channelId: string;
+  integrationAccountId: string;
+  messageTimestamp: string;
+  requestId: string;
+}): Promise<void> {
+  await getDatabase()
+    .insert(issuePullRequestSlackMessages)
+    .values(input)
+    .onConflictDoNothing({
+      target: [
+        issuePullRequestSlackMessages.requestId,
+        issuePullRequestSlackMessages.integrationAccountId,
+        issuePullRequestSlackMessages.channelId,
+        issuePullRequestSlackMessages.messageTimestamp,
+      ],
+    });
+}
+
+export async function getIssuePullRequestSlackCard(requestId: string) {
+  const rows = await getDatabase()
+    .select({
+      requestId: issuePullRequests.id,
+      issueId: issues.id,
+      issueTitle: issues.title,
+      issueSeverity: issues.severity,
+      issueRemediations: issues.remediations,
+      remediationId: issuePullRequests.remediationId,
+      repositoryFullName: issuePullRequests.repositoryFullName,
+      status: issuePullRequests.status,
+      pullRequestNumber: issuePullRequests.pullRequestNumber,
+      pullRequestUrl: issuePullRequests.pullRequestUrl,
+      failureReason: issuePullRequests.failureReason,
+    })
+    .from(issuePullRequests)
+    .innerJoin(issues, eq(issues.id, issuePullRequests.issueId))
+    .where(eq(issuePullRequests.id, requestId))
+    .limit(1);
+  const request = rows[0];
+  if (!request) return null;
+  const selectedRemediation = request.remediationId
+    ? request.issueRemediations.find(
+        (remediation) => remediation.id === request.remediationId,
+      )
+    : undefined;
+  if (!selectedRemediation) return null;
+  return { ...request, selectedRemediation };
+}
+
+export async function getIssuePullRequestSlackDeliveries(requestId: string) {
+  return getDatabase()
+    .select({
+      channelId: issuePullRequestSlackMessages.channelId,
+      encryptedCredentials: integrationAccounts.encryptedCredentials,
+      messageTimestamp: issuePullRequestSlackMessages.messageTimestamp,
+    })
+    .from(issuePullRequestSlackMessages)
+    .innerJoin(
+      integrationAccounts,
+      eq(
+        integrationAccounts.id,
+        issuePullRequestSlackMessages.integrationAccountId,
+      ),
+    )
+    .where(
+      and(
+        eq(issuePullRequestSlackMessages.requestId, requestId),
+        eq(integrationAccounts.provider, "slack"),
+        eq(integrationAccounts.status, "connected"),
+      ),
+    );
 }
 
 export async function queueManualIssuePullRequest(input: {
   issueId: string;
   organizationId: string;
+  remediationId: string;
 }) {
   const db = getDatabase();
   return db.transaction(async (tx) => {
     const issueRows = await tx
-      .select({ id: issues.id })
+      .select({ id: issues.id, remediations: issues.remediations })
       .from(issues)
       .where(
         and(
@@ -191,8 +344,18 @@ export async function queueManualIssuePullRequest(input: {
         ),
       )
       .limit(1);
-    if (!issueRows[0]) {
+    const issue = issueRows[0];
+    if (!issue) {
       throw new IssuePullRequestError("Issue not found", "issue_not_found");
+    }
+    const remediation = issue.remediations.find(
+      (candidate) => candidate.id === input.remediationId,
+    );
+    if (!remediation || remediation.type !== "code_change") {
+      throw new IssuePullRequestError(
+        "Code remediation not found",
+        "remediation_not_found",
+      );
     }
 
     const activeIndexAvailable = await prepareIssuePullRequestWrite(tx);
@@ -261,6 +424,7 @@ export async function queueManualIssuePullRequest(input: {
         issueId: input.issueId,
         investigationId: target.investigationId,
         agentConfigVersionId: target.agentConfigVersionId,
+        remediationId: remediation.id,
       });
     const inserted = activeIndexAvailable
       ? await insert
@@ -291,6 +455,7 @@ export async function getIssuePullRequestForRemediation(requestId: string) {
       issueRootCause: issues.rootCause,
       issueTimeline: issues.timeline,
       issueRemediation: issues.remediation,
+      issueRemediations: issues.remediations,
       issueSeverity: issues.severity,
       issueEvidence: issues.evidence,
       investigationId: investigations.id,
@@ -298,6 +463,7 @@ export async function getIssuePullRequestForRemediation(requestId: string) {
       agentId: agents.id,
       organizationId: agents.organizationId,
       runtimeProfileId: investigations.runtimeProfileId,
+      remediationId: issuePullRequests.remediationId,
       status: issuePullRequests.status,
     })
     .from(issuePullRequests)
@@ -320,6 +486,17 @@ export async function getIssuePullRequestForRemediation(requestId: string) {
       "request_not_found",
     );
   }
+  const selectedRemediation = request.remediationId
+    ? request.issueRemediations.find(
+        (remediation) => remediation.id === request.remediationId,
+      )
+    : undefined;
+  if (request.remediationId && selectedRemediation?.type !== "code_change") {
+    throw new IssuePullRequestError(
+      "Code remediation not found",
+      "remediation_not_found",
+    );
+  }
 
   let runtimeProfileId = request.runtimeProfileId;
   if (!runtimeProfileId) {
@@ -337,7 +514,7 @@ export async function getIssuePullRequestForRemediation(requestId: string) {
   if (!runtimeProfileId) {
     throw new Error("The Responder instance does not have an active runtime profile");
   }
-  return { ...request, runtimeProfileId };
+  return { ...request, runtimeProfileId, selectedRemediation };
 }
 
 async function transitionIssuePullRequestToCreating(
@@ -407,6 +584,8 @@ export async function getExecutableIssuePullRequest(input: {
       issueTimeline: issues.timeline,
       issueEvidence: issues.evidence,
       issueRemediation: issues.remediation,
+      issueRemediations: issues.remediations,
+      remediationId: issuePullRequests.remediationId,
       investigationEvidence: investigationIssues.evidence,
       investigationInput: investigations.input,
       status: issuePullRequests.status,
@@ -451,7 +630,12 @@ export async function getExecutableIssuePullRequest(input: {
       "request_not_found",
     );
   }
-  return request;
+  const selectedRemediation = request.remediationId
+    ? request.issueRemediations.find(
+        (remediation) => remediation.id === request.remediationId,
+      )
+    : undefined;
+  return { ...request, selectedRemediation };
 }
 
 export async function markIssuePullRequestCreated(input: {

--- a/packages/core/src/db/schema.ts
+++ b/packages/core/src/db/schema.ts
@@ -17,6 +17,7 @@ import {
 import type {
   InvestigationReportSubmission,
   IssueEvidence,
+  IssueRemediation,
   IssueTimelineEntry,
   StructuredInvestigationReport,
 } from "../investigations/report.js";
@@ -377,6 +378,22 @@ export interface InvestigationTraceEvent {
   };
 }
 
+export interface IssuePullRequestActivityEvent {
+  type:
+    | "review.comment.received"
+    | "review.job.queued"
+    | "review.session.started"
+    | "review.trace"
+    | "review.commit.pushed"
+    | "review.threads.addressed"
+    | "review.session.completed"
+    | "review.session.failed";
+  data?: Record<string, unknown>;
+  meta: {
+    at: string;
+  };
+}
+
 export interface InvestigationSlackTraceItem {
   detail?: string;
   id: string;
@@ -506,6 +523,10 @@ export const issues = pgTable(
     timeline: jsonb("timeline").$type<IssueTimelineEntry[]>().notNull().default([]),
     severity: severity("severity").notNull(),
     remediation: text("remediation").notNull(),
+    remediations: jsonb("remediations")
+      .$type<IssueRemediation[]>()
+      .notNull()
+      .default([]),
     evidence: jsonb("evidence").$type<IssueEvidence[]>().notNull().default([]),
     embedding: jsonb("embedding").$type<number[]>(),
     embeddingModel: text("embedding_model"),
@@ -538,6 +559,7 @@ export const issuePullRequests = pgTable(
     agentConfigVersionId: uuid("agent_config_version_id")
       .notNull()
       .references(() => agentConfigVersions.id, { onDelete: "restrict" }),
+    remediationId: uuid("remediation_id"),
     repositoryFullName: text("repository_full_name"),
     status: text("status")
       .$type<"queued" | "creating" | "created" | "merged" | "failed">()
@@ -561,6 +583,53 @@ export const issuePullRequests = pgTable(
       table.createdAt,
     ),
     index("issue_pull_requests_investigation_idx").on(table.investigationId),
+  ],
+);
+
+export const issuePullRequestActivities = pgTable(
+  "issue_pull_request_activities",
+  {
+    id: serial("id").primaryKey(),
+    requestId: uuid("request_id")
+      .notNull()
+      .references(() => issuePullRequests.id, { onDelete: "cascade" }),
+    externalKey: text("external_key"),
+    event: jsonb("event").$type<IssuePullRequestActivityEvent>().notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    index("issue_pull_request_activities_request_idx").on(
+      table.requestId,
+      table.id,
+    ),
+    uniqueIndex("issue_pull_request_activities_external_key_idx")
+      .on(table.requestId, table.externalKey)
+      .where(sql`${table.externalKey} is not null`),
+  ],
+);
+
+export const issuePullRequestSlackMessages = pgTable(
+  "issue_pull_request_slack_messages",
+  {
+    id: serial("id").primaryKey(),
+    requestId: uuid("request_id")
+      .notNull()
+      .references(() => issuePullRequests.id, { onDelete: "cascade" }),
+    integrationAccountId: uuid("integration_account_id")
+      .notNull()
+      .references(() => integrationAccounts.id, { onDelete: "cascade" }),
+    channelId: text("channel_id").notNull(),
+    messageTimestamp: text("message_timestamp").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    uniqueIndex("issue_pull_request_slack_messages_message_idx").on(
+      table.requestId,
+      table.integrationAccountId,
+      table.channelId,
+      table.messageTimestamp,
+    ),
+    index("issue_pull_request_slack_messages_request_idx").on(table.requestId),
   ],
 );
 

--- a/packages/core/src/integrations/slack-delivery.test.ts
+++ b/packages/core/src/integrations/slack-delivery.test.ts
@@ -56,6 +56,8 @@ describe("Slack issue delivery", () => {
       ],
       severity: "SEV-2",
       remediation: "Wait for organization provisioning before redirecting the user.",
+      remediations: [],
+      pullRequest: null,
       relationship: "new",
       evidence: [],
     });
@@ -71,5 +73,56 @@ describe("Slack issue delivery", () => {
       }),
       expect.objectContaining({ type: "actions" }),
     ]);
+  });
+
+  it("shows every proposed remediation in a carousel", () => {
+    const issueId = "07070707-0707-4707-8707-070707070707";
+    const message = slackIssueMessage({
+      id: issueId,
+      title: "Plant colors are stale",
+      description: "The rendered petals use the old color.",
+      rootCause: "The palette and component defaults disagree.",
+      timeline: [{
+        title: "Palette changed",
+        description: "The production palette changed before the component.",
+      }],
+      severity: "SEV-3",
+      remediation: "Update the component or production palette.",
+      remediations: [
+        {
+          id: "24242424-2424-4424-8424-242424242424",
+          type: "code_change",
+          title: "Update the component default",
+          description: "Use the configured petal color.",
+          diff: "diff --git a/a b/a\n--- a/a\n+++ b/a\n@@ -1 +1 @@\n-a\n+b",
+        },
+        {
+          id: "26262626-2626-4626-8626-262626262626",
+          type: "external_action",
+          title: "Update the production palette",
+          description: "Set the petal color in production.",
+          agentPrompt: "Set the production petal color to silver.",
+        },
+      ],
+      pullRequest: null,
+      relationship: "new",
+      evidence: [],
+    }, true);
+
+    expect(message.blocks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "carousel",
+          elements: [
+            expect.objectContaining({
+              subtitle: expect.objectContaining({ text: "Code change" }),
+            }),
+            expect.objectContaining({
+              subtitle: expect.objectContaining({ text: "External action" }),
+            }),
+          ],
+        }),
+      ]),
+    );
   });
 });

--- a/packages/core/src/integrations/slack-delivery.ts
+++ b/packages/core/src/integrations/slack-delivery.ts
@@ -6,6 +6,7 @@ import {
   getSlackInvestigationDeliveryContext,
   type SlackInvestigationDeliveryContext,
 } from "../db/issues.js";
+import { registerIssuePullRequestSlackMessage } from "../db/pull-requests.js";
 import {
   addSlackReaction,
   postSlackMessage,
@@ -13,6 +14,11 @@ import {
   setSlackThreadStatus,
   updateSlackMessage,
 } from "./slack.js";
+import {
+  refreshIssuePullRequestSlackMessages,
+  slackIssuePullRequestMessage,
+  slackRemediationCarousel,
+} from "./slack-remediations.js";
 import {
   slackErrorLogFields,
   slackInvestigationCard,
@@ -139,27 +145,17 @@ export function slackIssueMessage(
         type: "section",
         text: { type: "mrkdwn", text: blockText },
       },
+      ...(issue.remediations.length > 0
+        ? slackRemediationCarousel({
+            canCreatePullRequest,
+            issueId: issue.id,
+            remediations: issue.remediations,
+          })
+        : []),
       {
         type: "actions",
         block_id: `issue_actions_${issue.id}`,
         elements: [
-          ...(canCreatePullRequest
-            ? [
-                {
-                  type: "button",
-                  action_id: "create_issue_pull_request",
-                  style: "primary",
-                  text: { type: "plain_text", text: "Create pull request" },
-                  value: issue.id,
-                },
-              ]
-            : []),
-          {
-            type: "button",
-            action_id: "copy_issue_prompt",
-            text: { type: "plain_text", text: "Copy prompt" },
-            value: issue.id,
-          },
           {
             type: "button",
             action_id: "view_issue",
@@ -171,6 +167,54 @@ export function slackIssueMessage(
       },
     ],
   };
+}
+
+function issueSlackMessage(
+  context: SlackInvestigationDeliveryContext,
+  issue: DeliveryIssue,
+) {
+  const request = issue.pullRequest;
+  const selectedRemediation = request?.remediationId
+    ? issue.remediations.find(
+        (remediation) => remediation.id === request.remediationId,
+      )
+    : undefined;
+  return context.prMode === "always" && request && selectedRemediation
+    ? slackIssuePullRequestMessage({
+        failureReason: request.failureReason,
+        issueId: issue.id,
+        issueSeverity: issue.severity,
+        issueTitle: issue.title,
+        pullRequestNumber: request.pullRequestNumber,
+        pullRequestUrl: request.pullRequestUrl,
+        repositoryFullName: request.repositoryFullName,
+        requestId: request.id,
+        selectedRemediation,
+        status: request.status,
+      })
+    : slackIssueMessage(
+        issue,
+        context.prMode === "manual" &&
+          issue.remediations.some(
+            (remediation) => remediation.type === "code_change",
+          ),
+      );
+}
+
+async function registerPullRequestMessage(input: {
+  channelId: string;
+  integrationAccountId: string;
+  issue: DeliveryIssue;
+  messageTimestamp: string | null;
+}): Promise<void> {
+  if (!input.issue.pullRequest || !input.messageTimestamp) return;
+  await registerIssuePullRequestSlackMessage({
+    channelId: input.channelId,
+    integrationAccountId: input.integrationAccountId,
+    messageTimestamp: input.messageTimestamp,
+    requestId: input.issue.pullRequest.id,
+  });
+  await refreshIssuePullRequestSlackMessages(input.issue.pullRequest.id);
 }
 
 function accessToken(encryptedCredentials: string): string {
@@ -289,9 +333,9 @@ async function deliverSourceThread(
     failures.push(error);
   }
   for (const [issueIndex, issue] of context.issues.entries()) {
-    const message = slackIssueMessage(issue, context.prMode === "manual");
+    const message = issueSlackMessage(context, issue);
     try {
-      await postSlackMessage({
+      const messageTimestamp = await postSlackMessage({
         accessToken: token,
         blocks: message.blocks,
         channelId: context.source.channelId,
@@ -301,6 +345,12 @@ async function deliverSourceThread(
         ),
         text: message.text,
         threadTimestamp: context.source.threadTimestamp,
+      });
+      await registerPullRequestMessage({
+        channelId: context.source.channelId,
+        integrationAccountId: context.source.integrationAccountId,
+        issue,
+        messageTimestamp,
       });
     } catch (error) {
       console.error(
@@ -357,8 +407,8 @@ async function deliverOutputChannel(
     context.output.severities,
   );
   for (const issue of issues) {
-    const message = slackIssueMessage(issue, context.prMode === "manual");
-    await postSlackMessage({
+    const message = issueSlackMessage(context, issue);
+    const messageTimestamp = await postSlackMessage({
       accessToken: token,
       blocks: message.blocks,
       channelId: context.output.channelId,
@@ -367,6 +417,12 @@ async function deliverOutputChannel(
         `output:${context.output.channelId}:issue:${issue.id}`,
       ),
       text: message.text,
+    });
+    await registerPullRequestMessage({
+      channelId: context.output.channelId,
+      integrationAccountId: context.output.integrationAccountId,
+      issue,
+      messageTimestamp,
     });
   }
 }

--- a/packages/core/src/integrations/slack-remediations.test.ts
+++ b/packages/core/src/integrations/slack-remediations.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseSlackRemediationActionValue,
+  slackCodeChangeUrl,
+  slackIssuePullRequestMessage,
+  slackRemediationActionValue,
+  slackRemediationCarousel,
+} from "./slack-remediations.js";
+
+const issueId = "07070707-0707-4707-8707-070707070707";
+const codeRemediation = {
+  id: "24242424-2424-4424-8424-242424242424",
+  type: "code_change" as const,
+  title: "Restore the plant guard",
+  description: "Handle plants without a configured color.",
+  diff: "diff --git a/a b/a\n--- a/a\n+++ b/a\n@@ -1 +1 @@\n-a\n+b",
+};
+const externalRemediation = {
+  id: "26262626-2626-4626-8626-262626262626",
+  type: "external_action" as const,
+  title: "Update the production palette",
+  description: "Change the configured petal color.",
+  agentPrompt: "Set the production petal color to silver.",
+};
+
+describe("Slack remediation cards", () => {
+  it("renders every remediation in a selectable carousel", () => {
+    const blocks = slackRemediationCarousel({
+      canCreatePullRequest: true,
+      issueId,
+      remediations: [codeRemediation, externalRemediation],
+    });
+
+    expect(blocks).toEqual([
+      expect.objectContaining({ type: "header" }),
+      expect.objectContaining({ type: "section" }),
+      expect.objectContaining({
+        type: "carousel",
+        elements: [
+          expect.objectContaining({
+            title: expect.objectContaining({ text: codeRemediation.title }),
+            subtitle: expect.objectContaining({ text: "Code change" }),
+            actions: expect.arrayContaining([
+              expect.objectContaining({
+                action_id: "view_code_change",
+                url: slackCodeChangeUrl(issueId, codeRemediation.id),
+              }),
+              expect.objectContaining({
+                action_id: "create_issue_pull_request",
+                value: slackRemediationActionValue(
+                  issueId,
+                  codeRemediation.id,
+                ),
+              }),
+            ]),
+          }),
+          expect.objectContaining({
+            title: expect.objectContaining({ text: externalRemediation.title }),
+            subtitle: expect.objectContaining({ text: "External action" }),
+            actions: [
+              expect.objectContaining({
+                action_id: "copy_issue_prompt",
+                value: slackRemediationActionValue(
+                  issueId,
+                  externalRemediation.id,
+                ),
+              }),
+            ],
+          }),
+        ],
+      }),
+    ]);
+  });
+
+  it("round-trips the selected issue and remediation IDs", () => {
+    expect(
+      parseSlackRemediationActionValue(
+        slackRemediationActionValue(issueId, codeRemediation.id),
+      ),
+    ).toEqual({ issueId, remediationId: codeRemediation.id });
+    expect(parseSlackRemediationActionValue(issueId)).toBeNull();
+  });
+
+  it("deep-links code changes to the selected remediation diff", () => {
+    const url = new URL(slackCodeChangeUrl(issueId, codeRemediation.id));
+    expect(url.pathname).toBe(`/issues/${issueId}`);
+    expect(url.searchParams.get("codeChange")).toBe(codeRemediation.id);
+    expect(url.hash).toBe(`#remediation-${codeRemediation.id}`);
+  });
+
+  it("shows the selected remediation and live pull request state", () => {
+    const message = slackIssuePullRequestMessage({
+      failureReason: null,
+      issueId,
+      issueSeverity: "SEV-2",
+      issueTitle: "Plant API returns HTTP 500",
+      pullRequestNumber: 42,
+      pullRequestUrl: "https://github.com/example/plants/pull/42",
+      repositoryFullName: "example/plants",
+      requestId: "23232323-2323-4323-8323-232323232323",
+      selectedRemediation: codeRemediation,
+      status: "created",
+    });
+
+    expect(message.text).toContain("Pull request: Open");
+    expect(message.blocks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "carousel",
+          elements: [
+            expect.objectContaining({
+              block_id: "pull-request-23232323-2323-4323-8323-232323232323",
+              subtitle: expect.objectContaining({ text: "Open" }),
+              actions: expect.arrayContaining([
+                expect.objectContaining({
+                  action_id: "open_pull_request",
+                  url: "https://github.com/example/plants/pull/42",
+                }),
+              ]),
+            }),
+          ],
+        }),
+      ]),
+    );
+  });
+});

--- a/packages/core/src/integrations/slack-remediations.ts
+++ b/packages/core/src/integrations/slack-remediations.ts
@@ -1,0 +1,370 @@
+import { z } from "zod";
+import { decryptCredentials } from "../credentials/encryption.js";
+import {
+  getIssuePullRequestSlackCard,
+  getIssuePullRequestSlackDeliveries,
+} from "../db/pull-requests.js";
+import type { IssueRemediation } from "../investigations/report.js";
+import { responderIssueUrl } from "../responder-urls.js";
+import { updateSlackMessage } from "./slack.js";
+
+const slackCredentialsSchema = z.object({
+  accessToken: z.string().min(1),
+});
+
+const remediationActionValueSchema = z.object({
+  issueId: z.uuid(),
+  remediationId: z.uuid(),
+});
+
+export type SlackRemediationActionValue = z.infer<
+  typeof remediationActionValueSchema
+>;
+
+function escapeSlack(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+}
+
+function truncate(value: string, maxLength: number): string {
+  return value.length > maxLength
+    ? `${value.slice(0, maxLength - 1).trimEnd()}…`
+    : value;
+}
+
+function remediationKind(remediation: IssueRemediation): string {
+  return remediation.type === "code_change" ? "Code change" : "External action";
+}
+
+function responderAppUrl(): string {
+  return (
+    process.env.RESPONDER_APP_URL ??
+    process.env.BETTER_AUTH_URL ??
+    "http://localhost:3000"
+  ).replace(/\/$/, "");
+}
+
+export function slackCodeChangeUrl(
+  issueId: string,
+  remediationId: string,
+): string {
+  const url = new URL(responderIssueUrl(issueId, responderAppUrl()));
+  url.searchParams.set("codeChange", remediationId);
+  url.hash = `remediation-${remediationId}`;
+  return url.toString();
+}
+
+export function slackRemediationActionValue(
+  issueId: string,
+  remediationId: string,
+): string {
+  return JSON.stringify({ issueId, remediationId });
+}
+
+export function parseSlackRemediationActionValue(
+  value: string,
+): SlackRemediationActionValue | null {
+  try {
+    const parsed = remediationActionValueSchema.safeParse(JSON.parse(value));
+    return parsed.success ? parsed.data : null;
+  } catch {
+    return null;
+  }
+}
+
+export function slackRemediationCard(input: {
+  issueId: string;
+  remediation: IssueRemediation;
+  selectable?: boolean;
+}) {
+  const actions = input.remediation.type === "code_change"
+    ? [
+        {
+          type: "button",
+          text: {
+            type: "plain_text",
+            text: "See code change",
+            emoji: false,
+          },
+          action_id: "view_code_change",
+          url: slackCodeChangeUrl(input.issueId, input.remediation.id),
+          value: slackRemediationActionValue(
+            input.issueId,
+            input.remediation.id,
+          ),
+        },
+        ...(input.selectable === false
+          ? []
+          : [{
+              type: "button",
+              text: { type: "plain_text", text: "Open PR", emoji: false },
+              style: "primary",
+              action_id: "create_issue_pull_request",
+              value: slackRemediationActionValue(
+                input.issueId,
+                input.remediation.id,
+              ),
+            }]),
+      ]
+    : input.selectable === false
+      ? []
+      : [{
+          type: "button",
+          text: { type: "plain_text", text: "Copy prompt", emoji: false },
+          action_id: "copy_issue_prompt",
+          value: slackRemediationActionValue(
+            input.issueId,
+            input.remediation.id,
+          ),
+        }];
+  return {
+    type: "card",
+    block_id: `remediation-${input.remediation.id}`,
+    title: {
+      type: "mrkdwn",
+      text: truncate(escapeSlack(input.remediation.title), 200),
+      verbatim: false,
+    },
+    subtitle: {
+      type: "mrkdwn",
+      text: remediationKind(input.remediation),
+      verbatim: false,
+    },
+    body: {
+      type: "mrkdwn",
+      text: truncate(escapeSlack(input.remediation.description), 2_900),
+      verbatim: false,
+    },
+    ...(actions.length > 0 ? { actions } : {}),
+  };
+}
+
+export function slackRemediationCarousel(input: {
+  canCreatePullRequest: boolean;
+  issueId: string;
+  remediations: IssueRemediation[];
+}): unknown[] {
+  return [
+    {
+      type: "header",
+      text: { type: "plain_text", text: "Remediations", emoji: true },
+    },
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: "You can use any of these remediations.",
+      },
+    },
+    {
+      type: "carousel",
+      elements: input.remediations.map((remediation) =>
+        slackRemediationCard({
+          issueId: input.issueId,
+          remediation,
+          selectable:
+            remediation.type === "external_action" ||
+            input.canCreatePullRequest,
+        }),
+      ),
+    },
+  ];
+}
+
+export interface SlackIssuePullRequestCard {
+  failureReason: string | null;
+  issueId: string;
+  issueSeverity: "SEV-1" | "SEV-2" | "SEV-3";
+  issueTitle: string;
+  pullRequestNumber: number | null;
+  pullRequestUrl: string | null;
+  repositoryFullName: string | null;
+  requestId: string;
+  selectedRemediation: IssueRemediation;
+  status: "queued" | "creating" | "created" | "merged" | "failed";
+}
+
+function pullRequestStatus(card: SlackIssuePullRequestCard): {
+  body: string;
+  label: string;
+} {
+  switch (card.status) {
+    case "queued":
+      return {
+        body: "The selected remediation is queued and will start shortly.",
+        label: "Queued",
+      };
+    case "creating":
+      return {
+        body: "Applying the selected remediation and preparing the pull request.",
+        label: "Creating",
+      };
+    case "created":
+      return {
+        body:
+          card.repositoryFullName && card.pullRequestNumber
+            ? `${escapeSlack(card.repositoryFullName)} #${card.pullRequestNumber}`
+            : "The pull request is ready for review.",
+        label: "Open",
+      };
+    case "merged":
+      return {
+        body:
+          card.repositoryFullName && card.pullRequestNumber
+            ? `${escapeSlack(card.repositoryFullName)} #${card.pullRequestNumber}`
+            : "The pull request was merged.",
+        label: "Merged",
+      };
+    case "failed":
+      return {
+        body: truncate(
+          escapeSlack(
+            card.failureReason ?? "Responder could not create the pull request.",
+          ),
+          2_900,
+        ),
+        label: "Failed",
+      };
+  }
+}
+
+export function slackIssuePullRequestMessage(card: SlackIssuePullRequestCard): {
+  blocks: unknown[];
+  text: string;
+} {
+  const status = pullRequestStatus(card);
+  const issueUrl = responderIssueUrl(card.issueId, responderAppUrl());
+  const pullRequestActions = [
+    ...(card.pullRequestUrl
+      ? [{
+          type: "button",
+          action_id: "open_pull_request",
+          text: { type: "plain_text", text: "Open PR", emoji: false },
+          url: card.pullRequestUrl,
+          value: card.requestId,
+        }]
+      : []),
+    {
+      type: "button",
+      action_id: "view_issue",
+      text: { type: "plain_text", text: "View issue", emoji: false },
+      url: issueUrl,
+      value: card.issueId,
+    },
+  ];
+  return {
+    text: `${card.issueSeverity} — ${card.issueTitle}\n${card.selectedRemediation.title}\nPull request: ${status.label}`,
+    blocks: [
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: `*${card.issueSeverity} — ${escapeSlack(card.issueTitle)}*`,
+        },
+      },
+      {
+        type: "header",
+        text: {
+          type: "plain_text",
+          text: "Selected remediation",
+          emoji: true,
+        },
+      },
+      {
+        type: "carousel",
+        elements: [
+          slackRemediationCard({
+            issueId: card.issueId,
+            remediation: card.selectedRemediation,
+            selectable: false,
+          }),
+        ],
+      },
+      {
+        type: "header",
+        text: { type: "plain_text", text: "Pull request", emoji: true },
+      },
+      {
+        type: "carousel",
+        elements: [
+          {
+            type: "card",
+            block_id: `pull-request-${card.requestId}`,
+            title: {
+              type: "mrkdwn",
+              text: "Pull request",
+              verbatim: false,
+            },
+            subtitle: {
+              type: "mrkdwn",
+              text: status.label,
+              verbatim: false,
+            },
+            body: {
+              type: "mrkdwn",
+              text: status.body,
+              verbatim: false,
+            },
+            actions: pullRequestActions,
+          },
+        ],
+      },
+    ],
+  };
+}
+
+export async function refreshIssuePullRequestSlackMessages(
+  requestId: string,
+): Promise<void> {
+  try {
+    const [card, deliveries] = await Promise.all([
+      getIssuePullRequestSlackCard(requestId),
+      getIssuePullRequestSlackDeliveries(requestId),
+    ]);
+    if (!card || deliveries.length === 0) return;
+    const message = slackIssuePullRequestMessage(card);
+    const updates = await Promise.allSettled(
+      deliveries.map(async (delivery) => {
+        if (!delivery.encryptedCredentials) {
+          throw new Error("Slack credentials are unavailable");
+        }
+        const credentials = slackCredentialsSchema.parse(
+          decryptCredentials<Record<string, unknown>>(
+            delivery.encryptedCredentials,
+          ),
+        );
+        await updateSlackMessage({
+          accessToken: credentials.accessToken,
+          blocks: message.blocks,
+          channelId: delivery.channelId,
+          text: message.text,
+          timestamp: delivery.messageTimestamp,
+        });
+      }),
+    );
+    for (const update of updates) {
+      if (update.status === "rejected") {
+        console.error(
+          JSON.stringify({
+            error:
+              update.reason instanceof Error
+                ? update.reason.message
+                : String(update.reason),
+            event: "issue_pull_request_slack_update_failed",
+            requestId,
+          }),
+        );
+      }
+    }
+  } catch (error) {
+    console.error(
+      JSON.stringify({
+        error: error instanceof Error ? error.message : String(error),
+        event: "issue_pull_request_slack_update_failed",
+        requestId,
+      }),
+    );
+  }
+}

--- a/packages/core/src/investigations/report.test.ts
+++ b/packages/core/src/investigations/report.test.ts
@@ -13,6 +13,15 @@ const evidence = {
   line: 9,
 };
 
+function externalRemediation(description: string) {
+  return [{
+    type: "external_action" as const,
+    title: "Correct the deployment",
+    description,
+    agentPrompt: `Apply this remediation: ${description}`,
+  }];
+}
+
 describe("investigation report", () => {
   it("renders a copy-ready issue remediation prompt", () => {
     const prompt = renderIssueFixPrompt({
@@ -53,6 +62,65 @@ describe("investigation report", () => {
     expect(parsed.success).toBe(true);
   });
 
+  it("accepts code and external remediation options for a new issue", () => {
+    const parsed = investigationReportSubmissionSchema.safeParse({
+      schemaVersion: 1,
+      headline: "Route and deployment need remediation",
+      summary: "The route needs a guard and the deployment needs a restart.",
+      issues: [{
+        resolution: "new",
+        title: "Missing route guard",
+        description: "The route reads an optional value without checking it.",
+        rootCause: "A route change removed the optional-value guard.",
+        timeline: [{
+          title: "Request reached the route",
+          description: "The request reached the route without the optional value.",
+        }],
+        severity: "SEV-2",
+        remediations: [
+          {
+            type: "code_change",
+            title: "Restore the route guard",
+            description: "Return early when the optional value is absent.",
+            diff: "diff --git a/src/route.ts b/src/route.ts\n--- a/src/route.ts\n+++ b/src/route.ts\n@@ -1 +1,2 @@\n+if (!value) return;\n use(value);",
+          },
+          {
+            type: "external_action",
+            title: "Restart the deployment",
+            description: "Restart the deployment after the fix is merged.",
+            agentPrompt: "Restart the production deployment after confirming the route fix is live.",
+          },
+        ],
+        evidence: [evidence],
+      }],
+    });
+
+    expect(parsed.success).toBe(true);
+  });
+
+  it("requires at least one remediation option for every new issue", () => {
+    const parsed = investigationReportSubmissionSchema.safeParse({
+      schemaVersion: 1,
+      headline: "Route needs remediation",
+      summary: "The route needs a guard.",
+      issues: [{
+        resolution: "new",
+        title: "Missing route guard",
+        description: "The route reads an optional value without checking it.",
+        rootCause: "A route change removed the optional-value guard.",
+        timeline: [{
+          title: "Request reached the route",
+          description: "The request reached the route without the optional value.",
+        }],
+        severity: "SEV-2",
+        remediations: [],
+        evidence: [evidence],
+      }],
+    });
+
+    expect(parsed.success).toBe(false);
+  });
+
   it("preserves Vercel as an evidence source", () => {
     const parsed = investigationReportSubmissionSchema.safeParse({
       schemaVersion: 1,
@@ -68,7 +136,7 @@ describe("investigation report", () => {
           description: "Vercel started compiling the production deployment.",
         }],
         severity: "SEV-2",
-        remediation: "Correct the compile error and redeploy.",
+        remediations: externalRemediation("Correct the compile error and redeploy."),
         evidence: [{
           source: "vercel",
           title: "Failed production deployment",
@@ -95,7 +163,7 @@ describe("investigation report", () => {
           description: "Vercel started the build.",
         }],
         severity: "SEV-2",
-        remediation: "Correct the compile error and redeploy.",
+        remediations: externalRemediation("Correct the compile error and redeploy."),
         evidence: [evidence],
       }],
     });
@@ -118,7 +186,7 @@ describe("investigation report", () => {
           description: "Vercel started the build.",
         }],
         severity: "SEV-2",
-        remediation: "Correct the compile error and redeploy.",
+        remediations: externalRemediation("Correct the compile error and redeploy."),
         evidence: [evidence],
       }],
     });
@@ -141,7 +209,7 @@ describe("investigation report", () => {
           description: "Vercel started the build.",
         }],
         severity: "SEV-2",
-        remediation: "Correct the compile error and redeploy.",
+        remediations: externalRemediation("Correct the compile error and redeploy."),
         evidence: [evidence],
       }],
     });

--- a/packages/core/src/investigations/report.ts
+++ b/packages/core/src/investigations/report.ts
@@ -60,6 +60,63 @@ export const issueEvidenceSchema = z.object({
 
 export type IssueEvidence = z.infer<typeof issueEvidenceSchema>;
 
+const remediationTitleSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(200)
+  .describe("Short action-oriented remediation title.");
+
+const remediationDescriptionSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(4_000)
+  .describe("Human-readable explanation of the proposed remediation.");
+
+export const issueRemediationSubmissionSchema = z.discriminatedUnion("type", [
+  z.object({
+    type: z.literal("code_change"),
+    title: remediationTitleSchema,
+    description: remediationDescriptionSchema,
+    diff: z
+      .string()
+      .trim()
+      .min(1)
+      .max(40_000)
+      .refine(
+        (diff) =>
+          /^diff --git /m.test(diff) &&
+          /^--- /m.test(diff) &&
+          /^\+\+\+ /m.test(diff) &&
+          /^@@ /m.test(diff),
+        "Must be a complete unified git diff",
+      )
+      .describe(
+        "A complete unified git diff proposing the code change, including diff --git, ---/+++, and hunk headers. Do not invent a diff unless the relevant repository files were inspected.",
+      ),
+  }),
+  z.object({
+    type: z.literal("external_action"),
+    title: remediationTitleSchema,
+    description: remediationDescriptionSchema,
+    agentPrompt: z
+      .string()
+      .trim()
+      .min(1)
+      .max(8_000)
+      .describe(
+        "A self-contained prompt the user can give to an agent that has access to the external system.",
+      ),
+  }),
+]);
+
+export type IssueRemediationSubmission = z.infer<
+  typeof issueRemediationSubmissionSchema
+>;
+
+export type IssueRemediation = IssueRemediationSubmission & { id: string };
+
 const newIssueSubmissionSchema = z.object({
   resolution: z.literal("new"),
   title: z
@@ -84,12 +141,13 @@ const newIssueSubmissionSchema = z.object({
     .max(30)
     .describe("Ordered events that explain how the issue unfolded."),
   severity: issueSeveritySchema,
-  remediation: z
-    .string()
-    .trim()
+  remediations: z
+    .array(issueRemediationSubmissionSchema)
     .min(1)
-    .max(8_000)
-    .describe("Suggested remediation."),
+    .max(10)
+    .describe(
+      "Concrete remediation options. Use code_change only after inspecting the relevant files; use external_action for configuration, deployment, data, or other work outside the attached repositories.",
+    ),
   evidence: z.array(issueEvidenceSchema).min(1).max(30),
 });
 
@@ -156,10 +214,20 @@ export interface ReportIssue {
   timeline: IssueTimelineEntry[];
   severity: "SEV-1" | "SEV-2" | "SEV-3";
   remediation: string;
+  remediations?: IssueRemediation[];
+}
+
+export function remediationSummary(
+  remediations: IssueRemediationSubmission[],
+): string {
+  return remediations
+    .map((remediation) => `${remediation.title}: ${remediation.description}`)
+    .join("\n\n");
 }
 
 export function renderIssueFixPrompt(
   issue: ReportIssue & { evidence: IssueEvidence[] },
+  selectedRemediation?: IssueRemediationSubmission,
 ): string {
   const timeline = issue.timeline ?? [];
   const evidence = issue.evidence
@@ -186,7 +254,11 @@ export function renderIssueFixPrompt(
         ]
       : []),
     `Severity: ${issue.severity}`,
-    `Remediation: ${issue.remediation}`,
+    `Remediation: ${selectedRemediation?.title ?? "Recommended fix"}`,
+    selectedRemediation?.description ?? issue.remediation,
+    ...(selectedRemediation?.type === "code_change"
+      ? ["", "Proposed diff:", "```diff", selectedRemediation.diff, "```"]
+      : []),
     ...(evidence ? ["", "Evidence:", evidence] : []),
     "",
     "Make the smallest safe change and verify it with relevant tests.",

--- a/packages/core/src/jobs.ts
+++ b/packages/core/src/jobs.ts
@@ -5,6 +5,7 @@ import { investigationRequestSchema } from "./investigations/input.js";
 import { agentPrModeSchema } from "./agents/config.js";
 import {
   issueEvidenceSchema,
+  issueRemediationSubmissionSchema,
   issueSeveritySchema,
   issueTimelineEntrySchema,
 } from "./investigations/report.js";
@@ -63,6 +64,7 @@ export const remediationJobSchema = z.object({
   config: runtimeAgentJobConfigSchema,
   investigationId: z.uuid(),
   issue: remediationIssueSchema,
+  selectedRemediation: issueRemediationSubmissionSchema.optional(),
   queuedAt: z.iso.datetime(),
   remediationRequestId: z.uuid(),
   runtimeProfileId: z.uuid(),

--- a/packages/core/src/pull-request-review-queue.test.ts
+++ b/packages/core/src/pull-request-review-queue.test.ts
@@ -1,6 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { getRuntimeAgentConfig } from "./db/investigations.js";
-import { getIssuePullRequestForReview } from "./db/pull-requests.js";
+import {
+  appendIssuePullRequestActivity,
+  getIssuePullRequestForReview,
+} from "./db/pull-requests.js";
 import { pullRequestReviewQueue } from "./jobs.js";
 import { queuePullRequestReviewJob } from "./pull-request-review-queue.js";
 
@@ -9,8 +12,22 @@ vi.mock("./db/investigations.js", () => ({
 }));
 
 vi.mock("./db/pull-requests.js", () => ({
+  appendIssuePullRequestActivity: vi.fn(),
   getIssuePullRequestForReview: vi.fn(),
+  pullRequestActivityEvent: (
+    type: string,
+    data?: Record<string, unknown>,
+  ) => ({ type, data, meta: { at: "2026-08-25T00:00:00.000Z" } }),
 }));
+
+const reviewComment = {
+  author: "reviewer-bot",
+  body: "Use a null guard here.",
+  id: 123,
+  line: 17,
+  path: "src/route.ts",
+  url: "https://github.com/acme/app/pull/42#discussion_r123",
+};
 
 const review = {
   agentConfigVersionId: "08080808-0808-4808-8808-080808080808",
@@ -55,6 +72,7 @@ describe("pull request review queue", () => {
         {
           installationId: 123,
           pullRequestNumber: 42,
+          reviewComment,
           repositoryFullName: "acme/app",
         },
       ),
@@ -77,6 +95,21 @@ describe("pull request review queue", () => {
       }),
       { singletonKey: `pull-request-review:${review.requestId}` },
     );
+    expect(appendIssuePullRequestActivity).toHaveBeenCalledTimes(2);
+    expect(appendIssuePullRequestActivity).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        externalKey: "github-review-comment:123",
+        requestId: review.requestId,
+      }),
+    );
+    expect(appendIssuePullRequestActivity).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        externalKey: "review-job:job-1:queued",
+        requestId: review.requestId,
+      }),
+    );
   });
 
   it("ignores a review for a pull request Responder did not create", async () => {
@@ -89,6 +122,7 @@ describe("pull request review queue", () => {
         {
           installationId: 123,
           pullRequestNumber: 42,
+          reviewComment,
           repositoryFullName: "acme/app",
         },
       ),

--- a/packages/core/src/pull-request-review-queue.ts
+++ b/packages/core/src/pull-request-review-queue.ts
@@ -1,5 +1,9 @@
 import { getRuntimeAgentConfig } from "./db/investigations.js";
-import { getIssuePullRequestForReview } from "./db/pull-requests.js";
+import {
+  appendIssuePullRequestActivity,
+  getIssuePullRequestForReview,
+  pullRequestActivityEvent,
+} from "./db/pull-requests.js";
 import {
   pullRequestReviewQueue,
   type PullRequestReviewJob,
@@ -18,6 +22,14 @@ export async function queuePullRequestReviewJob(
   input: {
     installationId: number;
     pullRequestNumber: number;
+    reviewComment: {
+      author: string;
+      body: string;
+      id: number;
+      line: number | null;
+      path: string;
+      url: string;
+    };
     repositoryFullName: string;
   },
 ) {
@@ -26,6 +38,19 @@ export async function queuePullRequestReviewJob(
 
   const config = await getRuntimeAgentConfig(review.agentConfigVersionId);
   if (!config) throw new Error("Agent configuration is unavailable");
+
+  await appendIssuePullRequestActivity({
+    event: pullRequestActivityEvent("review.comment.received", {
+      author: input.reviewComment.author,
+      body: input.reviewComment.body,
+      commentId: input.reviewComment.id,
+      line: input.reviewComment.line,
+      path: input.reviewComment.path,
+      url: input.reviewComment.url,
+    }),
+    externalKey: `github-review-comment:${input.reviewComment.id}`,
+    requestId: review.requestId,
+  });
 
   const jobId = await queue.send(
     pullRequestReviewQueue,
@@ -55,6 +80,14 @@ export async function queuePullRequestReviewJob(
     },
     { singletonKey: `pull-request-review:${review.requestId}` },
   );
+
+  if (jobId) {
+    await appendIssuePullRequestActivity({
+      event: pullRequestActivityEvent("review.job.queued", { jobId }),
+      externalKey: `review-job:${jobId}:queued`,
+      requestId: review.requestId,
+    });
+  }
 
   return {
     matched: true as const,

--- a/packages/core/src/remediation-queue.ts
+++ b/packages/core/src/remediation-queue.ts
@@ -7,6 +7,7 @@ import {
   recoverAbandonedIssuePullRequest,
   setIssuePullRequestSession,
 } from "./db/pull-requests.js";
+import { refreshIssuePullRequestSlackMessages } from "./integrations/slack-remediations.js";
 import {
   investigationQueue,
   remediationQueue,
@@ -66,6 +67,7 @@ export async function recoverAbandonedIssueRemediations(
         staleBefore,
       )
     ) {
+      await refreshIssuePullRequestSlackMessages(candidate.requestId);
       recovered.push(candidate.requestId);
     }
   }
@@ -107,6 +109,7 @@ export async function queueIssueRemediationJob(
           remediation: remediation.issueRemediation,
           evidence: remediation.issueEvidence,
         },
+        selectedRemediation: remediation.selectedRemediation,
         queuedAt: new Date().toISOString(),
         remediationRequestId: remediation.requestId,
         runtimeProfileId: remediation.runtimeProfileId,
@@ -156,6 +159,7 @@ export async function queueIssueRemediationJob(
         requestId,
         error instanceof Error ? error.message : "Unable to start remediation",
       );
+      await refreshIssuePullRequestSlackMessages(requestId);
     }
     throw error;
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,6 +87,9 @@ importers:
       '@hono/node-server':
         specifier: 2.0.12
         version: 2.0.12(hono@4.12.34)
+      '@pierre/diffs':
+        specifier: 1.2.5
+        version: 1.2.5(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@responder/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -1102,6 +1105,16 @@ packages:
   '@oxc-project/types@0.144.0':
     resolution: {integrity: sha512-nuhZIOLuI6TFQ32I/WnUx+SCPY7SdSKwgnFHydAuoS1+Z4BRcaP+RRJmGzl9lw+0OFF7UmaESf7KQRXaNLHypg==}
 
+  '@pierre/diffs@1.2.5':
+    resolution: {integrity: sha512-uYOz3Kfs5ED0qY0VraUXzylsEKvZPTVdexboM3QKPx/qBZmTT9F3lKAFuPpY5aIrV04sdHtoFCKStyzEu99U2A==}
+    peerDependencies:
+      react: ^18.3.1 || ^19.0.0
+      react-dom: ^18.3.1 || ^19.0.0
+
+  '@pierre/theme@1.0.3':
+    resolution: {integrity: sha512-sWHv11TMoqKxKDgTIk5VbhQjdPhs8DCcBxbjh3mRlS3YOM/OcrWoGX6MM8eBGn9cUu3M46Py0JnxsG2nJaFTuA==}
+    engines: {vscode: ^1.0.0}
+
   '@playwright/test@1.62.1':
     resolution: {integrity: sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==}
     engines: {node: '>=20'}
@@ -1403,6 +1416,30 @@ packages:
   '@sentry/vite-plugin@5.4.0':
     resolution: {integrity: sha512-fFJgCxs5hDyAm9BbZJ+LbA+LK2tjX5OoD0v0ARU4StR6KQmGUduoPs69yJ9AfqZ0om3Rlp5JDliiwFcNkasORA==}
     engines: {node: '>= 18'}
+
+  '@shikijs/core@3.23.0':
+    resolution: {integrity: sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA==}
+
+  '@shikijs/engine-javascript@3.23.0':
+    resolution: {integrity: sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA==}
+
+  '@shikijs/engine-oniguruma@3.23.0':
+    resolution: {integrity: sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==}
+
+  '@shikijs/langs@3.23.0':
+    resolution: {integrity: sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==}
+
+  '@shikijs/themes@3.23.0':
+    resolution: {integrity: sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==}
+
+  '@shikijs/transformers@3.23.0':
+    resolution: {integrity: sha512-F9msZVxdF+krQNSdQ4V+Ja5QemeAoTQ2jxt7nJCwhDsdF1JWS3KxIQXA3lQbyKwS3J61oHRUSv4jYWv3CkaKTQ==}
+
+  '@shikijs/types@3.23.0':
+    resolution: {integrity: sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==}
+
+  '@shikijs/vscode-textmate@10.0.2':
+    resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
 
   '@smithy/core@3.33.2':
     resolution: {integrity: sha512-CUGXpnPkVdjUCbix+83sWLW9VFgQOm44MDOx/ihITJMAnOZKvL8YYIc7DR9pP/tZ8CIRvMiON/TucvygqbHO3w==}
@@ -2169,6 +2206,10 @@ packages:
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
+  diff@8.0.3:
+    resolution: {integrity: sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==}
+    engines: {node: '>=0.3.1'}
+
   dompurify@3.4.13:
     resolution: {integrity: sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==}
 
@@ -2598,6 +2639,9 @@ packages:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
+  hast-util-to-html@9.0.5:
+    resolution: {integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==}
+
   hast-util-to-jsx-runtime@2.3.6:
     resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
 
@@ -2620,6 +2664,9 @@ packages:
 
   html-url-attributes@3.0.1:
     resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
+
+  html-void-elements@3.0.0:
+    resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
@@ -2938,6 +2985,9 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
+  lru_map@0.4.1:
+    resolution: {integrity: sha512-I+lBvqMMFfqaV8CJCISjI3wbjmwVu/VyOoU7+qtu9d7ioW5klMgsTTiUOUp+DJvfTTzKXoPbyC6YfgkNcyPSOg==}
+
   luxon@3.7.2:
     resolution: {integrity: sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==}
     engines: {node: '>=12'}
@@ -3144,6 +3194,12 @@ packages:
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  oniguruma-parser@0.12.2:
+    resolution: {integrity: sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==}
+
+  oniguruma-to-es@4.3.6:
+    resolution: {integrity: sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==}
 
   openai@6.49.0:
     resolution: {integrity: sha512-aYCc0C6L864eR6WSYIwQGyXriw/nIyZx0ObvhzOEVuk0zoBDpynjSbrionWI7q65B5H8jJX0DXR9snEzM6bfPg==}
@@ -3411,6 +3467,15 @@ packages:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
 
+  regex-recursion@6.0.2:
+    resolution: {integrity: sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==}
+
+  regex-utilities@2.3.0:
+    resolution: {integrity: sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==}
+
+  regex@6.1.0:
+    resolution: {integrity: sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==}
+
   remark-parse@11.0.0:
     resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
 
@@ -3523,6 +3588,9 @@ packages:
   shell-quote@1.9.0:
     resolution: {integrity: sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==}
     engines: {node: '>= 0.4'}
+
+  shiki@3.23.0:
+    resolution: {integrity: sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA==}
 
   side-channel-list@1.0.1:
     resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
@@ -5095,6 +5163,19 @@ snapshots:
 
   '@oxc-project/types@0.144.0': {}
 
+  '@pierre/diffs@1.2.5(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@pierre/theme': 1.0.3
+      '@shikijs/transformers': 3.23.0
+      diff: 8.0.3
+      hast-util-to-html: 9.0.5
+      lru_map: 0.4.1
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      shiki: 3.23.0
+
+  '@pierre/theme@1.0.3': {}
+
   '@playwright/test@1.62.1':
     dependencies:
       playwright: 1.62.1
@@ -5341,6 +5422,44 @@ snapshots:
       - rollup
       - supports-color
       - webpack
+
+  '@shikijs/core@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.5
+      hast-util-to-html: 9.0.5
+
+  '@shikijs/engine-javascript@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
+      '@shikijs/vscode-textmate': 10.0.2
+      oniguruma-to-es: 4.3.6
+
+  '@shikijs/engine-oniguruma@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
+      '@shikijs/vscode-textmate': 10.0.2
+
+  '@shikijs/langs@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
+
+  '@shikijs/themes@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
+
+  '@shikijs/transformers@3.23.0':
+    dependencies:
+      '@shikijs/core': 3.23.0
+      '@shikijs/types': 3.23.0
+
+  '@shikijs/types@3.23.0':
+    dependencies:
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.5
+
+  '@shikijs/vscode-textmate@10.0.2': {}
 
   '@smithy/core@3.33.2':
     dependencies:
@@ -6077,6 +6196,8 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
+  diff@8.0.3: {}
+
   dompurify@3.4.13:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
@@ -6481,6 +6602,20 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hast-util-to-html@9.0.5:
+    dependencies:
+      '@types/hast': 3.0.5
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      comma-separated-tokens: 2.0.3
+      hast-util-whitespace: 3.0.0
+      html-void-elements: 3.0.0
+      mdast-util-to-hast: 13.2.1
+      property-information: 7.2.0
+      space-separated-tokens: 2.0.2
+      stringify-entities: 4.0.4
+      zwitch: 2.0.4
+
   hast-util-to-jsx-runtime@2.3.6(supports-color@8.1.1):
     dependencies:
       '@types/estree': 1.0.9
@@ -6518,6 +6653,8 @@ snapshots:
   hono@4.12.34: {}
 
   html-url-attributes@3.0.1: {}
+
+  html-void-elements@3.0.0: {}
 
   http-errors@2.0.1:
     dependencies:
@@ -6748,6 +6885,8 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  lru_map@0.4.1: {}
 
   luxon@3.7.2: {}
 
@@ -7052,6 +7191,14 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
 
+  oniguruma-parser@0.12.2: {}
+
+  oniguruma-to-es@4.3.6:
+    dependencies:
+      oniguruma-parser: 0.12.2
+      regex: 6.1.0
+      regex-recursion: 6.0.2
+
   openai@6.49.0(@aws-sdk/credential-provider-node@3.972.80)(@smithy/signature-v4@5.7.2)(ws@8.21.3)(zod@4.4.3):
     optionalDependencies:
       '@aws-sdk/credential-provider-node': 3.972.80
@@ -7309,6 +7456,16 @@ snapshots:
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
 
+  regex-recursion@6.0.2:
+    dependencies:
+      regex-utilities: 2.3.0
+
+  regex-utilities@2.3.0: {}
+
+  regex@6.1.0:
+    dependencies:
+      regex-utilities: 2.3.0
+
   remark-parse@11.0.0(supports-color@8.1.1):
     dependencies:
       '@types/mdast': 4.0.4
@@ -7445,6 +7602,17 @@ snapshots:
   shebang-regex@3.0.0: {}
 
   shell-quote@1.9.0: {}
+
+  shiki@3.23.0:
+    dependencies:
+      '@shikijs/core': 3.23.0
+      '@shikijs/engine-javascript': 3.23.0
+      '@shikijs/engine-oniguruma': 3.23.0
+      '@shikijs/langs': 3.23.0
+      '@shikijs/themes': 3.23.0
+      '@shikijs/types': 3.23.0
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.5
 
   side-channel-list@1.0.1:
     dependencies:


### PR DESCRIPTION
## Summary

- let investigations propose multiple typed remediations, including code changes with unified diffs and external actions with reusable prompts
- add manual and automatic pull-request flows, with remediation selection and durable pull-request status updates in the dashboard and Slack
- record pull-request comments, review runs with expandable traces, commits, and automated review follow-ups as activity
- add Slack remediation carousels, exact code-change deep links, and pull-request status cards

## Validation

- `pnpm test` (115 files, 824 tests)
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`