### PR TITLE
Make Daytona sandbox retries safe

### DIFF
--- a/apps/worker/src/investigate.ts
+++ b/apps/worker/src/investigate.ts
@@ -55,6 +55,7 @@ import {
 import {
   closeDaytonaSandbox,
   configureDaytonaSandboxLifecycle,
+  createDaytonaSandboxSession,
   prepareDaytonaSandbox,
 } from "./sandbox.js";
 import {
@@ -509,9 +510,10 @@ export async function runInvestigationAgent(
     (server): server is NonNullable<typeof server> => server !== null,
   );
 
+  const sandboxName = `responder-investigation-${job.investigationId}`;
   const client = new DaytonaSandboxClient({
     ...daytonaClientOptions(config),
-    name: `responder-investigation-${job.investigationId}`,
+    name: sandboxName,
     pauseOnExit: false,
   });
 
@@ -564,7 +566,7 @@ export async function runInvestigationAgent(
         );
       }
     }
-    session = await client.create();
+    session = await createDaytonaSandboxSession(client, config, sandboxName);
     await configureDaytonaSandboxLifecycle(session, config, workspaceSecrets);
     await prepareDaytonaSandbox(session);
     const repositories = await checkoutRuntimeRepositories(

--- a/apps/worker/src/remediate.ts
+++ b/apps/worker/src/remediate.ts
@@ -23,6 +23,7 @@ import { checkoutRuntimeRepositories } from "./repositories.js";
 import {
   closeDaytonaSandbox,
   configureDaytonaSandboxLifecycle,
+  createDaytonaSandboxSession,
   prepareDaytonaSandbox,
 } from "./sandbox.js";
 import {
@@ -179,15 +180,16 @@ export async function runRemediationAgent(
   setTracingDisabled(true);
   const runtimeProfile = await getRuntimeProfile(job.runtimeProfileId);
   const workspaceSecrets = await getRuntimeWorkspaceSecrets(job.config.id);
+  const sandboxName = `responder-remediation-${job.remediationRequestId}`;
   const client = new DaytonaSandboxClient({
     ...daytonaClientOptions(config),
-    name: `responder-remediation-${job.remediationRequestId}`,
+    name: sandboxName,
     pauseOnExit: false,
   });
   let session: DaytonaSandboxSession | null = null;
 
   try {
-    session = await client.create();
+    session = await createDaytonaSandboxSession(client, config, sandboxName);
     await configureDaytonaSandboxLifecycle(session, config, workspaceSecrets);
     await prepareDaytonaSandbox(session);
     const repositories = await checkoutRuntimeRepositories(

--- a/apps/worker/src/review-pull-request.ts
+++ b/apps/worker/src/review-pull-request.ts
@@ -24,6 +24,7 @@ import { checkoutRuntimeRepositoriesAtRefs } from "./repositories.js";
 import {
   closeDaytonaSandbox,
   configureDaytonaSandboxLifecycle,
+  createDaytonaSandboxSession,
   prepareDaytonaSandbox,
 } from "./sandbox.js";
 import { workspaceSecretUsageInstructions } from "./secret-safety.js";
@@ -81,15 +82,16 @@ export async function runPullRequestReviewAgent(
     getRuntimeProfile(job.runtimeProfileId),
     getRuntimeWorkspaceSecrets(job.config.id),
   ]);
+  const sandboxName = `responder-pr-review-${job.requestId}`;
   const client = new DaytonaSandboxClient({
     ...daytonaClientOptions(config),
-    name: `responder-pr-review-${job.requestId}`,
+    name: sandboxName,
     pauseOnExit: false,
   });
   let session: DaytonaSandboxSession | null = null;
 
   try {
-    session = await client.create();
+    session = await createDaytonaSandboxSession(client, config, sandboxName);
     await configureDaytonaSandboxLifecycle(session, config, workspaceSecrets);
     await prepareDaytonaSandbox(session);
     const repositories = await checkoutRuntimeRepositoriesAtRefs(

--- a/apps/worker/src/sandbox.test.ts
+++ b/apps/worker/src/sandbox.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   closeDaytonaSandbox,
   configureDaytonaSandboxLifecycle,
+  createDaytonaSandboxSession,
   type DaytonaCleanupDependencies,
   prepareDaytonaSandbox,
 } from "./sandbox.js";
@@ -100,6 +101,62 @@ describe("Daytona sandbox preparation", () => {
 });
 
 describe("Daytona sandbox cleanup", () => {
+  it("removes an existing named sandbox before creating a replacement", async () => {
+    const harness = cleanupHarness();
+    const createdSession = { state: { sandboxId: "sandbox-2" } };
+    const creator = {
+      create: vi.fn().mockResolvedValue(createdSession),
+    };
+
+    await expect(
+      createDaytonaSandboxSession(
+        creator,
+        { daytonaApiKey: "daytona-test" },
+        "responder-investigation-1",
+        harness.dependencies,
+      ),
+    ).resolves.toBe(createdSession);
+
+    expect(harness.get).toHaveBeenCalledWith("responder-investigation-1");
+    expect(harness.deleteSandbox).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "sandbox-1" }),
+      60,
+      true,
+    );
+    expect(creator.create).toHaveBeenCalledOnce();
+  });
+
+  it("cleans up a sandbox that appears after creation times out", async () => {
+    const harness = cleanupHarness({ missing: true });
+    const timeout = new Error("sandbox creation timed out");
+    const creator = { create: vi.fn().mockRejectedValue(timeout) };
+    harness.get
+      .mockRejectedValueOnce(
+        Object.assign(new Error("missing"), { statusCode: 404 }),
+      )
+      .mockRejectedValueOnce(
+        Object.assign(new Error("missing"), { statusCode: 404 }),
+      )
+      .mockResolvedValueOnce({ id: "sandbox-1" });
+
+    await expect(
+      createDaytonaSandboxSession(
+        creator,
+        { daytonaApiKey: "daytona-test" },
+        "responder-investigation-1",
+        harness.dependencies,
+      ),
+    ).rejects.toBe(timeout);
+
+    expect(harness.get).toHaveBeenCalledTimes(3);
+    expect(harness.deleteSandbox).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "sandbox-1" }),
+      60,
+      true,
+    );
+    expect(harness.sleep).toHaveBeenCalledWith(500);
+  });
+
   it("enables provider-side deletion when a sandbox stops", async () => {
     const harness = cleanupHarness();
     const setAutoDeleteInterval = vi.fn().mockResolvedValue(undefined);
@@ -117,6 +174,32 @@ describe("Daytona sandbox cleanup", () => {
 
     expect(setAutoDeleteInterval).toHaveBeenCalledWith(0);
     expect(harness.dispose).toHaveBeenCalledOnce();
+  });
+
+  it("retries transient lifecycle failures", async () => {
+    const harness = cleanupHarness();
+    const gatewayError = Object.assign(new Error("bad gateway"), {
+      name: "DaytonaBadGatewayError",
+      statusCode: 502,
+    });
+    const setAutoDeleteInterval = vi
+      .fn()
+      .mockRejectedValueOnce(gatewayError)
+      .mockResolvedValue(undefined);
+    harness.get.mockResolvedValue({
+      id: "sandbox-1",
+      setAutoDeleteInterval,
+    });
+
+    await configureDaytonaSandboxLifecycle(
+      harness.session,
+      { daytonaApiKey: "daytona-test" },
+      [],
+      harness.dependencies,
+    );
+
+    expect(setAutoDeleteInterval).toHaveBeenCalledTimes(2);
+    expect(harness.sleep).toHaveBeenCalledWith(500);
   });
 
   it("mounts opaque secrets and restarts before enabling stop-time deletion", async () => {

--- a/apps/worker/src/sandbox.ts
+++ b/apps/worker/src/sandbox.ts
@@ -2,7 +2,10 @@ import {
   Daytona,
   type Sandbox,
 } from "@daytona/sdk";
-import type { DaytonaSandboxSession } from "@openai/agents-extensions/sandbox/daytona";
+import type {
+  DaytonaSandboxClient,
+  DaytonaSandboxSession,
+} from "@openai/agents-extensions/sandbox/daytona";
 import {
   daytonaClientOptions,
   isDaytonaNotFound,
@@ -23,6 +26,8 @@ interface DaytonaCleanupClient {
   [Symbol.asyncDispose](): Promise<void>;
 }
 
+type DaytonaSandboxCreator = Pick<DaytonaSandboxClient, "create">;
+
 export interface DaytonaCleanupDependencies {
   createClient(config: DaytonaCleanupConfig): DaytonaCleanupClient;
   reportException: typeof reportWorkerException;
@@ -38,6 +43,115 @@ const defaultCleanupDependencies: DaytonaCleanupDependencies = {
     }),
 };
 
+const daytonaRetryDelaysMs = [0, 500, 1_500] as const;
+
+function isTransientDaytonaError(error: unknown): boolean {
+  if (typeof error === "object" && error !== null && "statusCode" in error) {
+    const statusCode = error.statusCode;
+    if (
+      typeof statusCode === "number" &&
+      (statusCode === 408 || statusCode === 429 || statusCode >= 500)
+    ) {
+      return true;
+    }
+  }
+  return (
+    error instanceof Error &&
+    [
+      "DaytonaBadGatewayError",
+      "DaytonaConnectionError",
+      "DaytonaConnectionTimeoutError",
+      "DaytonaInternalServerError",
+      "DaytonaRateLimitError",
+      "DaytonaServiceUnavailableError",
+      "DaytonaTimeoutError",
+    ].includes(error.name)
+  );
+}
+
+async function retryTransientDaytonaOperation<T>(
+  operation: () => Promise<T>,
+  dependencies: DaytonaCleanupDependencies,
+): Promise<T> {
+  let lastError: unknown;
+  for (const delayMs of daytonaRetryDelaysMs) {
+    if (delayMs > 0) await dependencies.sleep(delayMs);
+    try {
+      return await operation();
+    } catch (error) {
+      lastError = error;
+      if (!isTransientDaytonaError(error)) throw error;
+    }
+  }
+  throw lastError;
+}
+
+async function deleteDaytonaSandboxByReference(
+  reference: string,
+  config: DaytonaCleanupConfig,
+  waitForAppearance: boolean,
+  dependencies: DaytonaCleanupDependencies,
+): Promise<void> {
+  const client = dependencies.createClient(config);
+  try {
+    for (const [index, delayMs] of daytonaRetryDelaysMs.entries()) {
+      if (delayMs > 0) await dependencies.sleep(delayMs);
+      try {
+        const sandbox = await client.get(reference);
+        await client.delete(sandbox, 60, true);
+        return;
+      } catch (error) {
+        if (isDaytonaNotFound(error)) {
+          if (waitForAppearance && index < daytonaRetryDelaysMs.length - 1) {
+            continue;
+          }
+          return;
+        }
+        if (
+          !isTransientDaytonaError(error) ||
+          index === daytonaRetryDelaysMs.length - 1
+        ) {
+          throw error;
+        }
+      }
+    }
+  } finally {
+    await client[Symbol.asyncDispose]().catch(() => undefined);
+  }
+}
+
+export async function createDaytonaSandboxSession(
+  creator: DaytonaSandboxCreator,
+  config: DaytonaCleanupConfig,
+  sandboxName: string,
+  dependencies: DaytonaCleanupDependencies = defaultCleanupDependencies,
+): Promise<DaytonaSandboxSession> {
+  await deleteDaytonaSandboxByReference(
+    sandboxName,
+    config,
+    false,
+    dependencies,
+  );
+  try {
+    return await creator.create();
+  } catch (createError) {
+    try {
+      await deleteDaytonaSandboxByReference(
+        sandboxName,
+        config,
+        true,
+        dependencies,
+      );
+    } catch (cleanupError) {
+      throw new AggregateError(
+        [createError, cleanupError],
+        `Unable to create or clean up Daytona sandbox ${sandboxName}`,
+      );
+    }
+    throw createError;
+  }
+}
+
 export async function configureDaytonaSandboxLifecycle(
   session: DaytonaSandboxSession,
   config: DaytonaCleanupConfig,
@@ -46,20 +160,30 @@ export async function configureDaytonaSandboxLifecycle(
 ): Promise<void> {
   const client = dependencies.createClient(config);
   try {
-    const sandbox = await client.get(session.state.sandboxId);
+    const sandbox = await retryTransientDaytonaOperation(
+      () => client.get(session.state.sandboxId),
+      dependencies,
+    );
     if (secrets.length > 0) {
-      await sandbox.updateSecrets(
-        Object.fromEntries(
-          secrets.map((secret) => [
-            secret.environmentVariable,
-            secret.daytonaSecretName,
-          ]),
-        ),
+      await retryTransientDaytonaOperation(
+        () =>
+          sandbox.updateSecrets(
+            Object.fromEntries(
+              secrets.map((secret) => [
+                secret.environmentVariable,
+                secret.daytonaSecretName,
+              ]),
+            ),
+          ),
+        dependencies,
       );
-      await sandbox.stop();
-      await sandbox.start();
+      await retryTransientDaytonaOperation(() => sandbox.stop(), dependencies);
+      await retryTransientDaytonaOperation(() => sandbox.start(), dependencies);
     }
-    await sandbox.setAutoDeleteInterval(0);
+    await retryTransientDaytonaOperation(
+      () => sandbox.setAutoDeleteInterval(0),
+      dependencies,
+    );
   } finally {
     await client[Symbol.asyncDispose]().catch(() => undefined);
   }


### PR DESCRIPTION
## Summary

- retry transient Daytona lifecycle operations
- remove stale named sandboxes before creating replacements
- clean up sandboxes that appear after creation timeouts
- apply the shared acquisition path to investigations, remediations, and PR reviews

Fixes RESPONDER-PROD-T.
Fixes RESPONDER-PROD-R.

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
- `pnpm build:app`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retries transient Daytona sandbox operations and removes stale named sandboxes before creating replacements, fixing RESPONDER-PROD-T and RESPONDER-PROD-R.

- Retries lifecycle calls (get, secret updates, stop/start, auto-delete) up to three times with backoff on transient errors.
- Deletes any sandbox already using the target name before creating a new session.
- Watches for a sandbox appearing after a creation timeout and removes it.
- Routes investigations, remediations, and PR reviews through the shared sandbox acquisition path.

<sup>Written for commit 54b6ff55211af93f91faa273942266936b75d8a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/responder-oss/pull/81?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

