### PR TITLE
Fix remediation pull request recovery

### DIFF
--- a/apps/control-plane/src/pages/issue-detail.tsx
+++ b/apps/control-plane/src/pages/issue-detail.tsx
@@ -546,6 +546,8 @@ export function IssueDetailPage() {
                   (request.status === "created" || request.status === "merged")
                     ? request
                     : null;
+                const failedPullRequest =
+                  request?.status === "failed" ? request : null;
                 return (
                   <article
                     className="remediationCard"
@@ -623,23 +625,32 @@ export function IssueDetailPage() {
                     {remediation.type === "code_change" && publishedPullRequest ? null : (
                       <div className="remediationCard__actions">
                         {remediation.type === "code_change" ? (
-                          request &&
-                          ["queued", "creating"].includes(request.status) ? (
-                            <span className="remediationCard__status">
-                              Opening pull request…
-                            </span>
-                          ) : detail.pullRequestState.canCreate ? (
-                            <Button
-                              loading={pullRequestPending === remediation.id}
-                              onClick={() => void createPullRequest(remediation.id)}
-                              size="small"
-                              variant="primary"
-                            >
-                              {pullRequestPending === remediation.id
-                                ? "Starting…"
-                                : "Open pull request"}
-                            </Button>
-                          ) : null
+                          <>
+                            {failedPullRequest?.failureReason ? (
+                              <span className="remediationCard__failure">
+                                {failedPullRequest.failureReason}
+                              </span>
+                            ) : null}
+                            {request &&
+                            ["queued", "creating"].includes(request.status) ? (
+                              <span className="remediationCard__status">
+                                Opening pull request…
+                              </span>
+                            ) : detail.pullRequestState.canCreate ? (
+                              <Button
+                                loading={pullRequestPending === remediation.id}
+                                onClick={() => void createPullRequest(remediation.id)}
+                                size="small"
+                                variant="primary"
+                              >
+                                {pullRequestPending === remediation.id
+                                  ? "Starting…"
+                                  : failedPullRequest
+                                    ? "Retry pull request"
+                                    : "Open pull request"}
+                              </Button>
+                            ) : null}
+                          </>
                         ) : (
                           <Button
                             aria-live="polite"

--- a/apps/control-plane/src/styles.css
+++ b/apps/control-plane/src/styles.css
@@ -8219,7 +8219,15 @@ body:has(.appShell--create) {
   min-height: 30px;
   display: flex;
   align-items: center;
+  gap: 12px;
   justify-content: flex-end;
+}
+
+.remediationCard__failure {
+  margin-right: auto;
+  color: #f29a9a;
+  font-size: 12px;
+  line-height: 16px;
 }
 
 .remediationCard__status {

--- a/apps/worker/src/pull-request.test.ts
+++ b/apps/worker/src/pull-request.test.ts
@@ -100,6 +100,7 @@ describe("pull request tool", () => {
       investigationId: "16161616-1616-4616-8616-161616161616",
       organizationId: "15151515-1515-4515-8515-151515151515",
       pullRequestRequestId: requestId,
+      repositories: manifest.repositories,
       session,
     });
 
@@ -139,6 +140,38 @@ describe("pull request tool", () => {
       }),
       session,
     );
+  });
+
+  it("rejects repository names outside the configured checkouts", async () => {
+    const pullRequestTool = createPullRequestTool({
+      agentConfigVersionId: "08080808-0808-4808-8808-080808080808",
+      investigationId: "16161616-1616-4616-8616-161616161616",
+      organizationId: "15151515-1515-4515-8515-151515151515",
+      repositories: [
+        {
+          branch: "main",
+          path: "/home/daytona/workspace/repositories/acme/service",
+          repository: "acme/service",
+          sha: "a".repeat(40),
+          workspaceBaseSha: "b".repeat(40),
+        },
+      ],
+      session: {} as DaytonaSandboxSession,
+    });
+
+    await expect(
+      pullRequestTool.invoke(
+        undefined as never,
+        JSON.stringify({
+          issueId: "12121212-1212-4212-8212-121212121212",
+          repository: "acme/other-service",
+          failureMechanism: "A missing value made the page stop loading.",
+          summary: "Handle the unchecked value.",
+          testing: "Added a regression test.",
+        }),
+      ),
+    ).resolves.toContain("Invalid JSON input for tool");
+    expect(getExecutableIssuePullRequest).not.toHaveBeenCalled();
   });
 
   it("builds a Responder issue URL only when an app origin is configured", () => {

--- a/apps/worker/src/pull-request.ts
+++ b/apps/worker/src/pull-request.ts
@@ -17,18 +17,7 @@ import {
   buildPullRequestBody,
   createPullRequestFromSandbox,
 } from "./github-pull-request.js";
-
-const checkedOutRepositoriesSchema = z.object({
-  repositories: z.array(
-    z.object({
-      branch: z.string().min(1),
-      path: z.string().min(1),
-      repository: z.string().min(1),
-      sha: z.string().regex(/^[a-f0-9]{40}$/i),
-      workspaceBaseSha: z.string().regex(/^[a-f0-9]{40}$/i),
-    }),
-  ),
-});
+import type { CheckedOutRepository } from "./repositories.js";
 
 export function responderIssueUrl(
   issueId: string,
@@ -71,15 +60,26 @@ export function createPullRequestTool(input: {
   investigationId: string;
   organizationId: string;
   pullRequestRequestId?: string;
+  repositories: CheckedOutRepository[];
   session: DaytonaSandboxSession;
 }) {
+  const configuredRepositoryNames = [
+    ...new Set(input.repositories.map(({ repository }) => repository)),
+  ];
+  if (configuredRepositoryNames.length === 0) {
+    throw new Error("No repositories are configured for this agent");
+  }
+  const repositorySchema = z
+    .enum(configuredRepositoryNames as [string, ...string[]])
+    .describe(`One of: ${configuredRepositoryNames.join(", ")}`);
+
   return tool({
     name: "create_pull_request",
     description:
       "Create a GitHub pull request from changes made in one selected repository. Call this only after the report tool returns the matching issue ID, or when this run explicitly asks for that issue to be fixed.",
     parameters: z.object({
       issueId: z.uuid(),
-      repository: z.string().min(1),
+      repository: repositorySchema,
       failureMechanism: z
         .string()
         .trim()
@@ -116,13 +116,7 @@ export function createPullRequestTool(input: {
           throw new Error("The selected repository is not configured for this agent");
         }
 
-        const manifestBytes = await input.session.readFile({
-          path: "/home/daytona/workspace/.responder/repositories.json",
-        });
-        const manifest = checkedOutRepositoriesSchema.parse(
-          JSON.parse(new TextDecoder().decode(manifestBytes)),
-        );
-        const checkout = manifest.repositories.find(
+        const checkout = input.repositories.find(
           (candidate) => candidate.repository === requestedPullRequest.repository,
         );
         if (!checkout) throw new Error("The selected repository is not checked out");

--- a/apps/worker/src/remediate.ts
+++ b/apps/worker/src/remediate.ts
@@ -202,6 +202,7 @@ export async function runRemediationAgent(
       investigationId: job.investigationId,
       organizationId: job.config.organizationId,
       pullRequestRequestId: job.remediationRequestId,
+      repositories,
       session,
     });
     const agent = new SandboxAgent({
@@ -221,6 +222,7 @@ export async function runRemediationAgent(
           ? "Use the proposed diff as the starting point. Verify it against the current checkout, adjust it when needed, make the smallest safe fix in exactly one selected repository, and run the narrowest useful checks."
           : "Inspect the relevant code, make the smallest safe fix in exactly one selected repository, and run the narrowest useful checks.",
         remediationFailureMechanismInstruction,
+        "Call create_pull_request with exactly one of the selected repository names shown above.",
         `Then call create_pull_request with issue ID ${job.issue.id}. Do not finish without creating the pull request or clearly explaining why no safe code fix is possible.`,
         "Do not expose credentials or secret values. The pull request is the only allowed external change.",
         workspaceSecretUsageInstructions(workspaceSecrets),

--- a/packages/core/src/db/pull-requests.test.ts
+++ b/packages/core/src/db/pull-requests.test.ts
@@ -44,16 +44,22 @@ function simpleSelect(
   };
 }
 
-function joinedSelect(rows: unknown[]) {
+function joinedSelect(
+  rows: unknown[],
+  where = vi.fn(() => ({
+    orderBy: vi.fn(() => ({ limit: vi.fn().mockResolvedValue(rows) })),
+  })),
+) {
   const limit = vi.fn().mockResolvedValue(rows);
+  where.mockImplementation(() => ({
+    orderBy: vi.fn(() => ({ limit })),
+  }));
   const joined = {
     innerJoin: vi.fn(),
-    where: vi.fn(() => ({
-      orderBy: vi.fn(() => ({ limit })),
-    })),
+    where,
   };
   joined.innerJoin.mockReturnValue(joined);
-  return { from: vi.fn(() => joined) };
+  return { from: vi.fn(() => joined), where };
 }
 
 function databaseDouble(
@@ -72,16 +78,19 @@ function databaseDouble(
     .fn()
     .mockResolvedValueOnce({ rows: [{ available: activeIndexAvailable }] })
     .mockResolvedValue({ rows: [] });
+  const eligibilityWhere = vi.fn();
   const transaction = vi.fn(async (callback) => {
+    const eligible = joinedSelect(
+      [{ investigationId, agentConfigVersionId }],
+      eligibilityWhere,
+    );
     const select = vi
       .fn()
       .mockReturnValueOnce(
         simpleSelect([{ id: issueId, remediations: [codeRemediation] }]),
       )
       .mockReturnValueOnce(simpleSelect(options.existing ?? [], existingLimit))
-      .mockReturnValueOnce(
-        joinedSelect([{ investigationId, agentConfigVersionId }]),
-      );
+      .mockReturnValueOnce(eligible);
     return callback({
       execute,
       insert: vi.fn(() => ({ values })),
@@ -89,7 +98,13 @@ function databaseDouble(
     });
   });
   vi.mocked(getDatabase).mockReturnValue({ transaction } as never);
-  return { execute, existingLimit, onConflictDoNothing, returning };
+  return {
+    eligibilityWhere,
+    execute,
+    existingLimit,
+    onConflictDoNothing,
+    returning,
+  };
 }
 
 function compiledSql(statement: unknown) {
@@ -170,6 +185,21 @@ describe("manual pull request uniqueness", () => {
       target: issuePullRequests.issueId,
       where: activeIssuePullRequestIndexPredicate,
     });
+  });
+
+  it("allows a failed automatic pull request to be retried", async () => {
+    const requestId = "05050505-0505-4505-8505-050505050505";
+    const { eligibilityWhere } = databaseDouble([{ id: requestId }]);
+
+    await queueManualIssuePullRequest({ issueId, organizationId, remediationId });
+
+    expect(compiledSql(eligibilityWhere.mock.calls[0]![0]).params).toEqual([
+      issueId,
+      organizationId,
+      true,
+      "manual",
+      "always",
+    ]);
   });
 
   it("rejects a concurrent request that loses the atomic insert", async () => {

--- a/packages/core/src/db/pull-requests.ts
+++ b/packages/core/src/db/pull-requests.ts
@@ -26,6 +26,8 @@ const activeIssuePullRequestStatuses = [
   "created",
 ] as const;
 
+const requestablePullRequestModes = ["manual", "always"] as const;
+
 export class IssuePullRequestError extends Error {
   constructor(
     message: string,
@@ -177,7 +179,7 @@ export async function getIssuePullRequestState(
           eq(investigationIssues.issueId, issueId),
           eq(investigations.organizationId, organizationId),
           eq(agents.enabled, true),
-          eq(agentConfigVersions.prMode, "manual"),
+          inArray(agentConfigVersions.prMode, requestablePullRequestModes),
         ),
       )
       .limit(1),
@@ -405,7 +407,7 @@ export async function queueManualIssuePullRequest(input: {
           eq(investigationIssues.issueId, input.issueId),
           eq(investigations.organizationId, input.organizationId),
           eq(agents.enabled, true),
-          eq(agentConfigVersions.prMode, "manual"),
+          inArray(agentConfigVersions.prMode, requestablePullRequestModes),
         ),
       )
       .orderBy(desc(investigations.createdAt))
@@ -413,7 +415,7 @@ export async function queueManualIssuePullRequest(input: {
     const target = eligible[0];
     if (!target) {
       throw new IssuePullRequestError(
-        "This issue is not linked to an agent configured for on-request pull requests",
+        "This issue is not linked to an agent configured to create pull requests",
         "not_available",
       );
     }


### PR DESCRIPTION
## Summary
- allow failed automatic remediation pull requests to be retried from the issue page
- show the failure reason beside a clear retry action
- constrain pull request creation to repositories checked out for the active agent version

## Context
Fixes the missing recovery action observed on [Responder issue 11cc3131-fd20-4dc6-a80e-8d4beba44aaa](https://responder.superlog.sh/issues/11cc3131-fd20-4dc6-a80e-8d4beba44aaa). The original automatic attempt failed after selecting a repository outside the configured checkout set.

## Hosted deployment pin
- https://github.com/superloglabs/responder/pull/161

Merge this pull request before the hosted gitlink update.

## Validation
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test` (830 tests)
- `pnpm build`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lets users retry failed automatic remediation pull requests from the issue page: failed requests now show the failure reason and a retry button instead of being a dead end. Pull request creation is also restricted to repositories checked out for the active agent version, so the worker no longer reads the repositories manifest from the session at request time.

- On-request pull requests are now available for agents in `always` mode, not just `manual` mode.
- The `create_pull_request` tool rejects any repository not in the configured checkouts before doing work.

<sup>Written for commit 7efcd9a9a009390afdf5c7cf280752b5c85dc896. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/responder-oss/pull/70?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

