### PR TITLE
Fix missing Slack issue messages

### DIFF
--- a/apps/worker/src/backfill-slack-issues.ts
+++ b/apps/worker/src/backfill-slack-issues.ts
@@ -1,0 +1,44 @@
+import { closeDatabase } from "@responder/core/db/client";
+import { redeliverInvestigationSlackIssue } from "@responder/core/integrations/slack-delivery";
+import { loadResponderSecrets } from "@responder/core/secrets";
+import { z } from "zod";
+
+const targetSchema = z.object({
+  investigationId: z.uuid(),
+  issueId: z.uuid(),
+});
+
+function parseTarget(value: string) {
+  const [investigationId, issueId, ...extra] = value.split(":");
+  if (extra.length > 0) {
+    throw new Error(`Invalid Slack issue backfill target: ${value}`);
+  }
+  return targetSchema.parse({ investigationId, issueId });
+}
+
+const [deliveryRunId, ...targetValues] = process.argv.slice(2);
+if (!deliveryRunId || targetValues.length === 0) {
+  throw new Error(
+    "Usage: backfill-slack-issues <delivery-run-id> <investigation-id:issue-id> [...]",
+  );
+}
+
+loadResponderSecrets();
+
+try {
+  for (const targetValue of targetValues) {
+    const target = parseTarget(targetValue);
+    const result = await redeliverInvestigationSlackIssue({
+      deliveryRunId,
+      ...target,
+    });
+    console.log(JSON.stringify({
+      deliveryRunId,
+      event: "slack_issue_backfill_complete",
+      investigationId: target.investigationId,
+      ...result,
+    }));
+  }
+} finally {
+  await closeDatabase();
+}

--- a/packages/core/src/integrations/slack-delivery.test.ts
+++ b/packages/core/src/integrations/slack-delivery.test.ts
@@ -1,6 +1,9 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import { SlackApiError } from "./slack.js";
 import {
+  redeliverInvestigationSlackIssue,
   slackDeliveryClientMessageId,
+  slackDeliveryErrorMessage,
   slackIssueMessage,
 } from "./slack-delivery.js";
 
@@ -31,6 +34,91 @@ describe("Slack issue delivery", () => {
     );
     expect(first).toMatch(
       /^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+    );
+  });
+
+  it("includes safe Slack response diagnostics in delivery warnings", () => {
+    const warning = slackDeliveryErrorMessage(
+      new AggregateError(
+        [
+          new SlackApiError("chat.postMessage", "http_200", [
+            "Slack returned invalid JSON (status=200, content-type=text/plain, bytes=12); body=bad response",
+          ]),
+        ],
+        "Slack source thread delivery failed",
+      ),
+    );
+
+    expect(warning).toContain("Slack source thread delivery failed");
+    expect(warning).toContain("chat.postMessage http_200");
+    expect(warning).toContain("Slack returned invalid JSON");
+  });
+
+  it("redelivers only the selected issue to its source thread", async () => {
+    const postMessage = vi.fn().mockResolvedValue("1785500001.000200");
+    const registerPullRequestMessage = vi.fn().mockResolvedValue(undefined);
+    const issue = {
+      id: "07070707-0707-4707-8707-070707070707",
+      title: "Organization provisioning race",
+      description: "The first request failed.",
+      rootCause: "Provisioning was still running.",
+      timeline: [],
+      severity: "SEV-2" as const,
+      remediation: "Wait for provisioning.",
+      remediations: [],
+      relationship: "new" as const,
+      evidence: [],
+      pullRequest: null,
+    };
+
+    await expect(
+      redeliverInvestigationSlackIssue(
+        {
+          deliveryRunId: "backfill-2026-08-26",
+          investigationId: "08080808-0808-4808-8808-080808080808",
+          issueId: issue.id,
+        },
+        {
+          getContext: vi.fn().mockResolvedValue({
+            investigationId: "08080808-0808-4808-8808-080808080808",
+            issues: [issue],
+            prMode: "manual",
+            source: {
+              channelId: "C123",
+              encryptedCredentials:
+                "not-read-because-the-credential-parser-is-covered-separately",
+              integrationAccountId: "09090909-0909-4909-8909-090909090909",
+              messageTimestamp: null,
+              reactionTimestamp: "1785500000.000100",
+              threadTimestamp: "1785500000.000100",
+            },
+          } as never),
+          postMessage,
+          registerPullRequestMessage,
+          resolveAccessToken: vi.fn().mockReturnValue("xoxb-test"),
+        },
+      ),
+    ).resolves.toEqual({
+      issueId: issue.id,
+      messageTimestamp: "1785500001.000200",
+    });
+    expect(postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accessToken: "xoxb-test",
+        channelId: "C123",
+        clientMessageId: slackDeliveryClientMessageId(
+          "backfill-2026-08-26",
+          `source:C123:issue:${issue.id}`,
+        ),
+        threadTimestamp: "1785500000.000100",
+      }),
+    );
+    expect(registerPullRequestMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channelId: "C123",
+        issue,
+        messageTimestamp: "1785500001.000200",
+      }),
     );
   });
 

--- a/packages/core/src/integrations/slack-delivery.ts
+++ b/packages/core/src/integrations/slack-delivery.ts
@@ -223,6 +223,67 @@ function accessToken(encryptedCredentials: string): string {
   ).accessToken;
 }
 
+interface SlackIssueRedeliveryDependencies {
+  getContext: typeof getSlackInvestigationDeliveryContext;
+  postMessage: typeof postSlackMessage;
+  registerPullRequestMessage: typeof registerPullRequestMessage;
+  resolveAccessToken: typeof accessToken;
+}
+
+export async function redeliverInvestigationSlackIssue(
+  input: {
+    deliveryRunId: string;
+    investigationId: string;
+    issueId: string;
+  },
+  dependencies?: SlackIssueRedeliveryDependencies,
+): Promise<{ issueId: string; messageTimestamp: string }> {
+  const resolvedDependencies = dependencies ?? {
+    getContext: getSlackInvestigationDeliveryContext,
+    postMessage: postSlackMessage,
+    registerPullRequestMessage,
+    resolveAccessToken: accessToken,
+  };
+  const context = await resolvedDependencies.getContext(input.investigationId);
+  if (!context?.source) {
+    throw new Error(
+      `Slack source thread is unavailable for investigation ${input.investigationId}`,
+    );
+  }
+  const issue = context.issues.find((candidate) => candidate.id === input.issueId);
+  if (!issue) {
+    throw new Error(
+      `Issue ${input.issueId} is not attached to investigation ${input.investigationId}`,
+    );
+  }
+  const message = issueSlackMessage(context, issue);
+  const messageTimestamp = await resolvedDependencies.postMessage({
+    accessToken: resolvedDependencies.resolveAccessToken(
+      context.source.encryptedCredentials,
+    ),
+    blocks: message.blocks,
+    channelId: context.source.channelId,
+    clientMessageId: slackDeliveryClientMessageId(
+      input.deliveryRunId,
+      `source:${context.source.channelId}:issue:${issue.id}`,
+    ),
+    text: message.text,
+    threadTimestamp: context.source.threadTimestamp,
+  });
+  if (!messageTimestamp) {
+    throw new Error(
+      `Slack did not return a message timestamp for issue ${input.issueId}`,
+    );
+  }
+  await resolvedDependencies.registerPullRequestMessage({
+    channelId: context.source.channelId,
+    integrationAccountId: context.source.integrationAccountId,
+    issue,
+    messageTimestamp,
+  });
+  return { issueId: issue.id, messageTimestamp };
+}
+
 function completedInvestigationCard(context: SlackInvestigationDeliveryContext) {
   return slackInvestigationCard({
     agentId: context.agentId,
@@ -236,7 +297,15 @@ function completedInvestigationCard(context: SlackInvestigationDeliveryContext) 
 
 export function slackDeliveryErrorMessage(error: unknown): string {
   const fields = slackErrorLogFields(error);
-  return [fields.error, ...(fields.causes ?? [])].join(": ");
+  const diagnostics = (fields.slackErrors ?? []).flatMap((slackError) =>
+    slackError.diagnostics.map(
+      (diagnostic) =>
+        `${slackError.method} ${slackError.code}: ${diagnostic}`,
+    ),
+  );
+  return [fields.error, ...(fields.causes ?? []), ...diagnostics]
+    .join(": ")
+    .slice(0, 2_000);
 }
 
 export async function reconcileCompletedInvestigationSlackCard(

--- a/packages/core/src/integrations/slack.test.ts
+++ b/packages/core/src/integrations/slack.test.ts
@@ -65,6 +65,129 @@ describe("Slack delivery client", () => {
     );
   });
 
+  it("retries an ambiguous post response with the same client message ID", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response("upstream response was not JSON", {
+          headers: { "content-type": "text/plain" },
+          status: 200,
+        }),
+      )
+      .mockResolvedValueOnce(
+        Response.json({ ok: true, ts: "1785500001.000200" }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      postSlackMessage({
+        accessToken: "xoxb-test",
+        channelId: "C123",
+        clientMessageId: "16161616-1616-4616-8616-161616161616",
+        text: "Investigation result",
+        threadTimestamp: "1785500000.000100",
+      }),
+    ).resolves.toBe("1785500001.000200");
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[1]?.[1]).toEqual(fetchMock.mock.calls[0]?.[1]);
+  });
+
+  it("accepts successful posts with unexpected optional response fields", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      Response.json({
+        errors: "unexpected but irrelevant on success",
+        ok: true,
+        response_metadata: null,
+        ts: "1785500001.000200",
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      postSlackMessage({
+        accessToken: "xoxb-test",
+        channelId: "C123",
+        clientMessageId: "16161616-1616-4616-8616-161616161616",
+        text: "Investigation result",
+      }),
+    ).resolves.toBe("1785500001.000200");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps bounded metadata when Slack returns invalid JSON", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response("not JSON and not safe to log verbatim", {
+          headers: { "content-type": "text/plain; charset=utf-8" },
+          status: 200,
+        }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const failure = postSlackMessage({
+      accessToken: "xoxb-test",
+      channelId: "C123",
+      text: "Investigation result",
+    });
+
+    await expect(failure).rejects.toMatchObject({
+      code: "http_200",
+      diagnostics: [
+        "Slack returned invalid JSON (status=200, content-type=text/plain; charset=utf-8, bytes=37); body=not JSON and not safe to log verbatim",
+      ],
+      method: "chat.postMessage",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry a deterministic Slack rejection", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      Response.json({
+        error: "invalid_blocks",
+        ok: false,
+        response_metadata: {
+          messages: ["A block is invalid"],
+        },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const failure = postSlackMessage({
+      accessToken: "xoxb-test",
+      blocks: [{ type: "section" }],
+      channelId: "C123",
+      clientMessageId: "16161616-1616-4616-8616-161616161616",
+      text: "Investigation result",
+    });
+
+    await expect(failure).rejects.toMatchObject({ code: "invalid_blocks" });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps schema paths when Slack returns an invalid response shape", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(Response.json({ ok: "yes", ts: 123 })),
+    );
+
+    const failure = postSlackMessage({
+      accessToken: "xoxb-test",
+      channelId: "C123",
+      text: "Investigation result",
+    });
+
+    await expect(failure).rejects.toMatchObject({
+      code: "http_200",
+      diagnostics: [
+        expect.stringContaining("invalid response shape"),
+        "Invalid field ok (invalid_type)",
+      ],
+      method: "chat.postMessage",
+    });
+  });
+
   it("updates a live investigation card", async () => {
     const fetchMock = vi.fn().mockResolvedValue(Response.json({ ok: true }));
     vi.stubGlobal("fetch", fetchMock);

--- a/packages/core/src/integrations/slack.ts
+++ b/packages/core/src/integrations/slack.ts
@@ -3,38 +3,74 @@ import { z } from "zod";
 const slackResponseSchema = z
   .object({
     ok: z.boolean(),
-    error: z.string().optional(),
-    errors: z
-      .array(
-        z
-          .object({
-            code: z.string().optional(),
-            message: z.string().optional(),
-            pointer: z.string().optional(),
-          })
-          .passthrough(),
-      )
-      .optional(),
-    response_metadata: z
-      .object({ messages: z.array(z.string()).optional() })
-      .passthrough()
-      .optional(),
-    ts: z.string().optional(),
   })
   .passthrough();
+
+function objectValue(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function stringValue(value: unknown): string | null {
+  return typeof value === "string" ? value : null;
+}
 
 function slackErrorDiagnostics(
   response: z.infer<typeof slackResponseSchema>,
 ): string[] {
+  const errors = Array.isArray(response.errors) ? response.errors : [];
+  const responseMetadata = objectValue(response.response_metadata);
+  const metadataMessages = Array.isArray(responseMetadata?.messages)
+    ? responseMetadata.messages
+    : [];
   return [
-    ...(response.errors ?? []).map((error) =>
-      [error.code, error.pointer, error.message].filter(Boolean).join(": "),
-    ),
-    ...(response.response_metadata?.messages ?? []),
+    ...errors.flatMap((value) => {
+      const error = objectValue(value);
+      if (!error) return [];
+      const detail = [error.code, error.pointer, error.message]
+        .map(stringValue)
+        .filter((value): value is string => value !== null)
+        .join(": ");
+      return detail ? [detail] : [];
+    }),
+    ...metadataMessages.flatMap((value) => {
+      const message = stringValue(value);
+      return message ? [message] : [];
+    }),
   ]
     .filter((message) => message.trim().length > 0)
     .slice(0, 8)
     .map((message) => message.replaceAll(/\s+/g, " ").slice(0, 500));
+}
+
+function slackResponseSummary(response: Response, responseText: string): string {
+  const contentType =
+    response.headers
+      .get("content-type")
+      ?.replaceAll(/\s+/g, " ")
+      .slice(0, 100) ?? "unknown";
+  const byteLength = new TextEncoder().encode(responseText).byteLength;
+  return `status=${response.status}, content-type=${contentType}, bytes=${byteLength}`;
+}
+
+function slackResponseExcerpt(responseText: string): string {
+  const excerpt = responseText.replaceAll(/\s+/g, " ").trim().slice(0, 500);
+  return excerpt || "<empty>";
+}
+
+function slackResponseShapeDiagnostics(
+  response: Response,
+  responseText: string,
+  error: z.ZodError,
+): string[] {
+  return [
+    `Slack returned an invalid response shape (${slackResponseSummary(response, responseText)}); body=${slackResponseExcerpt(responseText)}`,
+    ...error.issues.slice(0, 7).map((issue) => {
+      const path = issue.path.length > 0 ? issue.path.join(".") : "response";
+      return `Invalid field ${path} (${issue.code})`;
+    }),
+  ];
 }
 
 export class SlackApiError extends Error {
@@ -61,20 +97,44 @@ async function callSlackApi(
     },
     body: JSON.stringify(body),
   });
-  const parsed = slackResponseSchema.safeParse(
-    await response.json().catch(() => null),
-  );
+  const responseText = await response.text();
+  let responseBody: unknown;
+  try {
+    responseBody = JSON.parse(responseText);
+  } catch {
+    const detail = responseText.trim()
+      ? "Slack returned invalid JSON"
+      : "Slack returned an empty response";
+    throw new SlackApiError(method, `http_${response.status}`, [
+      `${detail} (${slackResponseSummary(response, responseText)}); body=${slackResponseExcerpt(responseText)}`,
+    ]);
+  }
+  const parsed = slackResponseSchema.safeParse(responseBody);
   if (!response.ok || !parsed.success || !parsed.data.ok) {
     const code = parsed.success
-      ? parsed.data.error ?? `http_${response.status}`
+      ? stringValue(parsed.data.error) ?? `http_${response.status}`
       : `http_${response.status}`;
     throw new SlackApiError(
       method,
       code,
-      parsed.success ? slackErrorDiagnostics(parsed.data) : [],
+      parsed.success
+        ? slackErrorDiagnostics(parsed.data)
+        : slackResponseShapeDiagnostics(response, responseText, parsed.error),
     );
   }
   return parsed.data;
+}
+
+function isRetryableSlackPostError(error: unknown): boolean {
+  return (
+    error instanceof TypeError ||
+    (error instanceof SlackApiError &&
+      /^http_(?:200|408|425|429|5\d\d)$/u.test(error.code))
+  );
+}
+
+function wait(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
 }
 
 export async function addSlackReaction(input: {
@@ -125,7 +185,7 @@ export async function postSlackMessage(input: {
   text: string;
   threadTimestamp?: string;
 }): Promise<string | null> {
-  const response = await callSlackApi(input.accessToken, "chat.postMessage", {
+  const body = {
     channel: input.channelId,
     ...(input.clientMessageId
       ? { client_msg_id: input.clientMessageId }
@@ -133,8 +193,33 @@ export async function postSlackMessage(input: {
     text: input.text,
     ...(input.blocks ? { blocks: input.blocks } : {}),
     ...(input.threadTimestamp ? { thread_ts: input.threadTimestamp } : {}),
-  });
-  return response.ts ?? null;
+  };
+  try {
+    const response = await callSlackApi(
+      input.accessToken,
+      "chat.postMessage",
+      body,
+    );
+    return stringValue(response.ts);
+  } catch (error) {
+    if (!input.clientMessageId || !isRetryableSlackPostError(error)) {
+      throw error;
+    }
+    await wait(100);
+    try {
+      const response = await callSlackApi(
+        input.accessToken,
+        "chat.postMessage",
+        body,
+      );
+      return stringValue(response.ts);
+    } catch (retryError) {
+      throw new AggregateError(
+        [error, retryError],
+        "Slack chat.postMessage retry failed",
+      );
+    }
+  }
 }
 
 export async function updateSlackMessage(input: {
@@ -184,5 +269,5 @@ export async function postSlackEphemeralMessage(input: {
     ...(input.threadTimestamp ? { thread_ts: input.threadTimestamp } : {}),
     user: input.userId,
   });
-  return response.ts ?? null;
+  return stringValue(response.ts);
 }


### PR DESCRIPTION
## Summary
- accept successful Slack responses without over-validating optional metadata
- retain bounded response contents and validation diagnostics for malformed acknowledgements
- retry only ambiguous idempotent message posts, never deterministic Slack rejections
- add a targeted worker command for redelivering missing issue cards

## Validation
- pnpm lint
- pnpm test
- pnpm typecheck

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes dropped Slack issue messages caused by over-strict validation of successful posts and missing retries for ambiguous acknowledgements.

- Successful posts now accept unexpected optional response fields.
- Ambiguous idempotent posts are retried once with the same client message ID.
- Deterministic Slack rejections, like `invalid_blocks`, are never retried.
- Malformed responses keep bounded body excerpts and schema-path diagnostics in errors.
- Adds a `backfill-slack-issues` worker command to redeliver specific missing issue cards.

<sup>Written for commit 23d7a7898a8cbe605b6a888ff20aeb42e7d78da9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/responder-oss/pull/71?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

