### PR TITLE
Keep investigations running during Sentry outages

### DIFF
--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -467,6 +467,25 @@ await boss.work(investigationQueue, { localConcurrency: 1 }, async ([job]) => {
           }));
         }));
       },
+      async (error) => {
+        await reportWorkerException(error, {
+          diagnostics: {
+            contextProvider: "sentry",
+            degradedContext: true,
+            errorCode: error.errorCode,
+            failureKind: error.failureKind,
+            ...(error.httpStatus === undefined
+              ? {}
+              : { httpStatus: error.httpStatus }),
+            requestDurationMs: error.requestDurationMs,
+            retryable: error.retryable,
+          },
+          investigationId: payload.investigationId,
+          jobId: job.id,
+          operation: "investigation",
+          organizationId: payload.config.organizationId,
+        });
+      },
     );
     const deliveryWarnings = await completeInvestigationRun({
       deliveryRunId: job.id,

--- a/apps/worker/src/investigate.test.ts
+++ b/apps/worker/src/investigate.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from "vitest";
+import { SentryConnectionUnavailableError } from "@responder/core/db/investigations";
+import { describe, expect, it, vi } from "vitest";
 import {
   contextServerConnectFailureEvent,
   initialInvestigationMessage,
@@ -6,6 +7,7 @@ import {
   investigationInstructions,
   investigationInstructionsTraceEvent,
   investigationTraceWriteFailure,
+  loadSentryConnectionForInvestigation,
   safeInvestigationError,
   sandboxAgentConfig,
 } from "./investigate.js";
@@ -165,6 +167,25 @@ describe("sandbox agent configuration", () => {
     expect(instructions).toContain("connected ClickStack tools");
     expect(instructions).toContain(
       "Do not create, update, or delete ClickStack resources",
+    );
+  });
+
+  it("tells the agent to continue when live Sentry context is unavailable", () => {
+    const instructions = investigationInstructions({
+      agentPrompt: "Inspect the reported failure.",
+      clickStackConnected: false,
+      datadogConnected: false,
+      repositories: [],
+      sentryConnected: false,
+      sentryUnavailable: true,
+    });
+
+    expect(instructions).toContain("Sentry context is temporarily unavailable");
+    expect(instructions).toContain(
+      "Continue with the alert payload, repositories, and other connected evidence sources",
+    );
+    expect(instructions).toContain(
+      "live Sentry evidence could not be inspected",
     );
   });
 
@@ -343,5 +364,118 @@ describe("sandbox agent configuration", () => {
         OPENAI_API_KEY: "openai-secret",
       }),
     ).toBe("AWS guide failed after [redacted]");
+  });
+
+  it("continues without Sentry context after a refresh outage", async () => {
+    const failure = new SentryConnectionUnavailableError(
+      {
+        errorCode: "TimeoutError",
+        failureKind: "timeout",
+        requestDurationMs: 10_003,
+        retryable: true,
+      },
+      new DOMException("The operation was aborted", "TimeoutError"),
+    );
+    const getConnection = vi.fn().mockRejectedValue(failure);
+    const onRecoverableFailure = vi.fn().mockResolvedValue(undefined);
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(
+      loadSentryConnectionForInvestigation({
+        getConnection,
+        investigationId: "investigation-123",
+        investigationInput: {
+          body: "Sentry alert body",
+          externalEventId: "event-123",
+          provider: "slack",
+          title: "Sentry alert",
+        },
+        onRecoverableFailure,
+        versionId: "version-123",
+      }),
+    ).resolves.toBeNull();
+
+    expect(onRecoverableFailure).toHaveBeenCalledWith(failure);
+    expect(consoleError).toHaveBeenCalledWith(
+      JSON.stringify({
+        errorCode: "TimeoutError",
+        event: "sentry_connection_degraded",
+        failureKind: "timeout",
+        investigationContinues: true,
+        investigationId: "investigation-123",
+        requestDurationMs: 10_003,
+        retryable: true,
+      }),
+    );
+    consoleError.mockRestore();
+  });
+
+  it("does not let monitoring failure stop a degraded investigation", async () => {
+    const failure = new SentryConnectionUnavailableError(
+      {
+        errorCode: "SentryRefreshHttpError",
+        failureKind: "http",
+        httpStatus: 503,
+        requestDurationMs: 321,
+        retryable: true,
+      },
+      new Error("service unavailable"),
+    );
+    const reportingFailure = new Error("monitoring unavailable");
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(
+      loadSentryConnectionForInvestigation({
+        getConnection: vi.fn().mockRejectedValue(failure),
+        investigationId: "investigation-123",
+        investigationInput: {
+          body: "Sentry alert body",
+          externalEventId: "event-123",
+          provider: "slack",
+          title: "Sentry alert",
+        },
+        onRecoverableFailure: vi.fn().mockRejectedValue(reportingFailure),
+        versionId: "version-123",
+      }),
+    ).resolves.toBeNull();
+
+    expect(consoleError).toHaveBeenLastCalledWith(
+      JSON.stringify({
+        error: "monitoring unavailable",
+        errorCode: "Error",
+        event: "sentry_connection_degraded_reporting_failed",
+        investigationId: "investigation-123",
+      }),
+    );
+    consoleError.mockRestore();
+  });
+
+  it("still fails investigations for unexpected connection lookup errors", async () => {
+    const failure = new Error("database unavailable");
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(
+      loadSentryConnectionForInvestigation({
+        getConnection: vi.fn().mockRejectedValue(failure),
+        investigationId: "investigation-123",
+        investigationInput: {
+          body: "Sentry alert body",
+          externalEventId: "event-123",
+          provider: "slack",
+          title: "Sentry alert",
+        },
+        versionId: "version-123",
+      }),
+    ).rejects.toBe(failure);
+
+    expect(consoleError).toHaveBeenCalledWith(
+      JSON.stringify({
+        error: "database unavailable",
+        errorCode: "Error",
+        event: "sentry_connection_lookup_failed",
+        investigationId: "investigation-123",
+      }),
+    );
+    consoleError.mockRestore();
   });
 });

--- a/apps/worker/src/investigate.ts
+++ b/apps/worker/src/investigate.ts
@@ -16,6 +16,8 @@ import {
   getRuntimeSentryConnection,
   getRuntimeUpstashConnection,
   getRuntimeVercelConnections,
+  SentryConnectionUnavailableError,
+  type RuntimeSentryConnection,
 } from "@responder/core/db/investigations";
 import { getRuntimeWorkspaceSecrets } from "@responder/core/db/workspace-secrets";
 import { getRuntimeProfile } from "@responder/core/db/runtime-profiles";
@@ -154,6 +156,81 @@ export function contextServerConnectFailureEvent(input: {
   };
 }
 
+export async function loadSentryConnectionForInvestigation(input: {
+  getConnection?: typeof getRuntimeSentryConnection;
+  investigationId: string;
+  investigationInput: InvestigationInput;
+  onRecoverableFailure?: (
+    error: SentryConnectionUnavailableError,
+  ) => Promise<void>;
+  versionId: string;
+}): Promise<RuntimeSentryConnection | null> {
+  const getConnection = input.getConnection ?? getRuntimeSentryConnection;
+  try {
+    const connection = await getConnection(
+      input.versionId,
+      input.investigationInput,
+    );
+    if (!connection && input.investigationInput.provider === "sentry") {
+      console.info(
+        JSON.stringify({
+          event: "sentry_connection_unavailable",
+          investigationId: input.investigationId,
+        }),
+      );
+    }
+    return connection;
+  } catch (error) {
+    if (!(error instanceof SentryConnectionUnavailableError)) {
+      console.error(
+        JSON.stringify({
+          error: error instanceof Error ? error.message : String(error),
+          errorCode: error instanceof Error ? error.name : typeof error,
+          event: "sentry_connection_lookup_failed",
+          investigationId: input.investigationId,
+        }),
+      );
+      throw error;
+    }
+
+    console.error(
+      JSON.stringify({
+        errorCode: error.errorCode,
+        event: "sentry_connection_degraded",
+        failureKind: error.failureKind,
+        ...(error.httpStatus === undefined
+          ? {}
+          : { httpStatus: error.httpStatus }),
+        investigationContinues: true,
+        investigationId: input.investigationId,
+        requestDurationMs: error.requestDurationMs,
+        retryable: error.retryable,
+      }),
+    );
+    if (input.onRecoverableFailure) {
+      try {
+        await input.onRecoverableFailure(error);
+      } catch (reportingError) {
+        console.error(
+          JSON.stringify({
+            error:
+              reportingError instanceof Error
+                ? reportingError.message
+                : String(reportingError),
+            errorCode:
+              reportingError instanceof Error
+                ? reportingError.name
+                : typeof reportingError,
+            event: "sentry_connection_degraded_reporting_failed",
+            investigationId: input.investigationId,
+          }),
+        );
+      }
+    }
+    return null;
+  }
+}
+
 export function sandboxAgentConfig(
   environment: NodeJS.ProcessEnv = process.env,
 ): SandboxAgentConfig {
@@ -186,6 +263,7 @@ export function investigationInstructions(input: {
   repositories: CheckedOutRepository[];
   runtimeSystemPrompt?: string | null;
   sentryConnected: boolean;
+  sentryUnavailable?: boolean;
   linearConnected?: boolean;
   langfuseProjectNames?: string[];
   slackChannels?: Array<{ id: string; name: string }>;
@@ -239,6 +317,9 @@ export function investigationInstructions(input: {
       : null,
     input.sentryConnected
       ? "Use the connected read-only Sentry tools to inspect the issue, related events, traces, and relevant historical telemetry before concluding."
+      : null,
+    input.sentryUnavailable
+      ? "Sentry context is temporarily unavailable. Continue with the alert payload, repositories, and other connected evidence sources. Clearly state that live Sentry evidence could not be inspected."
       : null,
     input.upstashConnected
       ? "Use list_upstash_resources first to locate relevant Redis, Vector, Search, QStash, or team resources, then use the read-only Upstash inspection and runtime tools for evidence. Workflow and QStash runtime history are available through the connected Upstash tools. Never create, update, delete, retry, publish, or otherwise mutate Upstash resources or data."
@@ -311,8 +392,12 @@ export async function runInvestigationAgent(
   traceContext: { jobId: string },
   onAutomaticPullRequestRequests?: (requestIds: string[]) => Promise<void>,
   onLinearTicketRequests?: (requestIds: string[]) => Promise<void>,
+  onRecoverableSentryFailure?: (
+    error: SentryConnectionUnavailableError,
+  ) => Promise<void>,
 ): Promise<string> {
   const investigationInput = toInvestigationInput(job.request);
+  let sentryConnectionDegraded = false;
   const awsAlarmTriggered =
     investigationInput.provider === "slack" &&
     investigationInput.attributes?.slackAlertProvider === "aws";
@@ -360,28 +445,15 @@ export async function runInvestigationAgent(
     getRuntimeAwsConnections(job.config.id),
     getRuntimeAxiomConnection(job.config.id),
     getRuntimeDatadogConnection(job.config.id),
-    getRuntimeSentryConnection(job.config.id, investigationInput)
-      .then((connection) => {
-        if (!connection && investigationInput.provider === "sentry") {
-          console.info(
-            JSON.stringify({
-              event: "sentry_connection_unavailable",
-              investigationId: job.investigationId,
-            }),
-          );
-        }
-        return connection;
-      })
-      .catch((error: unknown) => {
-        console.error(
-          JSON.stringify({
-            error: error instanceof Error ? error.message : String(error),
-            event: "sentry_connection_lookup_failed",
-            investigationId: job.investigationId,
-          }),
-        );
-        throw error;
-      }),
+    loadSentryConnectionForInvestigation({
+      investigationId: job.investigationId,
+      investigationInput,
+      onRecoverableFailure: async (error) => {
+        sentryConnectionDegraded = true;
+        await onRecoverableSentryFailure?.(error);
+      },
+      versionId: job.config.id,
+    }),
     getRuntimeCustomMcpConnections(job.config.id),
     getRuntimeClickStackConnection(job.config.id),
     getRuntimeLinearConnection(job.config.id),
@@ -538,6 +610,7 @@ export async function runInvestigationAgent(
       repositories,
       runtimeSystemPrompt: runtimeProfile?.systemPrompt,
       sentryConnected: sentryServer !== null,
+      sentryUnavailable: sentryConnectionDegraded,
       linearConnected: linearServer !== null,
       langfuseProjectNames: langfuseConnections.map(
         (connection) => connection.displayName,

--- a/packages/core/src/db/investigations.ts
+++ b/packages/core/src/db/investigations.ts
@@ -1630,11 +1630,105 @@ const sentryAuthorizationSchema = z.object({
   expiresAt: z.string().nullable().optional(),
 });
 
-class SentryRefreshError extends Error {
+export class SentryRefreshHttpError extends Error {
   constructor(readonly httpStatus: number) {
     super("Unable to refresh Sentry access");
-    this.name = "SentryRefreshError";
+    this.name = "SentryRefreshHttpError";
   }
+}
+
+export type SentryConnectionFailureKind =
+  | "http"
+  | "invalid_response"
+  | "network"
+  | "timeout";
+
+export interface SentryConnectionFailureDiagnostics {
+  errorCode: string;
+  failureKind: SentryConnectionFailureKind;
+  httpStatus?: number;
+  requestDurationMs: number;
+  retryable: boolean;
+}
+
+export class SentryConnectionUnavailableError extends Error {
+  readonly errorCode: string;
+  readonly failureKind: SentryConnectionFailureKind;
+  readonly httpStatus?: number;
+  readonly requestDurationMs: number;
+  readonly retryable: boolean;
+
+  constructor(
+    diagnostics: SentryConnectionFailureDiagnostics,
+    cause: unknown,
+  ) {
+    super("Unable to refresh Sentry access", { cause });
+    this.name = "SentryConnectionUnavailableError";
+    this.errorCode = diagnostics.errorCode;
+    this.failureKind = diagnostics.failureKind;
+    this.httpStatus = diagnostics.httpStatus;
+    this.requestDurationMs = diagnostics.requestDurationMs;
+    this.retryable = diagnostics.retryable;
+  }
+}
+
+function nestedErrorCode(error: unknown): string | undefined {
+  if (!error || typeof error !== "object" || !("cause" in error)) return undefined;
+  const cause = error.cause;
+  if (!cause || typeof cause !== "object" || !("code" in cause)) return undefined;
+  return typeof cause.code === "string" &&
+    /^[A-Z][A-Z0-9_]{0,99}$/u.test(cause.code)
+    ? cause.code
+    : undefined;
+}
+
+export function sentryConnectionFailureDiagnostics(
+  error: unknown,
+  requestDurationMs: number,
+): SentryConnectionFailureDiagnostics {
+  if (error instanceof SentryRefreshHttpError) {
+    return {
+      errorCode: error.name,
+      failureKind: "http",
+      httpStatus: error.httpStatus,
+      requestDurationMs,
+      retryable:
+        error.httpStatus === 408 ||
+        error.httpStatus === 429 ||
+        error.httpStatus >= 500,
+    };
+  }
+
+  const errorCode =
+    nestedErrorCode(error) ??
+    (error instanceof Error ? error.name : typeof error);
+  if (
+    errorCode === "TimeoutError" ||
+    errorCode === "AbortError" ||
+    errorCode === "ETIMEDOUT" ||
+    errorCode === "UND_ERR_CONNECT_TIMEOUT"
+  ) {
+    return {
+      errorCode,
+      failureKind: "timeout",
+      requestDurationMs,
+      retryable: true,
+    };
+  }
+  if (error instanceof SyntaxError || error instanceof z.ZodError) {
+    return {
+      errorCode,
+      failureKind: "invalid_response",
+      requestDurationMs,
+      retryable: true,
+    };
+  }
+  return {
+    errorCode,
+    failureKind: "network",
+    requestDurationMs,
+    retryable: true,
+  };
 }
 
 const sentryTriggerConfigSchema = z.object({
@@ -1726,27 +1820,39 @@ export async function getRuntimeSentryConnection(
               return { value: current };
             }
 
-            const response = await fetch(
-              `https://sentry.io/api/0/sentry-app-installations/${encodeURIComponent(current.installationId)}/authorizations/`,
-              {
-                method: "POST",
-                headers: {
-                  accept: "application/json",
-                  "content-type": "application/json",
+            const requestStartedAt = Date.now();
+            let refreshed: z.infer<typeof sentryAuthorizationSchema>;
+            try {
+              const response = await fetch(
+                `https://sentry.io/api/0/sentry-app-installations/${encodeURIComponent(current.installationId)}/authorizations/`,
+                {
+                  method: "POST",
+                  headers: {
+                    accept: "application/json",
+                    "content-type": "application/json",
+                  },
+                  body: JSON.stringify({
+                    grant_type: "refresh_token",
+                    refresh_token: current.refreshToken,
+                    client_id: clientId,
+                    client_secret: clientSecret,
+                  }),
+                  signal: AbortSignal.timeout(10_000),
                 },
-                body: JSON.stringify({
-                  grant_type: "refresh_token",
-                  refresh_token: current.refreshToken,
-                  client_id: clientId,
-                  client_secret: clientSecret,
-                }),
-                signal: AbortSignal.timeout(10_000),
-              },
-            );
-            if (!response.ok) throw new SentryRefreshError(response.status);
-            const refreshed = sentryAuthorizationSchema.parse(
-              await response.json(),
-            );
+              );
+              if (!response.ok) {
+                throw new SentryRefreshHttpError(response.status);
+              }
+              refreshed = sentryAuthorizationSchema.parse(await response.json());
+            } catch (error) {
+              throw new SentryConnectionUnavailableError(
+                sentryConnectionFailureDiagnostics(
+                  error,
+                  Date.now() - requestStartedAt,
+                ),
+                error,
+              );
+            }
             const nextCredentials = {
               accessToken: refreshed.token,
               refreshToken: refreshed.refreshToken,
@@ -1762,7 +1868,8 @@ export async function getRuntimeSentryConnection(
           organizationId: config.organizationId,
           provider: "sentry",
           statusOnError: (error) =>
-            error instanceof SentryRefreshError &&
+            error instanceof SentryConnectionUnavailableError &&
+              error.httpStatus !== undefined &&
               [400, 401, 403].includes(error.httpStatus)
               ? "error"
               : undefined,
@@ -1770,16 +1877,31 @@ export async function getRuntimeSentryConnection(
       if (!refreshedCredentials) return null;
       credentials = refreshedCredentials;
     } catch (error) {
+      const diagnostics =
+        error instanceof SentryConnectionUnavailableError
+          ? {
+              errorCode: error.errorCode,
+              failureKind: error.failureKind,
+              ...(error.httpStatus === undefined
+                ? {}
+                : { httpStatus: error.httpStatus }),
+              requestDurationMs: error.requestDurationMs,
+              retryable: error.retryable,
+            }
+          : {
+              errorCode: error instanceof Error ? error.name : typeof error,
+              failureKind: "internal",
+              retryable: false,
+            };
       console.error(
         JSON.stringify({
           event: "sentry_token_refresh_failed",
-          ...(error instanceof SentryRefreshError
-            ? { httpStatus: error.httpStatus }
-            : {}),
+          ...diagnostics,
           integrationAccountId: account.id,
         }),
       );
-      throw new Error("Unable to refresh Sentry access");
+      if (error instanceof SentryConnectionUnavailableError) throw error;
+      throw new Error("Unable to refresh Sentry access", { cause: error });
     }
   }
 

--- a/packages/core/src/db/sentry-connection.test.ts
+++ b/packages/core/src/db/sentry-connection.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import {
+  SentryConnectionUnavailableError,
+  SentryRefreshHttpError,
+  sentryConnectionFailureDiagnostics,
+} from "./investigations.js";
+
+describe("Sentry connection failure diagnostics", () => {
+  it("identifies request timeouts without recording secret-bearing messages", () => {
+    const diagnostics = sentryConnectionFailureDiagnostics(
+      new DOMException("The operation was aborted", "TimeoutError"),
+      10_004,
+    );
+
+    expect(diagnostics).toEqual({
+      errorCode: "TimeoutError",
+      failureKind: "timeout",
+      requestDurationMs: 10_004,
+      retryable: true,
+    });
+  });
+
+  it("preserves safe nested network error codes", () => {
+    const error = new TypeError("fetch failed", {
+      cause: Object.assign(new Error("connect timed out"), {
+        code: "UND_ERR_CONNECT_TIMEOUT",
+      }),
+    });
+
+    expect(sentryConnectionFailureDiagnostics(error, 10_001)).toEqual({
+      errorCode: "UND_ERR_CONNECT_TIMEOUT",
+      failureKind: "timeout",
+      requestDurationMs: 10_001,
+      retryable: true,
+    });
+  });
+
+  it("does not log arbitrary nested error codes", () => {
+    const error = new TypeError("fetch failed", {
+      cause: Object.assign(new Error("request failed"), {
+        code: "customer-token-value",
+      }),
+    });
+
+    expect(sentryConnectionFailureDiagnostics(error, 12)).toEqual({
+      errorCode: "TypeError",
+      failureKind: "network",
+      requestDurationMs: 12,
+      retryable: true,
+    });
+  });
+
+  it.each([
+    { httpStatus: 401, retryable: false },
+    { httpStatus: 429, retryable: true },
+    { httpStatus: 503, retryable: true },
+  ])("classifies HTTP $httpStatus refresh failures", ({ httpStatus, retryable }) => {
+    expect(
+      sentryConnectionFailureDiagnostics(
+        new SentryRefreshHttpError(httpStatus),
+        245,
+      ),
+    ).toEqual({
+      errorCode: "SentryRefreshHttpError",
+      failureKind: "http",
+      httpStatus,
+      requestDurationMs: 245,
+      retryable,
+    });
+  });
+
+  it("preserves the original failure as the monitored cause", () => {
+    const cause = new DOMException("The operation was aborted", "TimeoutError");
+    const diagnostics = sentryConnectionFailureDiagnostics(cause, 10_002);
+    const error = new SentryConnectionUnavailableError(diagnostics, cause);
+
+    expect(error).toMatchObject({
+      cause,
+      errorCode: "TimeoutError",
+      failureKind: "timeout",
+      message: "Unable to refresh Sentry access",
+      name: "SentryConnectionUnavailableError",
+      requestDurationMs: 10_002,
+      retryable: true,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- classify Sentry token refresh failures with safe structured diagnostics
- continue investigations without live Sentry context when the refresh API is unavailable
- report degraded context to monitoring and instruct the investigator to disclose missing live evidence

## Hosted deployment
- superloglabs/responder#169 pins this exact commit
- merge this public pull request before the hosted gitlink update

## Testing
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
- `pnpm build`