### PR TITLE
Add feedback controls to Slack investigations

### DIFF
--- a/apps/control-plane/server/webhooks/slack-actions.test.ts
+++ b/apps/control-plane/server/webhooks/slack-actions.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   captureAnalyticsEvent: vi.fn(),
   decryptCredentials: vi.fn(),
+  getInvestigationForSlackAction: vi.fn(),
   getIssueForSlackAction: vi.fn(),
   postSlackEphemeralMessage: vi.fn(),
 }));
@@ -15,6 +16,13 @@ vi.mock("@responder/core/analytics", () => ({
 vi.mock("../../../../packages/core/src/credentials/encryption.js", () => ({
   decryptCredentials: mocks.decryptCredentials,
 }));
+vi.mock(
+  "../../../../packages/core/src/db/investigations.js",
+  async (importOriginal) => ({
+    ...(await importOriginal()),
+    getInvestigationForSlackAction: mocks.getInvestigationForSlackAction,
+  }),
+);
 vi.mock("../../../../packages/core/src/db/issues.js", () => ({
   getIssueForSlackAction: mocks.getIssueForSlackAction,
 }));
@@ -47,6 +55,11 @@ function signedActionRequest(payload: unknown) {
 describe("Slack actions", () => {
   beforeEach(() => {
     vi.stubEnv("SLACK_SIGNING_SECRET", "slack-signing-secret");
+    mocks.getInvestigationForSlackAction.mockResolvedValue({
+      agentId: "13131313-1313-4313-8313-131313131313",
+      id: "16161616-1616-4616-8616-161616161616",
+      organizationId: "03030303-0303-4303-8303-030303030303",
+    });
     mocks.getIssueForSlackAction.mockResolvedValue({
       id: "07070707-0707-4707-8707-070707070707",
       title: "Plant API returns HTTP 500",
@@ -72,6 +85,81 @@ describe("Slack actions", () => {
   afterEach(() => {
     vi.clearAllMocks();
     vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+
+  it("captures investigation feedback with workspace and user context", async () => {
+    const investigationId = "16161616-1616-4616-8616-161616161616";
+    const response = await signedActionRequest({
+      type: "block_actions",
+      team: { id: "T123" },
+      channel: { id: "C123" },
+      user: { id: "U123", name: "Ada Lovelace", username: "ada" },
+      response_url: "https://hooks.slack.com/actions/T123/B123/response-token",
+      message: { ts: "1785500001.000200" },
+      actions: [
+        {
+          action_id: "feedback",
+          block_id: `investigation_feedback_${investigationId}_card-version`,
+          value: "positive",
+        },
+      ],
+    });
+
+    expect(response.status).toBe(200);
+    expect(mocks.getInvestigationForSlackAction).toHaveBeenCalledWith({
+      investigationId,
+      teamId: "T123",
+    });
+    expect(mocks.captureAnalyticsEvent).toHaveBeenCalledWith({
+      distinctId: "slack:T123:U123",
+      event: "investigation feedback submitted",
+      organizationId: "03030303-0303-4303-8303-030303030303",
+      properties: {
+        $process_person_profile: false,
+        agent_id: "13131313-1313-4313-8313-131313131313",
+        channel_id: "C123",
+        feedback: "positive",
+        investigation_id: investigationId,
+        message_timestamp: "1785500001.000200",
+        slack_user_id: "U123",
+        surface: "slack",
+        team_id: "T123",
+        user_name: "Ada Lovelace",
+      },
+    });
+  });
+
+  it("removes an investigation message from its feedback controls", async () => {
+    const investigationId = "16161616-1616-4616-8616-161616161616";
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(null, { status: 200 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await signedActionRequest({
+      type: "block_actions",
+      team: { id: "T123" },
+      channel: { id: "C123" },
+      user: { id: "U123" },
+      response_url: "https://hooks.slack.com/actions/T123/B123/response-token",
+      actions: [
+        {
+          action_id: "remove",
+          block_id: `investigation_feedback_${investigationId}_card-version`,
+        },
+      ],
+    });
+
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://hooks.slack.com/actions/T123/B123/response-token",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ delete_original: true }),
+      },
+    );
   });
 
   it("shows an issue prompt in the thread containing the button", async () => {

--- a/apps/control-plane/server/webhooks/slack.ts
+++ b/apps/control-plane/server/webhooks/slack.ts
@@ -5,7 +5,10 @@ import { captureAnalyticsEvent } from "@responder/core/analytics";
 import { decryptCredentials } from "../../../../packages/core/src/credentials/encryption.js";
 import { findAgentsForSlackEvent } from "../../../../packages/core/src/db/agents.js";
 import { getSlackChannelConnection } from "../../../../packages/core/src/db/integrations.js";
-import { recordInvestigationSlackMessage } from "../../../../packages/core/src/db/investigations.js";
+import {
+  getInvestigationForSlackAction,
+  recordInvestigationSlackMessage,
+} from "../../../../packages/core/src/db/investigations.js";
 import { getIssueForSlackAction } from "../../../../packages/core/src/db/issues.js";
 import {
   IssuePullRequestError,
@@ -20,6 +23,7 @@ import {
 } from "../../../../packages/core/src/integrations/slack.js";
 import {
   failInvestigationSlackCard,
+  investigationIdFromFeedbackBlockId,
   slackErrorLogFields,
   slackInvestigationCard,
 } from "../../../../packages/core/src/integrations/slack-live-card.js";
@@ -89,11 +93,16 @@ const investigationStartResponseSchema = z.object({
   duplicate: z.boolean(),
   investigationId: z.uuid(),
 });
+const investigationFeedbackSchema = z.enum(["positive", "negative"]);
 const slackBlockActionsSchema = z.object({
   type: z.literal("block_actions"),
   team: z.object({ id: z.string().min(1) }),
   channel: z.object({ id: z.string().min(1) }),
-  user: z.object({ id: z.string().min(1) }),
+  user: z.object({
+    id: z.string().min(1),
+    name: z.string().min(1).optional(),
+    username: z.string().min(1).optional(),
+  }),
   response_url: z.string().url(),
   message: z
     .object({
@@ -106,6 +115,7 @@ const slackBlockActionsSchema = z.object({
   actions: z.array(
     z.object({
       action_id: z.string().min(1),
+      block_id: z.string().min(1).optional(),
       value: z.string().optional(),
     }),
   ),
@@ -887,6 +897,59 @@ export const slackWebhookRoutes = new Hono().post("/", async (context) => {
     });
     if (!response.ok) {
       console.error(`Unable to dismiss Slack issue prompt (${response.status})`);
+    }
+    return context.json({ ok: true });
+  }
+
+  const feedbackAction = action.data.actions.find(
+    (item) => item.action_id === "feedback",
+  );
+  const feedbackInvestigationId = investigationIdFromFeedbackBlockId(
+    feedbackAction?.block_id,
+  );
+  const feedback = investigationFeedbackSchema.safeParse(
+    feedbackAction?.value,
+  );
+  if (feedbackInvestigationId && feedback.success) {
+    const investigation = await getInvestigationForSlackAction({
+      investigationId: feedbackInvestigationId,
+      teamId: action.data.team.id,
+    });
+    if (investigation) {
+      await captureAnalyticsEvent({
+        distinctId: `slack:${action.data.team.id}:${action.data.user.id}`,
+        event: "investigation feedback submitted",
+        organizationId: investigation.organizationId,
+        properties: {
+          $process_person_profile: false,
+          agent_id: investigation.agentId,
+          channel_id: action.data.channel.id,
+          feedback: feedback.data,
+          investigation_id: investigation.id,
+          message_timestamp: action.data.message?.ts,
+          slack_user_id: action.data.user.id,
+          surface: "slack",
+          team_id: action.data.team.id,
+          user_name: action.data.user.name ?? action.data.user.username,
+        },
+      });
+    }
+    return context.json({ ok: true });
+  }
+
+  const removeAction = action.data.actions.find(
+    (item) => item.action_id === "remove",
+  );
+  if (investigationIdFromFeedbackBlockId(removeAction?.block_id)) {
+    const response = await fetch(action.data.response_url, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ delete_original: true }),
+    });
+    if (!response.ok) {
+      console.error(
+        `Unable to remove Slack investigation message (${response.status})`,
+      );
     }
     return context.json({ ok: true });
   }

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -16,12 +16,15 @@ activity can be separated from other products sharing the PostHog project.
 | `agent created` | A new agent and its initial configuration are persisted | `agent_id`, `trigger_kind`, `model`, `enabled`, `pr_mode` |
 | `prompt copied` | A user clicks **Copy prompt** in Slack | `issue_id`, `issue_found`, `team_id`, `channel_id`, `surface` |
 | `investigation created` | A new investigation or replay is persisted and accepted for processing | `investigation_id`, `agent_id`, `provider`, `is_replay`, `source_investigation_id` |
+| `investigation feedback submitted` | A Slack user rates a completed investigation response | `investigation_id`, `agent_id`, `feedback`, `organization_id`, `organization_name`, `slack_user_id`, `user_name`, `team_id`, `channel_id`, `surface` |
 | `investigation rerun` | A finished investigation is accepted for another run with the active Agent configuration | `investigation_id`, `agent_id`, `agent_config_version_id`, `provider` |
 
 Events associated with a workspace include `organization_id` and the PostHog
 `organization` group. Authenticated events use the Better Auth user ID as their
 distinct ID. Machine-triggered investigations and Slack actions do not create
 PostHog person profiles.
+Slack feedback includes the user name supplied in the interaction payload when
+Slack provides one.
 
 Configure these variables in the control-plane project:
 

--- a/packages/core/src/analytics.ts
+++ b/packages/core/src/analytics.ts
@@ -11,6 +11,7 @@ export interface AnalyticsEvent {
     | "agent created"
     | "integration connected"
     | "investigation created"
+    | "investigation feedback submitted"
     | "investigation rerun"
     | "organization created"
     | "pr merged"

--- a/packages/core/src/db/investigations.test.ts
+++ b/packages/core/src/db/investigations.test.ts
@@ -13,6 +13,7 @@ import {
   customMcpTokenRefreshFailureEvent,
   customMcpTokenRefreshSuccessEvent,
   customMcpReconnectError,
+  getInvestigationForSlackAction,
   investigationCanBeRetried,
   markInvestigationStarted,
   prepareInvestigationRetry,
@@ -22,6 +23,36 @@ import {
 vi.mock("./client.js", () => ({
   getDatabase: vi.fn(),
 }));
+
+describe("Slack investigation actions", () => {
+  it("resolves an investigation through a connected Slack workspace", async () => {
+    const investigation = {
+      agentId: "agent-1",
+      id: "investigation-1",
+      organizationId: "organization-1",
+    };
+    const query = {
+      from: vi.fn(),
+      innerJoin: vi.fn(),
+      where: vi.fn(),
+      limit: vi.fn().mockResolvedValue([investigation]),
+    };
+    query.from.mockReturnValue(query);
+    query.innerJoin.mockReturnValue(query);
+    query.where.mockReturnValue(query);
+    vi.mocked(getDatabase).mockReturnValue({
+      select: vi.fn(() => query),
+    } as never);
+
+    await expect(
+      getInvestigationForSlackAction({
+        investigationId: investigation.id,
+        teamId: "T123",
+      }),
+    ).resolves.toEqual(investigation);
+    expect(query.innerJoin).toHaveBeenCalledOnce();
+  });
+});
 
 describe("investigation retry", () => {
   it("allows terminal investigations to run again", () => {

--- a/packages/core/src/db/investigations.ts
+++ b/packages/core/src/db/investigations.ts
@@ -136,6 +136,35 @@ export async function getInvestigationForRetry(input: {
   return rows[0] ?? null;
 }
 
+export async function getInvestigationForSlackAction(input: {
+  investigationId: string;
+  teamId: string;
+}) {
+  const rows = await getDatabase()
+    .select({
+      agentId: investigations.agentId,
+      id: investigations.id,
+      organizationId: investigations.organizationId,
+    })
+    .from(investigations)
+    .innerJoin(
+      integrationAccounts,
+      and(
+        eq(
+          integrationAccounts.organizationId,
+          investigations.organizationId,
+        ),
+        eq(integrationAccounts.provider, "slack"),
+        eq(integrationAccounts.externalAccountId, input.teamId),
+        eq(integrationAccounts.status, "connected"),
+      ),
+    )
+    .where(eq(investigations.id, input.investigationId))
+    .limit(1);
+
+  return rows[0] ?? null;
+}
+
 export async function getInvestigationDetail(input: {
   organizationId: string;
   agentId: string;

--- a/packages/core/src/integrations/slack-delivery.test.ts
+++ b/packages/core/src/integrations/slack-delivery.test.ts
@@ -2,12 +2,46 @@ import { describe, expect, it, vi } from "vitest";
 import { SlackApiError } from "./slack.js";
 import {
   redeliverInvestigationSlackIssue,
+  slackCompletedInvestigationCard,
   slackDeliveryClientMessageId,
   slackDeliveryErrorMessage,
   slackIssueMessage,
 } from "./slack-delivery.js";
 
 describe("Slack issue delivery", () => {
+  it("adds feedback controls to completed investigation messages", () => {
+    const investigationId = "16161616-1616-4616-8616-161616161616";
+    const message = slackCompletedInvestigationCard({
+      agentId: "13131313-1313-4313-8313-131313131313",
+      investigationId,
+      title: "Plant API error rate is elevated",
+      traceItems: [],
+    });
+
+    expect(message.blocks).toEqual([
+      expect.objectContaining({ type: "plan" }),
+      expect.objectContaining({
+        type: "context_actions",
+        block_id: expect.stringMatching(
+          new RegExp(`^investigation_feedback_${investigationId}_`),
+        ),
+        elements: [
+          expect.objectContaining({
+            type: "feedback_buttons",
+            action_id: "feedback",
+            positive_button: expect.objectContaining({ value: "positive" }),
+            negative_button: expect.objectContaining({ value: "negative" }),
+          }),
+          expect.objectContaining({
+            type: "icon_button",
+            action_id: "remove",
+            icon: "trash",
+          }),
+        ],
+      }),
+    ]);
+  });
+
   it("uses stable, destination-specific message IDs for retry deduplication", () => {
     const first = slackDeliveryClientMessageId(
       "job-id",

--- a/packages/core/src/integrations/slack-delivery.ts
+++ b/packages/core/src/integrations/slack-delivery.ts
@@ -21,6 +21,7 @@ import {
 } from "./slack-remediations.js";
 import {
   slackErrorLogFields,
+  slackInvestigationFeedbackBlock,
   slackInvestigationCard,
 } from "./slack-live-card.js";
 
@@ -284,8 +285,13 @@ export async function redeliverInvestigationSlackIssue(
   return { issueId: issue.id, messageTimestamp };
 }
 
-function completedInvestigationCard(context: SlackInvestigationDeliveryContext) {
-  return slackInvestigationCard({
+export function slackCompletedInvestigationCard(
+  context: Pick<
+    SlackInvestigationDeliveryContext,
+    "agentId" | "investigationId" | "title" | "traceItems"
+  >,
+) {
+  const card = slackInvestigationCard({
     agentId: context.agentId,
     detail: "Completed the investigation plan.",
     investigationId: context.investigationId,
@@ -293,6 +299,13 @@ function completedInvestigationCard(context: SlackInvestigationDeliveryContext) 
     title: context.title,
     traceItems: context.traceItems ?? [],
   });
+  return {
+    ...card,
+    blocks: [
+      ...card.blocks,
+      slackInvestigationFeedbackBlock(context.investigationId),
+    ],
+  };
 }
 
 export function slackDeliveryErrorMessage(error: unknown): string {
@@ -314,7 +327,7 @@ export async function reconcileCompletedInvestigationSlackCard(
   const context = await getSlackInvestigationDeliveryContext(investigationId);
   if (!context?.source?.messageTimestamp) return false;
   const token = accessToken(context.source.encryptedCredentials);
-  const card = completedInvestigationCard(context);
+  const card = slackCompletedInvestigationCard(context);
   const results = await Promise.allSettled([
     updateSlackMessage({
       accessToken: token,
@@ -360,7 +373,7 @@ async function deliverSourceThread(
     context.issues.length,
   );
   if (context.source.messageTimestamp) {
-    const card = completedInvestigationCard(context);
+    const card = slackCompletedInvestigationCard(context);
     try {
       await updateSlackMessage({
         accessToken: token,

--- a/packages/core/src/integrations/slack-live-card.test.ts
+++ b/packages/core/src/integrations/slack-live-card.test.ts
@@ -9,6 +9,7 @@ import {
 } from "./slack.js";
 import {
   failInvestigationSlackCard,
+  investigationIdFromFeedbackBlockId,
   slackCardFailureMetricEvent,
   slackErrorLogFields,
   slackInvestigationCard,
@@ -142,6 +143,24 @@ describe("Slack live investigation card", () => {
         ],
       }),
     ]);
+  });
+
+  it("reads an investigation ID only from its feedback block", () => {
+    expect(
+      investigationIdFromFeedbackBlockId(
+        `investigation_feedback_${context.investigationId}_card-version`,
+      ),
+    ).toBe(context.investigationId);
+    expect(
+      investigationIdFromFeedbackBlockId(
+        `other_feedback_${context.investigationId}_card-version`,
+      ),
+    ).toBeNull();
+    expect(
+      investigationIdFromFeedbackBlockId(
+        "investigation_feedback_not-an-investigation_card-version",
+      ),
+    ).toBeNull();
   });
 
   it("renders ClickStack's alert shortcode as an emoji in the plan title", () => {

--- a/packages/core/src/integrations/slack-live-card.ts
+++ b/packages/core/src/integrations/slack-live-card.ts
@@ -14,12 +14,56 @@ import type { SlackInvestigationTraceItem } from "./slack-live-progress.js";
 const slackCredentialsSchema = z.object({
   accessToken: z.string().min(1),
 });
+const investigationIdSchema = z.uuid();
+const INVESTIGATION_FEEDBACK_BLOCK_PREFIX = "investigation_feedback_";
 
 export type SlackInvestigationCardStatus =
   | "pending"
   | "in_progress"
   | "complete"
   | "error";
+
+export function slackInvestigationFeedbackBlock(investigationId: string) {
+  return {
+    type: "context_actions",
+    block_id: `${INVESTIGATION_FEEDBACK_BLOCK_PREFIX}${investigationId}_${randomUUID()}`,
+    elements: [
+      {
+        type: "feedback_buttons",
+        action_id: "feedback",
+        positive_button: {
+          text: { type: "plain_text", text: "Good Response" },
+          value: "positive",
+          accessibility_label: "Submit positive investigation feedback",
+        },
+        negative_button: {
+          text: { type: "plain_text", text: "Bad Response" },
+          value: "negative",
+          accessibility_label: "Submit negative investigation feedback",
+        },
+      },
+      {
+        type: "icon_button",
+        action_id: "remove",
+        icon: "trash",
+        text: { type: "plain_text", text: "Remove" },
+      },
+    ],
+  };
+}
+
+export function investigationIdFromFeedbackBlockId(
+  blockId: string | undefined,
+): string | null {
+  if (!blockId?.startsWith(INVESTIGATION_FEEDBACK_BLOCK_PREFIX)) return null;
+  const investigationId = blockId.slice(
+    INVESTIGATION_FEEDBACK_BLOCK_PREFIX.length,
+    INVESTIGATION_FEEDBACK_BLOCK_PREFIX.length + 36,
+  );
+  return investigationIdSchema.safeParse(investigationId).success
+    ? investigationId
+    : null;
+}
 
 function truncate(value: string, maximum: number): string {
   return value.length > maximum


### PR DESCRIPTION
## Summary
- add Good Response and Bad Response controls to completed Slack investigation cards
- capture validated feedback in PostHog with investigation, organization, channel, and Slack user context
- support removing the investigation message from the feedback controls

Hosted companion PR: https://github.com/superloglabs/responder/pull/163

## Testing
- pnpm typecheck
- pnpm lint
- pnpm test