### PR TITLE
Refine Slack investigation feedback

### DIFF
--- a/apps/control-plane/server/index.test.ts
+++ b/apps/control-plane/server/index.test.ts
@@ -1068,7 +1068,7 @@ describe("control-plane API", () => {
     expect(message.blocks).toContainEqual(
       expect.objectContaining({
         type: "plan",
-        title: "Plant API error rate is elevated",
+        title: "Investigation trace",
         tasks: [
           expect.objectContaining({
             status: "in_progress",

--- a/packages/core/src/integrations/slack-delivery.test.ts
+++ b/packages/core/src/integrations/slack-delivery.test.ts
@@ -5,11 +5,12 @@ import {
   slackCompletedInvestigationCard,
   slackDeliveryClientMessageId,
   slackDeliveryErrorMessage,
+  slackInvestigationSummaryMessage,
   slackIssueMessage,
 } from "./slack-delivery.js";
 
 describe("Slack issue delivery", () => {
-  it("adds feedback controls to completed investigation messages", () => {
+  it("keeps the completed investigation card focused on the trace", () => {
     const investigationId = "16161616-1616-4616-8616-161616161616";
     const message = slackCompletedInvestigationCard({
       agentId: "13131313-1313-4313-8313-131313131313",
@@ -19,7 +20,26 @@ describe("Slack issue delivery", () => {
     });
 
     expect(message.blocks).toEqual([
-      expect.objectContaining({ type: "plan" }),
+      expect.objectContaining({ type: "plan", title: "Investigation trace" }),
+    ]);
+  });
+
+  it("adds feedback controls without a remove action to the final summary", () => {
+    const investigationId = "16161616-1616-4616-8616-161616161616";
+    const message = slackInvestigationSummaryMessage({
+      investigationId,
+      issueCount: 0,
+      summary: "The alert was transient.",
+    });
+
+    expect(message.text).toBe(
+      "✅ *No issues identified.* The alert was transient.",
+    );
+    expect(message.blocks).toEqual([
+      {
+        type: "section",
+        text: { type: "mrkdwn", text: message.text },
+      },
       expect.objectContaining({
         type: "context_actions",
         block_id: expect.stringMatching(
@@ -31,11 +51,6 @@ describe("Slack issue delivery", () => {
             action_id: "feedback",
             positive_button: expect.objectContaining({ value: "positive" }),
             negative_button: expect.objectContaining({ value: "negative" }),
-          }),
-          expect.objectContaining({
-            type: "icon_button",
-            action_id: "remove",
-            icon: "trash",
           }),
         ],
       }),

--- a/packages/core/src/integrations/slack-delivery.ts
+++ b/packages/core/src/integrations/slack-delivery.ts
@@ -90,6 +90,24 @@ export function slackThreadCompletionText(
   return `*${issueCount} ${issueCount === 1 ? "issue" : "issues"} identified:*`;
 }
 
+export function slackInvestigationSummaryMessage(input: {
+  investigationId: string;
+  issueCount: number;
+  summary: string;
+}): { blocks: unknown[]; text: string } {
+  const text = slackThreadCompletionText(input.summary, input.issueCount);
+  return {
+    text,
+    blocks: [
+      {
+        type: "section",
+        text: { type: "mrkdwn", text },
+      },
+      slackInvestigationFeedbackBlock(input.investigationId),
+    ],
+  };
+}
+
 function escapeSlack(value: string): string {
   return value
     .replaceAll("&", "&amp;")
@@ -315,7 +333,7 @@ export function slackCompletedInvestigationCard(
     "agentId" | "investigationId" | "title" | "traceItems"
   >,
 ) {
-  const card = slackInvestigationCard({
+  return slackInvestigationCard({
     agentId: context.agentId,
     detail: "Completed the investigation plan.",
     investigationId: context.investigationId,
@@ -323,13 +341,6 @@ export function slackCompletedInvestigationCard(
     title: context.title,
     traceItems: context.traceItems ?? [],
   });
-  return {
-    ...card,
-    blocks: [
-      ...card.blocks,
-      slackInvestigationFeedbackBlock(context.investigationId),
-    ],
-  };
 }
 
 export function slackDeliveryErrorMessage(error: unknown): string {
@@ -413,10 +424,11 @@ async function deliverSourceThread(
   if (!context.source) return;
   const token = accessToken(context.source.encryptedCredentials);
   const failures: unknown[] = [];
-  const completionText = slackThreadCompletionText(
-    context.report.summary,
-    context.issues.length,
-  );
+  const summaryMessage = slackInvestigationSummaryMessage({
+    investigationId: context.investigationId,
+    issueCount: context.issues.length,
+    summary: context.report.summary,
+  });
   if (context.source.messageTimestamp) {
     const card = slackCompletedInvestigationCard(context);
     try {
@@ -449,12 +461,13 @@ async function deliverSourceThread(
   try {
     const messageTimestamp = await postSlackMessage({
       accessToken: token,
+      blocks: summaryMessage.blocks,
       channelId: context.source.channelId,
       clientMessageId: slackDeliveryClientMessageId(
         deliveryRunId,
         `source:${context.source.channelId}:summary`,
       ),
-      text: completionText,
+      text: summaryMessage.text,
       threadTimestamp: context.source.threadTimestamp,
     });
     if (!messageTimestamp) {
@@ -463,10 +476,10 @@ async function deliverSourceThread(
     await recordInvestigationSlackReply(context.investigationId, {
       attachments: [],
       authorName: "Responder",
-      blocks: [],
+      blocks: summaryMessage.blocks,
       key: "investigation-summary",
       slackTimestamp: messageTimestamp,
-      text: completionText,
+      text: summaryMessage.text,
     });
   } catch (error) {
     console.error(

--- a/packages/core/src/integrations/slack-live-card.test.ts
+++ b/packages/core/src/integrations/slack-live-card.test.ts
@@ -128,7 +128,7 @@ describe("Slack live investigation card", () => {
     expect(message.blocks).toEqual([
       expect.objectContaining({
         type: "plan",
-        title: context.title,
+        title: "Investigation trace",
         tasks: [
           expect.objectContaining({
             status: "in_progress",
@@ -164,7 +164,7 @@ describe("Slack live investigation card", () => {
     ).toBeNull();
   });
 
-  it("renders ClickStack's alert shortcode as an emoji in the plan title", () => {
+  it("keeps the investigation title in fallback text while using a fixed plan title", () => {
     vi.stubEnv("RESPONDER_APP_URL", "https://responder.example");
 
     const message = slackInvestigationCard({
@@ -178,7 +178,7 @@ describe("Slack live investigation card", () => {
     expect(message.blocks).toEqual([
       expect.objectContaining({
         type: "plan",
-        title: '🚨 Alert for "Errors"',
+        title: "Investigation trace",
       }),
     ]);
     expect(message.text).toBe(

--- a/packages/core/src/integrations/slack-live-card.ts
+++ b/packages/core/src/integrations/slack-live-card.ts
@@ -45,12 +45,6 @@ export function slackInvestigationFeedbackBlock(investigationId: string) {
           accessibility_label: "Submit negative investigation feedback",
         },
       },
-      {
-        type: "icon_button",
-        action_id: "remove",
-        icon: "trash",
-        text: { type: "plain_text", text: "Remove" },
-      },
     ],
   };
 }
@@ -821,7 +815,7 @@ export function slackInvestigationCard(input: {
       {
         type: "plan",
         block_id: `investigation_plan_${input.status}_${randomUUID()}`,
-        title,
+        title: "Investigation trace",
         tasks: [
           ...(input.traceItems ?? [])
             .slice(-11)


### PR DESCRIPTION
## Summary
- use a fixed “Investigation trace” title for Slack plan cards
- move investigation feedback controls to the final summary message
- remove the feedback remove action

## Validation
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test` (859 tests)