### PR TITLE
Add light mode across the application

### DIFF
--- a/apps/control-plane/index.html
+++ b/apps/control-plane/index.html
@@ -7,6 +7,7 @@
       name="description"
       content="Managed incident investigation agents."
     />
+    <script src="/color-theme-init.js"></script>
     <title>Responder</title>
   </head>
   <body>

--- a/apps/control-plane/public/color-theme-init.js
+++ b/apps/control-plane/public/color-theme-init.js
@@ -1,0 +1,20 @@
+(() => {
+  const storageKey = "responder-marketing-theme";
+  let storedTheme = null;
+
+  try {
+    storedTheme = globalThis.localStorage.getItem(storageKey);
+  } catch {
+    // Fall back to the system preference when storage is unavailable.
+  }
+
+  const theme =
+    storedTheme === "dark" || storedTheme === "light"
+      ? storedTheme
+      : globalThis.matchMedia("(prefers-color-scheme: light)").matches
+        ? "light"
+        : "dark";
+
+  globalThis.document.documentElement.dataset.colorTheme = theme;
+  globalThis.document.documentElement.style.colorScheme = theme;
+})();

--- a/apps/control-plane/src/color-theme.test.ts
+++ b/apps/control-plane/src/color-theme.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { resolveColorTheme } from "./color-theme.js";
+
+describe("color theme", () => {
+  it("uses a saved preference before the system preference", () => {
+    expect(resolveColorTheme("dark", true)).toBe("dark");
+    expect(resolveColorTheme("light", false)).toBe("light");
+  });
+
+  it("falls back to the system preference", () => {
+    expect(resolveColorTheme(null, true)).toBe("light");
+    expect(resolveColorTheme(null, false)).toBe("dark");
+    expect(resolveColorTheme("unknown", true)).toBe("light");
+  });
+});

--- a/apps/control-plane/src/color-theme.ts
+++ b/apps/control-plane/src/color-theme.ts
@@ -1,0 +1,86 @@
+import { useCallback, useSyncExternalStore } from "react";
+
+export type ColorTheme = "dark" | "light";
+
+const colorThemeStorageKey = "responder-marketing-theme";
+const subscribers = new Set<() => void>();
+let colorTheme: ColorTheme = "dark";
+let inMemoryColorTheme: ColorTheme | null = null;
+let isInitialized = false;
+
+export function resolveColorTheme(
+  storedTheme: string | null,
+  prefersLight: boolean,
+): ColorTheme {
+  if (storedTheme === "dark" || storedTheme === "light") return storedTheme;
+  return prefersLight ? "light" : "dark";
+}
+
+function readStoredColorTheme() {
+  try {
+    return window.localStorage.getItem(colorThemeStorageKey) ?? inMemoryColorTheme;
+  } catch {
+    return inMemoryColorTheme;
+  }
+}
+
+function publishColorTheme(nextTheme: ColorTheme) {
+  colorTheme = nextTheme;
+  document.documentElement.dataset.colorTheme = nextTheme;
+  document.documentElement.style.colorScheme = nextTheme;
+  for (const subscriber of subscribers) subscriber();
+}
+
+function initializeColorTheme() {
+  if (isInitialized || typeof window === "undefined") return;
+  isInitialized = true;
+
+  const lightModePreference = window.matchMedia("(prefers-color-scheme: light)");
+  const syncTheme = () => {
+    publishColorTheme(
+      resolveColorTheme(readStoredColorTheme(), lightModePreference.matches),
+    );
+  };
+  const syncStoredTheme = (event: StorageEvent) => {
+    if (event.key === null || event.key === colorThemeStorageKey) syncTheme();
+  };
+
+  syncTheme();
+  lightModePreference.addEventListener("change", syncTheme);
+  window.addEventListener("storage", syncStoredTheme);
+}
+
+function subscribe(subscriber: () => void) {
+  initializeColorTheme();
+  subscribers.add(subscriber);
+  return () => subscribers.delete(subscriber);
+}
+
+function getColorTheme() {
+  return colorTheme;
+}
+
+function getServerColorTheme(): ColorTheme {
+  return "dark";
+}
+
+export function setColorTheme(nextTheme: ColorTheme) {
+  try {
+    window.localStorage.setItem(colorThemeStorageKey, nextTheme);
+    inMemoryColorTheme = null;
+  } catch {
+    inMemoryColorTheme = nextTheme;
+  }
+  publishColorTheme(nextTheme);
+}
+
+export function useColorTheme() {
+  const theme = useSyncExternalStore(subscribe, getColorTheme, getServerColorTheme);
+  const toggleTheme = useCallback(() => {
+    setColorTheme(theme === "dark" ? "light" : "dark");
+  }, [theme]);
+
+  return { theme, toggleTheme };
+}
+
+initializeColorTheme();

--- a/apps/control-plane/src/components/app-shell.tsx
+++ b/apps/control-plane/src/components/app-shell.tsx
@@ -4,6 +4,7 @@ import { authErrorCode } from "../auth-error-code";
 import { authClient } from "../auth-client";
 import { resetBrowserAnalytics } from "../browser-analytics";
 import { BillingBanner } from "./billing-banner";
+import { ColorThemeToggle } from "./color-theme-toggle";
 
 interface AppShellProps {
   active: "agents" | "issues" | "settings";
@@ -141,6 +142,7 @@ export function AppShell({ active, children, density = "default" }: AppShellProp
           </nav>
         </div>
         <div className="globalHeader__right" ref={menuRef}>
+          <ColorThemeToggle className="globalThemeToggle" />
           <div className="accountMenu">
             <button
               aria-expanded={isMenuOpen}

--- a/apps/control-plane/src/components/application-error.tsx
+++ b/apps/control-plane/src/components/application-error.tsx
@@ -1,3 +1,5 @@
+import { ColorThemeToggle } from "./color-theme-toggle";
+
 interface ApplicationErrorProps {
   eventId?: string;
 }
@@ -5,6 +7,7 @@ interface ApplicationErrorProps {
 export function ApplicationError({ eventId }: ApplicationErrorProps) {
   return (
     <main className="authPage">
+      <ColorThemeToggle className="authThemeToggle" />
       <section className="authCard">
         <div className="authIntro">
           <h1>Something went wrong</h1>

--- a/apps/control-plane/src/components/auth-gate.tsx
+++ b/apps/control-plane/src/components/auth-gate.tsx
@@ -10,6 +10,7 @@ import { trackXSignupPixel } from "../x-pixel";
 import { workspaceSlug } from "./workspace";
 import { ImpersonationBanner } from "./impersonation-banner";
 import { ProviderGlyph } from "./icons";
+import { ColorThemeToggle } from "./color-theme-toggle";
 
 interface AuthGateProps {
   children: ReactNode;
@@ -18,6 +19,7 @@ interface AuthGateProps {
 function AuthFrame({ children }: AuthGateProps) {
   return (
     <main className="authPage">
+      <ColorThemeToggle className="authThemeToggle" />
       <section className="authCard">
         <div className="authBrand">
           <img alt="Superlog" draggable={false} src="/superlog-wordmark.svg" />

--- a/apps/control-plane/src/components/color-theme-toggle.tsx
+++ b/apps/control-plane/src/components/color-theme-toggle.tsx
@@ -1,0 +1,27 @@
+import { useColorTheme } from "../color-theme";
+
+export function ColorThemeToggle({ className }: { className: string }) {
+  const { theme, toggleTheme } = useColorTheme();
+  const nextTheme = theme === "dark" ? "light" : "dark";
+
+  return (
+    <button
+      aria-label={`Switch to ${nextTheme} mode`}
+      className={className}
+      onClick={toggleTheme}
+      title={`Switch to ${nextTheme} mode`}
+      type="button"
+    >
+      {theme === "dark" ? (
+        <svg aria-hidden="true" fill="none" viewBox="0 0 16 16">
+          <circle cx="8" cy="8" r="2.5" stroke="currentColor" />
+          <path d="M8 1.25v1.5M8 13.25v1.5M1.25 8h1.5M13.25 8h1.5M3.23 3.23l1.06 1.06M11.71 11.71l1.06 1.06M12.77 3.23l-1.06 1.06M4.29 11.71l-1.06 1.06" stroke="currentColor" strokeLinecap="round" />
+        </svg>
+      ) : (
+        <svg aria-hidden="true" fill="none" viewBox="0 0 16 16">
+          <path d="M12.9 10.2A5.5 5.5 0 0 1 5.8 3.1a5.5 5.5 0 1 0 7.1 7.1Z" stroke="currentColor" strokeLinejoin="round" />
+        </svg>
+      )}
+    </button>
+  );
+}

--- a/apps/control-plane/src/components/remediation-diff.tsx
+++ b/apps/control-plane/src/components/remediation-diff.tsx
@@ -2,12 +2,14 @@ import { parsePatchFiles } from "@pierre/diffs";
 import { FileDiff } from "@pierre/diffs/react";
 import { useMemo } from "react";
 import type { IssueRemediation } from "../agents-api";
+import { useColorTheme } from "../color-theme";
 
 export function RemediationDiff({
   remediation,
 }: {
   remediation: IssueRemediation & { type: "code_change" };
 }) {
+  const { theme } = useColorTheme();
   const files = useMemo(() => {
     try {
       return parsePatchFiles(
@@ -35,7 +37,7 @@ export function RemediationDiff({
             diffIndicators: "bars",
             diffStyle: "unified",
             overflow: "scroll",
-            themeType: "dark",
+            themeType: theme,
           }}
         />
       ))}

--- a/apps/control-plane/src/design-system/design-library.css
+++ b/apps/control-plane/src/design-system/design-library.css
@@ -25,7 +25,7 @@ html:has(.designLibraryPage) {
 
 .designLibraryHero h1 {
   margin: 0;
-  color: #fff;
+  color: var(--ds-text-primary);
   font-size: 33px;
   font-weight: 500;
   line-height: 45px;
@@ -35,7 +35,7 @@ html:has(.designLibraryPage) {
 .designLibraryHero > p:last-child {
   max-width: 560px;
   margin: 0;
-  color: #cacaca;
+  color: var(--ds-text-secondary);
   font-size: 14px;
   line-height: 21px;
   opacity: 0.5;
@@ -52,7 +52,7 @@ html:has(.designLibraryPage) {
   gap: 2px;
   border: 1px solid var(--ds-border-subtle);
   border-radius: var(--ds-radius-pill);
-  background: rgb(18 18 18 / 88%);
+  background: color-mix(in srgb, var(--ds-surface-raised) 88%, transparent);
   box-shadow: 0 8px 28px rgb(0 0 0 / 28%);
   backdrop-filter: blur(16px);
 }

--- a/apps/control-plane/src/design-system/design-system.css
+++ b/apps/control-plane/src/design-system/design-system.css
@@ -21,6 +21,16 @@
   --ds-warning: #cbb984;
   --ds-danger: #cf9793;
   --ds-info: #91afca;
+  --ds-positive-border: #33452f;
+  --ds-positive-surface: #11190f;
+  --ds-warning-border: #514525;
+  --ds-warning-surface: #1b170c;
+  --ds-danger-border: #563432;
+  --ds-danger-border-hover: #754945;
+  --ds-danger-surface: #1c1110;
+  --ds-danger-surface-hover: #251514;
+  --ds-info-border: #2d4050;
+  --ds-info-surface: #10171c;
   --ds-font-sans: "Inter Variable", Inter, ui-sans-serif, system-ui, -apple-system, sans-serif;
   --ds-radius-small: 10px;
   --ds-radius-medium: 16px;
@@ -31,6 +41,39 @@
   --shadow-xl:
     0 22px 36px -10px rgb(0 0 0 / 60%),
     0 8px 14px -8px rgb(0 0 0 / 46%);
+}
+
+:root[data-color-theme="light"] {
+  --ds-canvas: #fbfbf9;
+  --ds-surface-base: #efefeb;
+  --ds-surface-raised: #e5e5df;
+  --ds-surface-overlay: #efefeb;
+  --ds-surface-hover: #ddddd7;
+  --ds-border-subtle: #dfdfd9;
+  --ds-border-default: #d5d5cf;
+  --ds-border-top: #ffffff;
+  --ds-border-strong: #b9b9b2;
+  --ds-text-primary: #171715;
+  --ds-text-secondary: #41413d;
+  --ds-text-muted: #62625d;
+  --ds-text-disabled: #92928b;
+  --ds-positive: #3d6f31;
+  --ds-warning: #76580f;
+  --ds-danger: #a33f38;
+  --ds-info: #326b96;
+  --ds-positive-border: color-mix(in srgb, var(--ds-positive) 28%, var(--ds-border-default));
+  --ds-positive-surface: color-mix(in srgb, var(--ds-positive) 9%, var(--ds-surface-base));
+  --ds-warning-border: color-mix(in srgb, var(--ds-warning) 28%, var(--ds-border-default));
+  --ds-warning-surface: color-mix(in srgb, var(--ds-warning) 9%, var(--ds-surface-base));
+  --ds-danger-border: color-mix(in srgb, var(--ds-danger) 28%, var(--ds-border-default));
+  --ds-danger-border-hover: color-mix(in srgb, var(--ds-danger) 42%, var(--ds-border-default));
+  --ds-danger-surface: color-mix(in srgb, var(--ds-danger) 9%, var(--ds-surface-base));
+  --ds-danger-surface-hover: color-mix(in srgb, var(--ds-danger) 13%, var(--ds-surface-base));
+  --ds-info-border: color-mix(in srgb, var(--ds-info) 28%, var(--ds-border-default));
+  --ds-info-surface: color-mix(in srgb, var(--ds-info) 9%, var(--ds-surface-base));
+  --shadow-xl:
+    0 22px 36px -10px rgb(41 41 37 / 18%),
+    0 8px 14px -8px rgb(41 41 37 / 14%);
 }
 
 .dsVisuallyHidden {
@@ -105,11 +148,11 @@
 
 .dsButton--primary {
   background: var(--ds-text-primary);
-  color: #11110f;
+  color: var(--ds-canvas);
 }
 
 .dsButton--primary:hover:not(:disabled) {
-  background: #d9d9d5;
+  background: color-mix(in srgb, var(--ds-text-primary) 90%, var(--ds-canvas));
 }
 
 .dsButton--secondary {
@@ -134,14 +177,14 @@
 }
 
 .dsButton--danger {
-  border-color: #563432;
-  background: #1c1110;
+  border-color: var(--ds-danger-border);
+  background: var(--ds-danger-surface);
   color: var(--ds-danger);
 }
 
 .dsButton--danger:hover:not(:disabled) {
-  border-color: #754945;
-  background: #251514;
+  border-color: var(--ds-danger-border-hover);
+  background: var(--ds-danger-surface-hover);
 }
 
 .dsButton--small {
@@ -302,26 +345,26 @@
 }
 
 .dsBadge--live {
-  border-color: #33452f;
-  background: #11190f;
+  border-color: var(--ds-positive-border);
+  background: var(--ds-positive-surface);
   color: var(--ds-positive);
 }
 
 .dsBadge--warning {
-  border-color: #514525;
-  background: #1b170c;
+  border-color: var(--ds-warning-border);
+  background: var(--ds-warning-surface);
   color: var(--ds-warning);
 }
 
 .dsBadge--danger {
-  border-color: #563432;
-  background: #1c1110;
+  border-color: var(--ds-danger-border);
+  background: var(--ds-danger-surface);
   color: var(--ds-danger);
 }
 
 .dsBadge--info {
-  border-color: #2d4050;
-  background: #10171c;
+  border-color: var(--ds-info-border);
+  background: var(--ds-info-surface);
   color: var(--ds-info);
 }
 
@@ -695,7 +738,7 @@
 }
 
 .dsSegmentedControl__option[aria-checked="true"] {
-  background: #3b3b3b;
+  background: var(--ds-surface-hover);
   color: var(--ds-text-primary);
   box-shadow: 0 1px 3px rgb(0 0 0 / 28%);
 }

--- a/apps/control-plane/src/styles.css
+++ b/apps/control-plane/src/styles.css
@@ -11,6 +11,19 @@
   --live: #b8e6a3;
 }
 
+:root[data-color-theme="light"] {
+  --background: var(--ds-canvas);
+  --surface: var(--ds-surface-base);
+  --foreground: var(--ds-text-primary);
+  --secondary: var(--ds-text-secondary);
+  --muted: var(--ds-text-muted);
+  --dim: #85857f;
+  --border: var(--ds-border-default);
+  --border-strong: var(--ds-border-strong);
+  --border-logo: var(--ds-text-disabled);
+  --live: var(--ds-positive);
+}
+
 /* Keep the viewport around design-system shells on the same canvas color. */
 html:has(.appShell--settings),
 body:has(.appShell--settings),
@@ -325,18 +338,18 @@ body:has(.appShell--investigation) {
 }
 
 .appShell--settings .settingsNotice--success {
-  border-color: #33452f;
+  border-color: var(--ds-positive-border);
   color: var(--ds-positive);
 }
 
 .appShell--settings .settingsNotice--warning {
-  border-color: #66542d;
+  border-color: var(--ds-warning-border);
   color: var(--ds-warning);
 }
 
 .appShell--settings .settingsNotice--error,
 .appShell--settings .integrationMessage--error {
-  border-color: #563432;
+  border-color: var(--ds-danger-border);
   color: var(--ds-danger);
 }
 
@@ -392,9 +405,9 @@ body:has(.appShell--investigation) {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  border: 1px solid #33452f;
+  border: 1px solid var(--ds-positive-border);
   border-radius: var(--ds-radius-pill);
-  background: #11190f;
+  background: var(--ds-positive-surface);
   color: var(--ds-positive);
   font-size: 10px;
   line-height: 16px;
@@ -773,8 +786,8 @@ body:has(.appShell--investigation) {
 }
 
 .contextStoryboardStep.isComplete > span {
-  border-color: #33452f;
-  background: #11190f;
+  border-color: var(--ds-positive-border);
+  background: var(--ds-positive-surface);
   color: var(--ds-positive);
 }
 
@@ -954,8 +967,8 @@ body:has(.appShell--investigation) {
 }
 
 .contextStoryboardToggle[aria-checked="true"] > i {
-  border-color: #3f5738;
-  background: #1b2a17;
+  border-color: var(--ds-positive-border);
+  background: var(--ds-positive-surface);
 }
 
 .contextStoryboardToggle[aria-checked="true"] > i > i {
@@ -1481,6 +1494,10 @@ html {
   color-scheme: dark;
 }
 
+html[data-color-theme="light"] {
+  color-scheme: light;
+}
+
 body {
   min-height: 100vh;
   margin: 0;
@@ -1546,6 +1563,17 @@ button:disabled {
   width: auto;
   height: 20px;
   display: block;
+}
+
+:root[data-color-theme="light"] .authBrand img,
+:root[data-color-theme="light"] .brand img {
+  filter: invert(1);
+}
+
+.authThemeToggle {
+  position: fixed;
+  top: 32px;
+  right: 32px;
 }
 
 .authIntro {
@@ -1711,7 +1739,7 @@ button:disabled {
 
 .authError {
   margin: -4px 0 0;
-  color: #e7a4a4;
+  color: var(--ds-danger);
   font-size: 12px;
   line-height: 18px;
 }
@@ -1927,6 +1955,42 @@ button:disabled {
 
 .globalHeader__right {
   position: relative;
+  gap: 8px;
+}
+
+.globalThemeToggle,
+.authThemeToggle {
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  display: inline-grid;
+  flex: 0 0 auto;
+  place-items: center;
+  border: 1px solid var(--border);
+  border-radius: 50%;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  transition:
+    background-color 140ms ease,
+    border-color 140ms ease,
+    color 140ms ease;
+}
+
+.globalThemeToggle:hover,
+.globalThemeToggle:focus-visible,
+.authThemeToggle:hover,
+.authThemeToggle:focus-visible {
+  border-color: var(--border-strong);
+  background: var(--surface);
+  color: var(--foreground);
+  outline: none;
+}
+
+.globalThemeToggle svg,
+.authThemeToggle svg {
+  width: 15px;
+  height: 15px;
 }
 
 .statusDot {
@@ -1946,7 +2010,7 @@ button:disabled {
   flex: 0 0 auto;
   border: 1px solid var(--border-strong);
   border-radius: 50%;
-  background: #151515;
+  background: var(--surface);
   color: var(--secondary);
   cursor: pointer;
   font-size: 10px;
@@ -2022,7 +2086,7 @@ button:disabled {
   overflow: hidden;
   border: 1px solid var(--border-strong);
   border-radius: 8px;
-  background: #111;
+  background: var(--surface);
   box-shadow: 0 18px 50px rgb(0 0 0 / 45%);
 }
 
@@ -2086,7 +2150,7 @@ button:disabled {
 
 .accountPopover__item:hover,
 .accountPopover__item:focus-visible {
-  background: #1a1a1a;
+  background: var(--ds-surface-hover);
   color: var(--foreground);
   outline: none;
 }
@@ -2198,12 +2262,12 @@ button:disabled {
 
 .button--primary {
   background: var(--foreground);
-  color: #11110f;
+  color: var(--background);
 }
 
 .button--primary:hover,
 .button--primary:focus-visible {
-  background: #d9d9d5;
+  background: color-mix(in srgb, var(--foreground) 90%, var(--background));
 }
 
 .button--secondary {
@@ -2315,14 +2379,14 @@ button:disabled {
 }
 
 .issueTableSeverity--sev-1 {
-  border-color: #563432;
-  background: #1c1110;
+  border-color: var(--ds-danger-border);
+  background: var(--ds-danger-surface);
   color: var(--ds-danger);
 }
 
 .issueTableSeverity--sev-2 {
-  border-color: #514525;
-  background: #1b170c;
+  border-color: var(--ds-warning-border);
+  background: var(--ds-warning-surface);
   color: var(--ds-warning);
 }
 
@@ -3529,8 +3593,8 @@ button:disabled {
 }
 
 .traceTool--failed .traceTool__label code {
-  border-color: #754d49;
-  background: #211311;
+  border-color: var(--ds-danger-border);
+  background: var(--ds-danger-surface);
   color: var(--ds-danger);
 }
 
@@ -3806,8 +3870,8 @@ button:disabled {
 }
 
 .traceMessage--failure .traceMessage__avatar {
-  border-color: #754d49;
-  background: #211311;
+  border-color: var(--ds-danger-border);
+  background: var(--ds-danger-surface);
   color: var(--ds-danger);
 }
 
@@ -5272,7 +5336,7 @@ button:disabled {
 .integrationCard:hover,
 .integrationCard:focus-visible {
   border-color: var(--border-strong);
-  background: #111;
+  background: var(--ds-surface-hover);
   outline: none;
 }
 
@@ -5814,7 +5878,7 @@ button:disabled {
   gap: 14px;
   border: 1px solid var(--border-strong);
   border-radius: 8px;
-  background: #0b0b0b;
+  background: var(--surface);
 }
 
 .connectedSetup--channel {
@@ -6473,8 +6537,8 @@ button:disabled {
 }
 
 .contextIntegrationToggle[aria-checked="true"] > i {
-  border-color: #3f5738;
-  background: #1b2a17;
+  border-color: var(--ds-positive-border);
+  background: var(--ds-positive-surface);
 }
 
 .contextIntegrationToggle[aria-checked="true"] > i > i {
@@ -7092,8 +7156,8 @@ body:has(.appShell--create) {
 }
 
 .appShell--create .createStepperStep.isComplete .createStepperStep__marker {
-  border-color: #33452f;
-  background: #11190f;
+  border-color: var(--ds-positive-border);
+  background: var(--ds-positive-surface);
   color: var(--ds-positive);
 }
 
@@ -7247,7 +7311,7 @@ body:has(.appShell--create) {
 }
 
 .appShell--create .providerMark.isConnected {
-  border-color: #33452f;
+  border-color: var(--ds-positive-border);
   color: var(--ds-positive);
 }
 
@@ -7400,8 +7464,8 @@ body:has(.appShell--create) {
 }
 
 .appShell--create .repositoryConnectButton.isConnected {
-  border-color: #33452f;
-  background: #11190f;
+  border-color: var(--ds-positive-border);
+  background: var(--ds-positive-surface);
   color: var(--ds-positive);
 }
 
@@ -7534,10 +7598,22 @@ body:has(.appShell--create) {
   --issueFaint: #3e4045;
   --issueHairline: #212224;
   --issueRailValue: #e8e9eb;
+  --issueLink: #7e8cde;
   padding-top: 18px;
   display: flex;
   align-items: flex-start;
   gap: 0;
+}
+
+:root[data-color-theme="light"] .issueDetail {
+  --issueText: var(--ds-text-primary);
+  --issueBody: var(--ds-text-secondary);
+  --issueMuted: var(--ds-text-muted);
+  --issueDim: #787872;
+  --issueFaint: var(--ds-text-disabled);
+  --issueHairline: var(--ds-border-default);
+  --issueRailValue: color-mix(in srgb, var(--ds-text-primary) 90%, var(--ds-text-secondary));
+  --issueLink: #4b5aae;
 }
 
 .issueDetail__main {
@@ -7590,8 +7666,8 @@ body:has(.appShell--create) {
   display: inline-flex;
   align-items: center;
   border-radius: 4px;
-  background: #3a2f1c;
-  color: #e9a23b;
+  background: var(--ds-warning-surface);
+  color: var(--ds-warning);
   font-size: 11px;
   font-weight: 600;
   line-height: 14px;
@@ -8305,7 +8381,7 @@ body:has(.appShell--create) {
 
 .evidenceItem__body a {
   margin-top: 2px;
-  color: #7e8cde;
+  color: var(--issueLink);
   font-size: 12.5px;
   line-height: 16px;
 }
@@ -9361,5 +9437,133 @@ a.issueLine:focus-visible {
 @media (max-width: 760px) {
   .screenSkeleton__pipeline {
     grid-template-columns: 1fr;
+  }
+}
+
+/* Light-theme corrections for legacy surfaces that predate the shared tokens. */
+:root[data-color-theme="light"] .inviteForm input,
+:root[data-color-theme="light"] .inviteForm select,
+:root[data-color-theme="light"] .invitationLink input,
+:root[data-color-theme="light"] .memberRow select,
+:root[data-color-theme="light"] .memberAvatar,
+:root[data-color-theme="light"] .channelPicker__popover,
+:root[data-color-theme="light"] .configurationDialog {
+  background: var(--ds-surface-base);
+}
+
+:root[data-color-theme="light"] .siteDialog__instructions,
+:root[data-color-theme="light"] .siteDialog__site,
+:root[data-color-theme="light"] .siteDialog__field input,
+:root[data-color-theme="light"] .siteDialog__field select {
+  background: var(--ds-surface-raised);
+}
+
+:root[data-color-theme="light"] .channelPicker__popover > input {
+  background: var(--ds-canvas);
+}
+
+:root[data-color-theme="light"] .billingProgress,
+:root[data-color-theme="light"] .toggle::after {
+  background: var(--ds-surface-hover);
+}
+
+:root[data-color-theme="light"] .issueCallout,
+:root[data-color-theme="light"] .remediationCard,
+:root[data-color-theme="light"] .remediationPullRequest,
+:root[data-color-theme="light"] .remediationActivity,
+:root[data-color-theme="light"] .remediationReviewTrace__timeline .traceTool__data pre,
+:root[data-color-theme="light"] .remediationReviewTrace__timeline .traceMessage--assistant,
+:root[data-color-theme="light"] .remediationDiff__file,
+:root[data-color-theme="light"] .remediationDiff__loading,
+:root[data-color-theme="light"] .remediationDiff__fallback,
+:root[data-color-theme="light"] .remediationPrompt pre {
+  border-color: var(--ds-border-default);
+  background: var(--ds-surface-base);
+}
+
+:root[data-color-theme="light"] .remediationCard__kind,
+:root[data-color-theme="light"] .remediationActivity__count,
+:root[data-color-theme="light"] .evidenceGlyph,
+:root[data-color-theme="light"] .evidenceGlyph--clickstack,
+:root[data-color-theme="light"] a.issueLine:hover,
+:root[data-color-theme="light"] .issueLine__action {
+  border-color: var(--ds-border-default);
+  background: var(--ds-surface-hover);
+  color: var(--issueMuted);
+}
+
+:root[data-color-theme="light"] .remediationPullRequest:hover,
+:root[data-color-theme="light"] .issueLine__action:hover {
+  border-color: var(--ds-border-strong);
+  background: var(--ds-surface-raised);
+  color: var(--issueText);
+}
+
+:root[data-color-theme="light"] .remediationActivity__marker {
+  background: var(--ds-surface-base);
+}
+
+:root[data-color-theme="light"] .remediationCard__kind--code_change,
+:root[data-color-theme="light"] .remediationPullRequest__icon,
+:root[data-color-theme="light"] .remediationPullRequest__state {
+  background: var(--ds-positive-surface);
+  color: var(--ds-positive);
+}
+
+:root[data-color-theme="light"] .remediationCard__kind--external_action,
+:root[data-color-theme="light"] .remediationPullRequest__icon--merged,
+:root[data-color-theme="light"] .remediationPullRequest__state--merged {
+  background: #eeeafb;
+  color: #6652ad;
+}
+
+:root[data-color-theme="light"] .evidenceGlyph--sentry {
+  background: #f5eafa;
+  color: #8b4aa1;
+}
+
+:root[data-color-theme="light"] .evidenceGlyph--datadog {
+  background: #e7f1f8;
+  color: #326b96;
+}
+
+:root[data-color-theme="light"] .issueCallout p,
+:root[data-color-theme="light"] .remediationDiff__fallback,
+:root[data-color-theme="light"] .remediationPrompt pre {
+  color: var(--issueBody);
+}
+
+:root[data-color-theme="light"] .issueRail__title {
+  color: var(--issueText);
+}
+
+@media (max-width: 620px) {
+  .authThemeToggle {
+    top: 18px;
+    right: 18px;
+  }
+}
+
+@media (max-width: 440px) {
+  .globalHeader .brand {
+    display: none;
+  }
+
+  .globalHeader__left {
+    gap: 0;
+  }
+
+  .primaryNav {
+    gap: 14px;
+    font-size: 12px;
+  }
+
+  .globalHeader__right {
+    gap: 4px;
+  }
+
+  .globalThemeToggle {
+    width: 30px;
+    height: 30px;
   }
 }


### PR DESCRIPTION
## Summary
- add a persistent light/dark theme shared across authentication, application, and hosted marketing pages
- add light design-system tokens and legacy surface corrections
- make remediation diffs follow the selected theme

## Hosted overlay
- Companion PR: superloglabs/responder#156
- Merge this public application PR first

## Validation
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test` (826 tests)
- `pnpm build:app`
- browser checks across app, homepage, blog, pricing, and configuration dialogs