### PR TITLE
Support audited historical Slack backfills

### DIFF
--- a/apps/worker/src/backfill-slack-issues.ts
+++ b/apps/worker/src/backfill-slack-issues.ts
@@ -4,22 +4,27 @@ import { loadResponderSecrets } from "@responder/core/secrets";
 import { z } from "zod";
 
 const targetSchema = z.object({
+  allowDetachedIssue: z.boolean(),
   investigationId: z.uuid(),
   issueId: z.uuid(),
 });
 
 function parseTarget(value: string) {
-  const [investigationId, issueId, ...extra] = value.split(":");
-  if (extra.length > 0) {
+  const [investigationId, issueId, mode, ...extra] = value.split(":");
+  if (extra.length > 0 || (mode !== undefined && mode !== "detached")) {
     throw new Error(`Invalid Slack issue backfill target: ${value}`);
   }
-  return targetSchema.parse({ investigationId, issueId });
+  return targetSchema.parse({
+    allowDetachedIssue: mode === "detached",
+    investigationId,
+    issueId,
+  });
 }
 
 const [deliveryRunId, ...targetValues] = process.argv.slice(2);
 if (!deliveryRunId || targetValues.length === 0) {
   throw new Error(
-    "Usage: backfill-slack-issues <delivery-run-id> <investigation-id:issue-id> [...]",
+    "Usage: backfill-slack-issues <delivery-run-id> <investigation-id:issue-id[:detached]> [...]",
   );
 }
 

--- a/packages/core/src/db/issues.ts
+++ b/packages/core/src/db/issues.ts
@@ -587,6 +587,44 @@ export async function getInvestigationIssueDetails(investigationId: string) {
     .orderBy(issues.createdAt);
 }
 
+export async function getIssueForSlackBackfill(input: {
+  investigationId: string;
+  issueId: string;
+}) {
+  const rows = await getDatabase()
+    .select({
+      id: issues.id,
+      title: issues.title,
+      description: issues.description,
+      rootCause: issues.rootCause,
+      timeline: issues.timeline,
+      severity: issues.severity,
+      remediation: issues.remediation,
+      remediations: issues.remediations,
+      evidence: issues.evidence,
+    })
+    .from(issues)
+    .innerJoin(
+      investigations,
+      eq(investigations.organizationId, issues.organizationId),
+    )
+    .where(
+      and(
+        eq(investigations.id, input.investigationId),
+        eq(issues.id, input.issueId),
+      ),
+    )
+    .limit(1);
+  const issue = rows[0];
+  return issue
+    ? {
+        ...issue,
+        pullRequest: null,
+        relationship: "new" as const,
+      }
+    : null;
+}
+
 export interface SlackInvestigationDeliveryContext {
   agentId: string;
   investigationId: string;

--- a/packages/core/src/integrations/slack-delivery.test.ts
+++ b/packages/core/src/integrations/slack-delivery.test.ts
@@ -128,6 +128,7 @@ describe("Slack issue delivery", () => {
               threadTimestamp: "1785500000.000100",
             },
           } as never),
+          getDetachedIssue: vi.fn().mockResolvedValue(null),
           postMessage,
           recordReply,
           registerPullRequestMessage,
@@ -163,6 +164,76 @@ describe("Slack issue delivery", () => {
         slackTimestamp: "1785500001.000200",
       }),
     );
+  });
+
+  it("requires an explicit flag to redeliver a detached historical issue", async () => {
+    const issue = {
+      id: "07070707-0707-4707-8707-070707070707",
+      title: "Historical delivery failure",
+      description: "Slack rejected the original issue card.",
+      rootCause: "The card body exceeded Slack's limit.",
+      timeline: [],
+      severity: "SEV-2" as const,
+      remediation: "Truncate card bodies.",
+      remediations: [],
+      relationship: "new" as const,
+      evidence: [],
+      pullRequest: null,
+    };
+    const getDetachedIssue = vi.fn().mockResolvedValue(issue);
+    const postMessage = vi.fn().mockResolvedValue("1785500002.000300");
+    const dependencies = {
+      getContext: vi.fn().mockResolvedValue({
+        investigationId: "08080808-0808-4808-8808-080808080808",
+        issues: [],
+        prMode: "manual",
+        source: {
+          channelId: "C123",
+          encryptedCredentials: "encrypted",
+          integrationAccountId: "09090909-0909-4909-8909-090909090909",
+          messageTimestamp: null,
+          reactionTimestamp: "1785500000.000100",
+          threadTimestamp: "1785500000.000100",
+        },
+      } as never),
+      getDetachedIssue,
+      postMessage,
+      recordReply: vi.fn().mockResolvedValue(undefined),
+      registerPullRequestMessage: vi.fn().mockResolvedValue(undefined),
+      resolveAccessToken: vi.fn().mockReturnValue("xoxb-test"),
+    };
+
+    await expect(
+      redeliverInvestigationSlackIssue(
+        {
+          deliveryRunId: "backfill-2026-08-27",
+          investigationId: "08080808-0808-4808-8808-080808080808",
+          issueId: issue.id,
+        },
+        dependencies,
+      ),
+    ).rejects.toThrow("is not available for investigation");
+    expect(getDetachedIssue).not.toHaveBeenCalled();
+
+    await expect(
+      redeliverInvestigationSlackIssue(
+        {
+          allowDetachedIssue: true,
+          deliveryRunId: "backfill-2026-08-27",
+          investigationId: "08080808-0808-4808-8808-080808080808",
+          issueId: issue.id,
+        },
+        dependencies,
+      ),
+    ).resolves.toEqual({
+      issueId: issue.id,
+      messageTimestamp: "1785500002.000300",
+    });
+    expect(getDetachedIssue).toHaveBeenCalledWith({
+      investigationId: "08080808-0808-4808-8808-080808080808",
+      issueId: issue.id,
+    });
+    expect(postMessage).toHaveBeenCalledTimes(1);
   });
 
   it("shows root cause and an ordered timeline in the issue message", () => {

--- a/packages/core/src/integrations/slack-delivery.ts
+++ b/packages/core/src/integrations/slack-delivery.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { decryptCredentials } from "../credentials/encryption.js";
 import { responderIssueUrl } from "../responder-urls.js";
 import {
+  getIssueForSlackBackfill,
   getSlackInvestigationDeliveryContext,
   type SlackInvestigationDeliveryContext,
 } from "../db/issues.js";
@@ -230,6 +231,7 @@ function accessToken(encryptedCredentials: string): string {
 
 interface SlackIssueRedeliveryDependencies {
   getContext: typeof getSlackInvestigationDeliveryContext;
+  getDetachedIssue: typeof getIssueForSlackBackfill;
   postMessage: typeof postSlackMessage;
   recordReply: typeof recordInvestigationSlackReply;
   registerPullRequestMessage: typeof registerPullRequestMessage;
@@ -238,6 +240,7 @@ interface SlackIssueRedeliveryDependencies {
 
 export async function redeliverInvestigationSlackIssue(
   input: {
+    allowDetachedIssue?: boolean;
     deliveryRunId: string;
     investigationId: string;
     issueId: string;
@@ -246,6 +249,7 @@ export async function redeliverInvestigationSlackIssue(
 ): Promise<{ issueId: string; messageTimestamp: string }> {
   const resolvedDependencies = dependencies ?? {
     getContext: getSlackInvestigationDeliveryContext,
+    getDetachedIssue: getIssueForSlackBackfill,
     postMessage: postSlackMessage,
     recordReply: recordInvestigationSlackReply,
     registerPullRequestMessage,
@@ -257,10 +261,16 @@ export async function redeliverInvestigationSlackIssue(
       `Slack source thread is unavailable for investigation ${input.investigationId}`,
     );
   }
-  const issue = context.issues.find((candidate) => candidate.id === input.issueId);
+  const issue = context.issues.find((candidate) => candidate.id === input.issueId) ??
+    (input.allowDetachedIssue
+      ? await resolvedDependencies.getDetachedIssue({
+          investigationId: input.investigationId,
+          issueId: input.issueId,
+        })
+      : null);
   if (!issue) {
     throw new Error(
-      `Issue ${input.issueId} is not attached to investigation ${input.investigationId}`,
+      `Issue ${input.issueId} is not available for investigation ${input.investigationId}`,
     );
   }
   const message = issueSlackMessage(context, issue);


### PR DESCRIPTION
## What changed
- add an explicit `:detached` backfill mode for historical issues removed from their original investigation by a later rerun
- require the detached issue and investigation to belong to the same organization
- keep normal redelivery strict by default
- add regression coverage proving the opt-in requirement

## Why
The production delivery log proves issue `11cc3131-fd20-4dc6-a80e-8d4beba44aaa` was attached when Slack rejected its card. A later rerun archived and detached it, so the normal safety check correctly prevents redelivery. This narrow mode allows that audited historical card to be restored without changing normal delivery behavior.

## Validation
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test` (844 passed)
- `pnpm build`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an explicit `:detached` backfill mode so audited historical Slack cards can be redelivered after a later rerun detached them from their investigation. Normal redelivery stays strict by default; detached mode requires opt-in and verifies the issue and investigation belong to the same organization.

**Migration**
- Backfill targets accept an optional `:detached` suffix, e.g. `investigation-id:issue-id:detached`.
- Existing targets without the suffix keep the previous strict behavior unchanged.

<sup>Written for commit 73385d4fb091e44b44f54c9d78e00568a17e22e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/responder-oss/pull/78?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

