### PR TITLE
Fix silent agent creation submissions

### DIFF
--- a/apps/control-plane/e2e/workspace-onboarding.spec.ts
+++ b/apps/control-plane/e2e/workspace-onboarding.spec.ts
@@ -62,6 +62,29 @@ test.beforeEach(async ({ page }) => {
   await mockApplicationApis(page);
 });
 
+async function mockSignedInWorkspace(page: Page) {
+  await page.route("**/api/auth/**", async (route) => {
+    const path = new URL(route.request().url()).pathname;
+
+    if (path.endsWith("/get-session")) {
+      await route.fulfill({ json: sessionResponse(organization.id) });
+      return;
+    }
+
+    if (path.endsWith("/organization/list")) {
+      await route.fulfill({ json: [organization] });
+      return;
+    }
+
+    if (path.endsWith("/organization/get-full-organization")) {
+      await route.fulfill({ json: organization });
+      return;
+    }
+
+    await route.fulfill({ json: null });
+  });
+}
+
 test("opens agent creation after creating a workspace", async ({ page }) => {
   let activeOrganizationId: string | null = null;
 
@@ -202,6 +225,91 @@ test("shows specific workspace secret validation issues", async ({
   await expect(dialog.getByRole("alert")).toHaveText(
     "PATH controls the sandbox runtime; choose a credential-specific environment variable name. Use a hostname without a scheme, path, or port",
   );
+});
+
+test("explains an earlier missing requirement when a saved draft resumes on the prompt step", async ({
+  page,
+}) => {
+  await mockSignedInWorkspace(page);
+  await page.addInitScript(() => {
+    window.sessionStorage.setItem("responder:new-agent-step", "4");
+  });
+
+  await page.goto("/agents/new");
+  await expect(page.getByRole("heading", { name: "Prompt" })).toBeVisible();
+  await expect(
+    page.getByText("Connect Sentry and choose at least one project."),
+  ).toBeVisible();
+
+  await page.getByRole("button", { name: "Create agent" }).click();
+
+  await expect(page.getByRole("alert")).toHaveText(
+    "Connect Sentry and choose at least one project.",
+  );
+  await expect(page.getByRole("heading", { name: "Input" })).toBeVisible();
+});
+
+test("submits a complete saved draft without depending on a native submitter", async ({
+  page,
+}) => {
+  await mockSignedInWorkspace(page);
+  const agentOptions = {
+    accounts: [
+      {
+        id: "slack-account-1",
+        provider: "slack",
+        displayName: "Acme Slack",
+        slackContextAvailable: true,
+      },
+    ],
+    resources: [
+      {
+        id: "slack-channel-1",
+        integrationAccountId: "slack-account-1",
+        kind: "slack_channel",
+        externalId: "C123",
+        displayName: "incidents",
+      },
+    ],
+    repositories: [],
+    secrets: [],
+  };
+  await page.route(/\/api\/agents\/options(?:\/refresh\/slack)?$/, (route) =>
+    route.fulfill({ json: agentOptions }),
+  );
+  await page.route("**/api/agents", async (route) => {
+    if (route.request().method() === "POST") {
+      await route.fulfill({ status: 201, json: { agentId: "agent-1" } });
+      return;
+    }
+    await route.fulfill({ json: { agents: [] } });
+  });
+  await page.addInitScript(() => {
+    window.sessionStorage.setItem("responder:new-agent-step", "4");
+    window.sessionStorage.setItem(
+      "responder:new-agent-draft",
+      JSON.stringify({
+        inputKind: "slack_channel",
+        slackInputResourceId: "slack-channel-1",
+        outputMode: "thread",
+      }),
+    );
+  });
+
+  await page.goto("/agents/new");
+  await expect(page.getByRole("heading", { name: "Prompt" })).toBeVisible();
+  const createRequest = page.waitForRequest(
+    (request) =>
+      new URL(request.url()).pathname === "/api/agents" &&
+      request.method() === "POST",
+  );
+
+  await page.locator("form.createAgentForm").evaluate((form) =>
+    (form as HTMLFormElement).requestSubmit(),
+  );
+
+  await createRequest;
+  await expect(page).toHaveURL(/\/agents\/agent-1$/);
 });
 
 test("keeps an invitation link open while the recipient signs in", async ({

--- a/apps/control-plane/src/pages/agent-create.tsx
+++ b/apps/control-plane/src/pages/agent-create.tsx
@@ -488,7 +488,6 @@ export function AgentCreatePage() {
   const [connectionSettingsOpen, setConnectionSettingsOpen] = useState<
     AgentOptions["accounts"][number] | null
   >(null);
-  const [promptStepReady, setPromptStepReady] = useState(false);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [connectingProvider, setConnectingProvider] =
@@ -596,12 +595,6 @@ export function AgentCreatePage() {
     slackContextDialogOpen,
     vercelDialogOpen,
   ]);
-
-  useEffect(() => {
-    if (activeStep !== 4 || promptStepReady) return;
-    const timeout = window.setTimeout(() => setPromptStepReady(true), 500);
-    return () => window.clearTimeout(timeout);
-  }, [activeStep, promptStepReady]);
 
   useEffect(() => {
     let cancelled = false;
@@ -1324,7 +1317,6 @@ export function AgentCreatePage() {
 
   function showStep(step: CreateStep) {
     if (step > furthestStep) return;
-    if (step === 4) setPromptStepReady(false);
     setActiveStep(step);
     setError(null);
     window.scrollTo({ top: 0, behavior: "smooth" });
@@ -1337,7 +1329,6 @@ export function AgentCreatePage() {
     }
     if (activeStep === 4) return;
     const nextStep = (activeStep + 1) as CreateStep;
-    if (nextStep === 4) setPromptStepReady(false);
     setActiveStep(nextStep);
     setFurthestStep((current) =>
       Math.max(current, nextStep) as CreateStep
@@ -1355,13 +1346,7 @@ export function AgentCreatePage() {
 
   async function submit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    const submitter = (event.nativeEvent as SubmitEvent).submitter;
-    if (
-      activeStep !== 4 ||
-      !promptStepReady ||
-      !(submitter instanceof HTMLButtonElement) ||
-      submitter.dataset.submitAgent !== "true"
-    ) {
+    if (activeStep !== 4) {
       if (activeStep < 4) continueToNextStep();
       return;
     }
@@ -2972,12 +2957,12 @@ export function AgentCreatePage() {
               <span
                 aria-live="polite"
                 className={
-                  currentRequirement
+                  currentRequirement || (activeStep === 4 && missingRequirement)
                     ? "createRequirement"
                     : "createRequirement isReady"
                 }
               >
-                {currentRequirement ??
+                {(activeStep === 4 ? missingRequirement : currentRequirement) ??
                   (activeStep === 3
                     ? "Context is optional. Add only what the agent needs."
                     : "All required setup is complete.")}
@@ -3005,10 +2990,7 @@ export function AgentCreatePage() {
               </Button>
             ) : (
               <Button
-                data-submit-agent="true"
-                disabled={
-                  Boolean(missingRequirement) || !promptStepReady || saving
-                }
+                disabled={saving}
                 loading={saving}
                 type="submit"
                 variant="primary"


### PR DESCRIPTION
## Summary
- allow the final agent form to submit without depending on browser submitter metadata
- surface missing requirements from earlier setup steps and route users back to the blocked step
- remove the artificial delay before the create button becomes usable
- add browser regression coverage for restored drafts and submitter-less submissions

Hosted gitlink update: [responder#174](https://github.com/superloglabs/responder/pull/174)

## Validation
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- `pnpm exec playwright test apps/control-plane/e2e/workspace-onboarding.spec.ts`