### PR TITLE
Respect Slack card text limits

### DIFF
--- a/packages/core/src/integrations/slack-remediations.test.ts
+++ b/packages/core/src/integrations/slack-remediations.test.ts
@@ -72,6 +72,26 @@ describe("Slack remediation cards", () => {
     ]);
   });
 
+  it("keeps card title and body text within Slack's 200-character limit", () => {
+    const blocks = slackRemediationCarousel({
+      canCreatePullRequest: true,
+      issueId,
+      remediations: [{
+        ...codeRemediation,
+        title: "T".repeat(250),
+        description: "D".repeat(250),
+      }],
+    });
+    const carousel = blocks[2] as {
+      elements: Array<{ body: { text: string }; title: { text: string } }>;
+    };
+
+    expect(carousel.elements[0]?.title.text).toHaveLength(200);
+    expect(carousel.elements[0]?.title.text.endsWith("…")).toBe(true);
+    expect(carousel.elements[0]?.body.text).toHaveLength(200);
+    expect(carousel.elements[0]?.body.text.endsWith("…")).toBe(true);
+  });
+
   it("round-trips the selected issue and remediation IDs", () => {
     expect(
       parseSlackRemediationActionValue(

--- a/packages/core/src/integrations/slack-remediations.ts
+++ b/packages/core/src/integrations/slack-remediations.ts
@@ -18,6 +18,8 @@ const remediationActionValueSchema = z.object({
   remediationId: z.uuid(),
 });
 
+const slackCardTextMaxLength = 200;
+
 export type SlackRemediationActionValue = z.infer<
   typeof remediationActionValueSchema
 >;
@@ -125,7 +127,10 @@ export function slackRemediationCard(input: {
     block_id: `remediation-${input.remediation.id}`,
     title: {
       type: "mrkdwn",
-      text: truncate(escapeSlack(input.remediation.title), 200),
+      text: truncate(
+        escapeSlack(input.remediation.title),
+        slackCardTextMaxLength,
+      ),
       verbatim: false,
     },
     subtitle: {
@@ -135,7 +140,10 @@ export function slackRemediationCard(input: {
     },
     body: {
       type: "mrkdwn",
-      text: truncate(escapeSlack(input.remediation.description), 2_900),
+      text: truncate(
+        escapeSlack(input.remediation.description),
+        slackCardTextMaxLength,
+      ),
       verbatim: false,
     },
     ...(actions.length > 0 ? { actions } : {}),
@@ -224,7 +232,7 @@ function pullRequestStatus(card: SlackIssuePullRequestCard): {
           escapeSlack(
             card.failureReason ?? "Responder could not create the pull request.",
           ),
-          2_900,
+          slackCardTextMaxLength,
         ),
         label: "Failed",
       };


### PR DESCRIPTION
## What changed
- truncate remediation card titles and bodies to Slack’s documented 200-character card text limit
- apply the same limit to pull-request failure card bodies
- add a regression test for overlong remediation content

## Why
Production Slack delivery returned `invalid_blocks` because remediation descriptions exceeded the card body limit.

## Validation
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test` (843 passed)
- `pnpm build`

Follow-up to #71.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `invalid_blocks` error in production Slack delivery by truncating card text to Slack's documented 200-character limit.

- Applies the limit to remediation card titles and bodies and to pull-request failure bodies, replacing the former 2,900-character body limit.
- Adds a regression test for overlong remediation content.

<sup>Written for commit eaac4e2a9425716f3324fdd8d66d5a6ae492bc31. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/responder-oss/pull/76?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

