### PR TITLE
Materialize repository submodules for investigations

### DIFF
--- a/apps/worker/src/repositories.test.ts
+++ b/apps/worker/src/repositories.test.ts
@@ -1,7 +1,9 @@
 import type { DaytonaSandboxSession } from "@openai/agents-extensions/sandbox/daytona";
+import { execFile } from "node:child_process";
 import { access, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { promisify } from "node:util";
 import { describe, expect, it, vi } from "vitest";
 import {
   checkoutRuntimeRepositories,
@@ -10,6 +12,7 @@ import {
 } from "./repositories.js";
 
 const sha = "a".repeat(40);
+const execFileAsync = promisify(execFile);
 
 function fakeSession() {
   return {
@@ -24,12 +27,19 @@ function uploadArchive() {
   return vi.fn().mockResolvedValue(undefined);
 }
 
+function missingGitmodules() {
+  return new Response(null, { status: 404 });
+}
+
 describe("Daytona repository checkout", () => {
   it("downloads an exact pull request head without resolving the default branch", async () => {
     const session = fakeSession();
-    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
-      new Response(new Uint8Array([31, 139, 8, 0]), { status: 200 }),
-    );
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(missingGitmodules())
+      .mockResolvedValueOnce(
+        new Response(new Uint8Array([31, 139, 8, 0]), { status: 200 }),
+      );
 
     await expect(
       checkoutRuntimeRepositoriesAtRefs(
@@ -55,7 +65,7 @@ describe("Daytona repository checkout", () => {
     ).resolves.toEqual([
       expect.objectContaining({ branch: "fix/review", sha }),
     ]);
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(fetchMock).toHaveBeenCalledWith(
       `https://api.github.com/repos/example-org/example-repo/tarball/${sha}`,
       expect.anything(),
@@ -73,6 +83,7 @@ describe("Daytona repository checkout", () => {
           status: 200,
         }),
       )
+      .mockResolvedValueOnce(missingGitmodules())
       .mockResolvedValueOnce(
         new Response(new Uint8Array([31, 139, 8, 0]), { status: 200 }),
       );
@@ -123,6 +134,115 @@ describe("Daytona repository checkout", () => {
     );
   });
 
+  it("uses an exact Git checkout when the parent commit declares submodules", async () => {
+    const session = fakeSession();
+    const downloadWithGit = vi.fn().mockResolvedValue({ sha });
+
+    await expect(
+      checkoutRuntimeRepositories(session, "version-id", {
+        createInstallationToken: vi.fn().mockResolvedValue("github-secret"),
+        downloadWithGit,
+        fetch: vi
+          .fn<typeof fetch>()
+          .mockResolvedValueOnce(
+            new Response(JSON.stringify({ sha }), { status: 200 }),
+          )
+          .mockResolvedValueOnce(new Response(null, { status: 200 })),
+        getRepositories: vi.fn().mockResolvedValue([
+          {
+            defaultBranch: "main",
+            fullName: "example-org/example-repo",
+            installationId: 123,
+            private: true,
+          },
+        ]),
+        uploadArchive: uploadArchive(),
+      }),
+    ).resolves.toEqual([
+      expect.objectContaining({
+        repository: "example-org/example-repo",
+        sha,
+      }),
+    ]);
+    expect(downloadWithGit).toHaveBeenCalledWith(
+      expect.objectContaining({ fullName: "example-org/example-repo" }),
+      "github-secret",
+      sha,
+      expect.any(String),
+      5 * 1024 * 1024 * 1024,
+    );
+  });
+
+  it("archives recursively materialized submodule files without Git metadata", async () => {
+    const session = fakeSession();
+    const temporaryDirectory = await mkdtemp(
+      join(tmpdir(), "responder-submodule-checkout-test-"),
+    );
+    const binDirectory = join(temporaryDirectory, "bin");
+    const gitPath = join(binDirectory, "git");
+    const callsPath = join(temporaryDirectory, "git-calls");
+    const authPath = join(temporaryDirectory, "git-auth");
+    let uploadedEntries = "";
+    await mkdir(binDirectory);
+    await writeFile(
+      gitPath,
+      [
+        "#!/bin/sh",
+        "printf '%s\\n' \"$*\" >> \"$RESPONDER_TEST_GIT_CALLS\"",
+        "case \" $* \" in",
+        "  *\" fetch \"*) printf '%s\\n' \"$GIT_CONFIG_VALUE_0\" > \"$RESPONDER_TEST_GIT_AUTH\" ;;",
+        "  *\" rev-parse \"*) printf '%s\\n' \"$RESPONDER_TEST_GIT_SHA\" ;;",
+        "  *\" ls-tree \"*) printf '.gitmodules\\n' ;;",
+        "  *\" worktree add \"*)",
+        "    for argument do destination=\"${previous:-}\"; previous=\"$argument\"; done",
+        "    mkdir -p \"$destination/.git\" \"$destination/open-core\"",
+        "    printf 'pinned source\\n' > \"$destination/open-core/app.ts\"",
+        "    ;;",
+        "esac",
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+    vi.stubEnv("PATH", `${binDirectory}:${process.env.PATH ?? ""}`);
+    vi.stubEnv("RESPONDER_TEST_GIT_AUTH", authPath);
+    vi.stubEnv("RESPONDER_TEST_GIT_CALLS", callsPath);
+    vi.stubEnv("RESPONDER_TEST_GIT_SHA", sha);
+
+    try {
+      await checkoutRuntimeRepositories(session, "version-id", {
+        createInstallationToken: vi.fn().mockResolvedValue("github-secret"),
+        fetch: vi.fn<typeof fetch>().mockRejectedValue(new Error("offline")),
+        getRepositories: vi.fn().mockResolvedValue([
+          {
+            defaultBranch: "main",
+            fullName: "example-org/example-repo",
+            installationId: 123,
+            private: true,
+          },
+        ]),
+        temporaryDirectory,
+        uploadArchive: vi.fn(async (_session, localPath) => {
+          const { stdout } = await execFileAsync("tar", ["-tzf", localPath]);
+          uploadedEntries = stdout;
+        }),
+      });
+
+      expect(uploadedEntries).toContain("./open-core/app.ts");
+      expect(uploadedEntries).not.toMatch(/(?:^|\/)\.git(?:\/|$)/m);
+      const gitCalls = await readFile(callsPath, "utf8");
+      expect(gitCalls).toContain(
+        "submodule update --init --recursive --depth=1",
+      );
+      expect(await readFile(authPath, "utf8")).toBe(
+        `Authorization: Basic ${Buffer.from(
+          "x-access-token:github-secret",
+        ).toString("base64")}\n`,
+      );
+    } finally {
+      vi.unstubAllEnvs();
+      await rm(temporaryDirectory, { force: true, recursive: true });
+    }
+  });
+
   it.each([429, 503])(
     "falls back to an exact Git fetch when the archive host returns %i",
     async (status) => {
@@ -141,6 +261,7 @@ describe("Daytona repository checkout", () => {
             status: 200,
           }),
         )
+        .mockResolvedValueOnce(missingGitmodules())
         .mockResolvedValueOnce(
           new Response("temporarily unavailable", { status }),
         );
@@ -264,6 +385,7 @@ describe("Daytona repository checkout", () => {
           status: 200,
         }),
       )
+      .mockResolvedValueOnce(missingGitmodules())
       .mockRejectedValueOnce(new DOMException("Timed out", "AbortError"));
 
     await expect(
@@ -299,6 +421,7 @@ describe("Daytona repository checkout", () => {
       .mockResolvedValueOnce(
         new Response(JSON.stringify({ sha }), { status: 200 }),
       )
+      .mockResolvedValueOnce(missingGitmodules())
       .mockResolvedValueOnce(
         new Response(new Uint8Array([31, 139, 8, 0]), {
           headers: { "content-length": String(101 * 1024 * 1024) },
@@ -345,6 +468,7 @@ describe("Daytona repository checkout", () => {
       .mockResolvedValueOnce(
         new Response(JSON.stringify({ sha }), { status: 200 }),
       )
+      .mockResolvedValueOnce(missingGitmodules())
       .mockResolvedValueOnce(new Response(archive, { status: 200 }));
 
     await expect(
@@ -365,12 +489,13 @@ describe("Daytona repository checkout", () => {
     ).rejects.toThrow("GitHub repository archive exceeds the 4 bytes limit");
   });
 
-  it("stops Git archive generation as soon as the disk-safety limit is crossed", async () => {
+  it("stops fallback archive generation as soon as the disk-safety limit is crossed", async () => {
     const temporaryDirectory = await mkdtemp(
       join(tmpdir(), "responder-git-limit-test-"),
     );
     const binDirectory = join(temporaryDirectory, "bin");
     const gitPath = join(binDirectory, "git");
+    const tarPath = join(binDirectory, "tar");
     const completionMarker = join(temporaryDirectory, "archive-completed");
     await mkdir(binDirectory);
     await writeFile(
@@ -379,13 +504,22 @@ describe("Daytona repository checkout", () => {
         "#!/bin/sh",
         "case \" $* \" in",
         "  *\" rev-parse \"*) printf '%s\\n' \"$RESPONDER_TEST_GIT_SHA\" ;;",
-        "  *\" archive \"*)",
-        "    printf '12345'",
-        "    sleep 1",
-        "    : > \"$RESPONDER_TEST_GIT_COMPLETED\"",
-        "    printf '6789'",
+        "  *\" worktree add \"*)",
+        "    for argument do destination=\"${previous:-}\"; previous=\"$argument\"; done",
+        "    mkdir -p \"$destination\"",
         "    ;;",
         "esac",
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+    await writeFile(
+      tarPath,
+      [
+        "#!/bin/sh",
+        "printf '12345'",
+        "sleep 1",
+        ": > \"$RESPONDER_TEST_GIT_COMPLETED\"",
+        "printf '6789'",
       ].join("\n"),
       { mode: 0o755 },
     );

--- a/apps/worker/src/repositories.ts
+++ b/apps/worker/src/repositories.ts
@@ -120,14 +120,22 @@ const defaultDependencies: RepositoryCheckoutDependencies = {
   getRepositories: getRuntimeRepositories,
 };
 
-async function writeGitArchiveWithLimit(
-  gitDirectory: string,
+async function writeRepositoryArchiveWithLimit(
+  repositoryDirectory: string,
   archivePath: string,
   archiveLimitBytes: number,
 ): Promise<void> {
   const archiveProcess = spawn(
-    "git",
-    ["-C", gitDirectory, "archive", "--format=tar.gz", "FETCH_HEAD"],
+    "tar",
+    [
+      "-czf",
+      "-",
+      "--exclude=.git",
+      "--exclude=*/.git",
+      "-C",
+      repositoryDirectory,
+      ".",
+    ],
     {
       killSignal: "SIGKILL",
       stdio: ["ignore", "pipe", "ignore"],
@@ -143,7 +151,7 @@ async function writeGitArchiveWithLimit(
       }
       reject(
         new Error(
-          `Git archive exited with ${signal ? `signal ${signal}` : `code ${code ?? "unknown"}`}`,
+          `Tar exited with ${signal ? `signal ${signal}` : `code ${code ?? "unknown"}`}`,
         ),
       );
     });
@@ -175,13 +183,22 @@ async function downloadRepositorySnapshotWithGit(
 ): Promise<{ sha: string }> {
   const temporaryRoot = dirname(archivePath);
   const gitDirectory = join(temporaryRoot, "repository.git");
+  const checkoutDirectory = join(temporaryRoot, "repository");
   const gitEnvironment = {
     ...process.env,
-    GIT_CONFIG_COUNT: "1",
-    GIT_CONFIG_KEY_0: "http.extraHeader",
-    GIT_CONFIG_VALUE_0: `Authorization: Bearer ${accessToken}`,
+    GIT_ALLOW_PROTOCOL: "https",
+    GIT_CONFIG_COUNT: "3",
+    GIT_CONFIG_KEY_0: "http.https://github.com/.extraHeader",
+    GIT_CONFIG_VALUE_0: `Authorization: Basic ${Buffer.from(
+      `x-access-token:${accessToken}`,
+    ).toString("base64")}`,
+    GIT_CONFIG_KEY_1: "url.https://github.com/.insteadOf",
+    GIT_CONFIG_VALUE_1: "git@github.com:",
+    GIT_CONFIG_KEY_2: "url.https://github.com/.insteadOf",
+    GIT_CONFIG_VALUE_2: "ssh://git@github.com/",
     GIT_TERMINAL_PROMPT: "0",
   };
+  const repositoryUrl = `https://github.com/${repository.fullName}.git`;
 
   try {
     await mkdir(gitDirectory);
@@ -196,7 +213,7 @@ async function downloadRepositorySnapshotWithGit(
         "remote",
         "add",
         "origin",
-        `https://github.com/${repository.fullName}.git`,
+        repositoryUrl,
       ],
       { timeout: 30_000 },
     );
@@ -222,8 +239,39 @@ async function downloadRepositorySnapshotWithGit(
     if (!/^[a-f0-9]{40}$/i.test(sha)) {
       throw new Error("Git returned an invalid repository commit");
     }
-    await writeGitArchiveWithLimit(
-      gitDirectory,
+
+    await execFileAsync(
+      "git",
+      [
+        "-C",
+        gitDirectory,
+        "worktree",
+        "add",
+        "--quiet",
+        "--detach",
+        checkoutDirectory,
+        sha,
+      ],
+      {
+        env: gitEnvironment,
+        timeout: repositoryDownloadTimeoutMs,
+      },
+    );
+    await execFileAsync(
+      "git",
+      [
+        "-C",
+        checkoutDirectory,
+        "submodule",
+        "update",
+        "--init",
+        "--recursive",
+        "--depth=1",
+      ],
+      { env: gitEnvironment, timeout: repositoryDownloadTimeoutMs },
+    );
+    await writeRepositoryArchiveWithLimit(
+      checkoutDirectory,
       archivePath,
       archiveLimitBytes,
     );
@@ -332,6 +380,31 @@ function shouldUseGitFallback(response: Response): boolean {
   );
 }
 
+async function repositoryUsesSubmodules(
+  repository: RuntimeRepository,
+  sha: string,
+  accessToken: string,
+  fetchImpl: typeof fetch,
+): Promise<boolean> {
+  let response: Response;
+  try {
+    response = await fetchImpl(
+      `https://api.github.com/repos/${repository.fullName}/contents/.gitmodules?ref=${sha}`,
+      {
+        headers: githubAppHeaders(accessToken),
+        signal: AbortSignal.timeout(30_000),
+      },
+    );
+  } catch {
+    return true;
+  }
+  await response.body?.cancel();
+  if (response.ok) return true;
+  if (response.status === 404) return false;
+  if (shouldUseGitFallback(response)) return true;
+  throw new Error(`Unable to inspect ${repository.fullName}@${sha} for submodules`);
+}
+
 async function downloadExactSnapshotWithGit(
   repository: RuntimeRepository,
   accessToken: string,
@@ -412,6 +485,24 @@ async function fetchRepositorySnapshot(
       );
     }
     sha = commit.sha;
+  }
+
+  if (
+    await repositoryUsesSubmodules(
+      repository,
+      sha,
+      accessToken,
+      fetchImpl,
+    )
+  ) {
+    return downloadExactSnapshotWithGit(
+      repository,
+      accessToken,
+      sha,
+      archivePath,
+      archiveLimitBytes,
+      downloadWithGit,
+    );
   }
 
   let archiveResponse: Response;


### PR DESCRIPTION
## Summary

- detect repositories that declare submodules before downloading their source snapshot
- materialize pinned submodules recursively in the host-side checkout
- archive the complete source tree without Git metadata or exposing repository credentials to the sandbox
- use Git-compatible authentication for private repository fallback checkouts

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
- live exact-SHA checkout with a pinned submodule

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detects repositories that declare submodules and materializes them recursively in the host-side checkout so investigation sandboxes receive the complete source tree.

- Checks `.gitmodules` at the pinned SHA before downloading an archive; when present, uses a Git checkout instead.
- Runs `submodule update --init --recursive --depth=1` with Git-compatible Basic auth, rewriting SSH submodule URLs to HTTPS so private submodules authenticate without exposing tokens to the sandbox.
- Archives the working tree with `tar --exclude=.git` rather than `git archive`, preserving submodule files and stripping Git metadata.

<sup>Written for commit 6a290e5c163464eae9aa51e8cb737b5c1255ba87. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/responder-oss/pull/68?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

