### PR TITLE
Fix settings integrations scrolling

### DIFF
--- a/apps/control-plane/e2e/settings-scroll.spec.ts
+++ b/apps/control-plane/e2e/settings-scroll.spec.ts
@@ -1,0 +1,112 @@
+import { expect, test, type Page } from "@playwright/test";
+
+const organization = {
+  id: "11111111-1111-4111-8111-111111111111",
+  name: "Acme",
+  slug: "acme-workspace-id",
+  createdAt: new Date().toISOString(),
+  logo: null,
+  metadata: null,
+};
+
+const user = {
+  id: "22222222-2222-4222-8222-222222222222",
+  name: "Ada Lovelace",
+  email: "ada@example.com",
+  emailVerified: true,
+  image: null,
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+};
+
+const providers = [
+  ["github", "GitHub"],
+  ["slack", "Slack"],
+  ["aws", "AWS"],
+  ["sentry", "Sentry"],
+  ["datadog", "Datadog"],
+  ["axiom", "Axiom"],
+  ["upstash", "Upstash"],
+  ["langfuse", "Langfuse"],
+  ["linear", "Linear"],
+  ["vercel", "Vercel"],
+  ["custom_mcp", "Custom MCP"],
+  ["clickstack", "ClickStack"],
+] as const;
+
+async function mockSettingsApis(page: Page) {
+  await page.route("**/api/auth/**", async (route) => {
+    const path = new URL(route.request().url()).pathname;
+
+    if (path.endsWith("/get-session")) {
+      await route.fulfill({
+        json: {
+          session: {
+            id: "session-id",
+            userId: user.id,
+            activeOrganizationId: organization.id,
+            token: "session-token",
+            expiresAt: new Date(Date.now() + 60_000).toISOString(),
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+          },
+          user,
+        },
+      });
+      return;
+    }
+
+    if (path.endsWith("/organization/list")) {
+      await route.fulfill({ json: [organization] });
+      return;
+    }
+
+    if (path.endsWith("/organization/get-full-organization")) {
+      await route.fulfill({ json: organization });
+      return;
+    }
+
+    await route.fulfill({ json: null });
+  });
+  await page.route("**/api/integrations", (route) =>
+    route.fulfill({
+      json: {
+        integrations: providers.map(([id, name]) => ({
+          id,
+          name,
+          description: `Connect ${name} to Responder.`,
+          state: "available",
+          accountCount: 0,
+          resourceCount: 0,
+          accounts: [],
+          connectUrl: `/api/integrations/${id}/start`,
+          configurationUrl: null,
+        })),
+      },
+    }),
+  );
+  await page.route("**/api/billing", (route) =>
+    route.fulfill({
+      json: {
+        configured: false,
+        enabled: false,
+        payAsYouGo: false,
+        remaining: 0,
+      },
+    }),
+  );
+}
+
+test("scrolls to integrations below the viewport", async ({ page }) => {
+  await mockSettingsApis(page);
+  await page.setViewportSize({ width: 1280, height: 720 });
+  await page.goto("/settings");
+
+  const lastIntegration = page.getByRole("button", { name: /ClickStack/ });
+  await expect(lastIntegration).not.toBeInViewport();
+
+  await page.mouse.wheel(0, 2_000);
+
+  await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThan(0);
+  await expect(lastIntegration).toBeInViewport();
+});

--- a/apps/control-plane/src/styles.css
+++ b/apps/control-plane/src/styles.css
@@ -5135,7 +5135,7 @@ button:disabled {
 .integrationBento {
   min-height: 0;
   display: flex;
-  flex: 1 1 0;
+  flex: none;
   flex-direction: column;
   gap: 20px;
 }


### PR DESCRIPTION
## Summary

- let the integrations section establish the settings page height
- add a browser regression that scrolls to the final integration at a 1280×720 viewport

## Testing

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test` (828 tests)
- full browser suite (6 tests)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the settings page so all integrations are reachable on shorter viewports. The integrations section previously stretched to fill the viewport height, clipping the bottom providers; it now keeps its natural height so the page scrolls correctly.

**Regression test**
- Adds a Playwright test that verifies scrolling reaches the final integration at a 1280×720 viewport.

<sup>Written for commit 6e4e63916e1c3a8093b4e14be93c76fb4c5ed530. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/responder-oss/pull/69?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

