### PR TITLE
Group agent investigations by day

### DIFF
--- a/apps/control-plane/src/date-presentation.test.ts
+++ b/apps/control-plane/src/date-presentation.test.ts
@@ -1,21 +1,21 @@
 import { describe, expect, it } from "vitest";
-import { issueDateGroupLabel } from "./issues-presentation";
+import { dateGroupLabel } from "./date-presentation";
 
-describe("issueDateGroupLabel", () => {
+describe("dateGroupLabel", () => {
   const now = new Date(2026, 7, 11, 9, 30);
 
-  it("labels issues from today and yesterday", () => {
-    expect(issueDateGroupLabel(new Date(2026, 7, 11, 0, 5).toISOString(), now)).toBe(
+  it("labels dates from today and yesterday", () => {
+    expect(dateGroupLabel(new Date(2026, 7, 11, 0, 5).toISOString(), now)).toBe(
       "Today",
     );
-    expect(issueDateGroupLabel(new Date(2026, 7, 10, 23, 55).toISOString(), now)).toBe(
+    expect(dateGroupLabel(new Date(2026, 7, 10, 23, 55).toISOString(), now)).toBe(
       "Yesterday",
     );
   });
 
   it("formats older dates with an unambiguous year", () => {
     expect(
-      issueDateGroupLabel(new Date(2026, 7, 9, 12).toISOString(), now, "en-US"),
+      dateGroupLabel(new Date(2026, 7, 9, 12).toISOString(), now, "en-US"),
     ).toBe("August 9, 2026");
   });
 
@@ -24,7 +24,7 @@ describe("issueDateGroupLabel", () => {
     const beforeClockChange = new Date(2026, 2, 29, 0, 30);
 
     expect(
-      issueDateGroupLabel(beforeClockChange.toISOString(), afterClockChange),
+      dateGroupLabel(beforeClockChange.toISOString(), afterClockChange),
     ).toBe("Yesterday");
   });
 });

--- a/apps/control-plane/src/date-presentation.ts
+++ b/apps/control-plane/src/date-presentation.ts
@@ -8,7 +8,7 @@ function localCalendarDay(value: Date): number {
   return Date.UTC(value.getFullYear(), value.getMonth(), value.getDate());
 }
 
-export function issueDateGroupLabel(
+export function dateGroupLabel(
   value: string,
   now = new Date(),
   locale?: string,

--- a/apps/control-plane/src/pages/agent-detail.tsx
+++ b/apps/control-plane/src/pages/agent-detail.tsx
@@ -27,6 +27,7 @@ import {
 } from "../agent-detail-presentation";
 import { AppShell } from "../components/app-shell";
 import { AgentDetailSkeleton } from "../components/screen-skeletons";
+import { dateGroupLabel } from "../date-presentation";
 import {
   Badge,
   DataTable,
@@ -489,6 +490,9 @@ export function AgentDetailPage() {
           aria-label="Agent investigations"
           columns={investigationColumns}
           emptyMessage="No investigations have run yet."
+          getRowGroup={(investigation) =>
+            dateGroupLabel(investigation.createdAt)
+          }
           getRowKey={(investigation) => investigation.id}
           rows={agent.investigations}
         />

--- a/apps/control-plane/src/pages/issues.tsx
+++ b/apps/control-plane/src/pages/issues.tsx
@@ -8,9 +8,9 @@ import {
 import { AppShell } from "../components/app-shell";
 import { ArrowIcon } from "../components/icons";
 import { IssueListSkeleton } from "../components/screen-skeletons";
+import { dateGroupLabel } from "../date-presentation";
 import { DataTable } from "../design-system";
 import { useDocumentTitle } from "../use-document-title";
-import { issueDateGroupLabel } from "./issues-presentation";
 
 type IssueFilter = "all" | IssueListItem["severity"];
 
@@ -158,7 +158,7 @@ export function IssuesPage() {
               value: "SEV-3",
             },
           ]}
-          getRowGroup={(issue) => issueDateGroupLabel(issue.createdAt)}
+          getRowGroup={(issue) => dateGroupLabel(issue.createdAt)}
           getRowKey={(issue) => issue.id}
           onFilterChange={setIssueFilter}
           rows={filteredIssues}


### PR DESCRIPTION
## Summary
- group investigations on the agent detail page by calendar day
- share the existing Today, Yesterday, and full-date labels with the issues list
- retain daylight-saving-aware date grouping coverage

## Validation
- pnpm test
- pnpm typecheck
- pnpm lint
- pnpm build

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Groups agent investigations on the agent detail page by calendar day, matching the issues list.

- Renames `issueDateGroupLabel` to `dateGroupLabel` and moves it to a shared module.
- Applies the shared label to both the agent investigations table and the issues list.
- Keeps daylight-saving-aware date grouping coverage intact.

<sup>Written for commit 6b176d6b5378ddb23d8a6fb85c6b4551348e9654. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/responder-oss/pull/74?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

