### PR TITLE
Add Slack tag mode

### DIFF
--- a/apps/control-plane/server/agents/routes.ts
+++ b/apps/control-plane/server/agents/routes.ts
@@ -1,7 +1,10 @@
 import { Hono } from "hono";
 import { z } from "zod";
 import { captureAnalyticsEvent } from "@responder/core/analytics";
-import { agentConfigurationSchema } from "../../../../packages/core/src/agents/config.js";
+import {
+  agentConfigurationSchema,
+  slackThreadModeConfigurationSchema,
+} from "../../../../packages/core/src/agents/config.js";
 import type { AgentConfiguration } from "../../../../packages/core/src/agents/config.js";
 import { decryptCredentials } from "../../../../packages/core/src/credentials/encryption.js";
 import {
@@ -9,9 +12,11 @@ import {
   createAgent,
   disableAgentsWithUnavailableRepositories,
   getAgent,
+  getSlackThreadModeConfiguration,
   listAgentOptions,
   listAgents,
   setAgentEnabled,
+  saveSlackThreadModeConfiguration,
   updateAgent,
 } from "../../../../packages/core/src/db/agents.js";
 import {
@@ -257,6 +262,43 @@ export const agentRoutes = new Hono()
     }
 
     return context.json(await listAgentOptions(tenant.organizationId));
+  })
+  .get("/thread-mode", async (context) => {
+    const tenant = await getActiveTenant(context.req.raw.headers);
+    if (tenant.ok === false) {
+      return context.json({ error: tenant.error }, tenant.status);
+    }
+    return context.json({
+      configuration: await getSlackThreadModeConfiguration(
+        tenant.organizationId,
+      ),
+    });
+  })
+  .put("/thread-mode", async (context) => {
+    const tenant = await getActiveTenant(context.req.raw.headers);
+    if (tenant.ok === false) {
+      return context.json({ error: tenant.error }, tenant.status);
+    }
+    const parsed = slackThreadModeConfigurationSchema.safeParse(
+      await context.req.json().catch(() => null),
+    );
+    if (!parsed.success) {
+      return context.json(
+        { error: "Invalid tag mode configuration", issues: parsed.error.issues },
+        400,
+      );
+    }
+    try {
+      await saveSlackThreadModeConfiguration({
+        organizationId: tenant.organizationId,
+        userId: tenant.user.id,
+        configuration: parsed.data,
+      });
+      return context.json({ configuration: parsed.data });
+    } catch (error) {
+      const response = configurationError(error);
+      return context.json(response.body, response.status);
+    }
   })
   .post("/options/refresh/slack", async (context) => {
     const tenant = await getActiveTenant(context.req.raw.headers);

--- a/apps/control-plane/server/index.test.ts
+++ b/apps/control-plane/server/index.test.ts
@@ -28,7 +28,10 @@ import {
   verifySentrySignature,
 } from "./webhooks/sentry.js";
 import { startSlackIssueRemediation } from "./issues/remediation.js";
-import { queueInvestigation } from "./investigations/queue.js";
+import {
+  queueInvestigation,
+  queueSlackThreadInvestigation,
+} from "./investigations/queue.js";
 
 const slackWebhookMocks = vi.hoisted(() => ({
   findAgentsForSlackEvent: vi.fn(),
@@ -74,6 +77,7 @@ vi.mock("./tenant.js", () => ({
 vi.mock("./investigations/queue.js", () => ({
   closeInvestigationQueue: vi.fn(),
   queueInvestigation: vi.fn(),
+  queueSlackThreadInvestigation: vi.fn(),
 }));
 
 describe("control-plane API", () => {
@@ -737,7 +741,7 @@ describe("control-plane API", () => {
     ).toBeNull();
   });
 
-  it("ignores human messages in a watched channel", async () => {
+  it("ignores the channel-message copy of a tagged thread reply", async () => {
     vi.stubEnv("SLACK_SIGNING_SECRET", "slack-signing-secret");
     const timestamp = Math.floor(Date.now() / 1_000).toString();
     const body = JSON.stringify({
@@ -748,8 +752,9 @@ describe("control-plane API", () => {
         type: "message",
         channel: "C123",
         ts: "1700000002.000001",
+        thread_ts: "1700000001.000001",
         user: "U123",
-        text: "Can someone take a look at this?",
+        text: "<@U-RESPONDER> Can you take another look?",
       },
     });
     const signature = `v0=${createHmac("sha256", "slack-signing-secret")
@@ -772,6 +777,80 @@ describe("control-plane API", () => {
       ignored: true,
       reason: "unsupported_alert_sender",
     });
+    expect(queueSlackThreadInvestigation).not.toHaveBeenCalled();
+  });
+
+  it("queues app mentions as durable Slack thread turns", async () => {
+    vi.stubEnv("SLACK_SIGNING_SECRET", "slack-signing-secret");
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    slackWebhookMocks.findAgentsForSlackEvent.mockResolvedValueOnce([
+      {
+        agentId: "17171717-1717-4717-8717-171717171717",
+        integrationAccountId: "04040404-0404-4404-8404-040404040404",
+        organizationId: "03030303-0303-4303-8303-030303030303",
+        trigger: "slack_thread",
+      },
+    ]);
+    slackWebhookMocks.getSlackChannelConnection.mockResolvedValueOnce(null);
+    vi.mocked(queueSlackThreadInvestigation).mockResolvedValueOnce({
+      investigationId: "01010101-0101-4101-8101-010101010101",
+      jobId: "21212121-2121-4121-8121-212121212121",
+      kind: "queued",
+    });
+    const timestamp = Math.floor(Date.now() / 1_000).toString();
+    const body = JSON.stringify({
+      type: "event_callback",
+      team_id: "T123",
+      event_id: "EvMention",
+      event: {
+        type: "app_mention",
+        channel: "C123",
+        ts: "1700000006.000002",
+        thread_ts: "1700000006.000001",
+        user: "U123",
+        text: "<@U-RESPONDER> investigate checkout latency",
+      },
+    });
+    const signature = `v0=${createHmac("sha256", "slack-signing-secret")
+      .update(`v0:${timestamp}:${body}`)
+      .digest("hex")}`;
+
+    const response = await app.request("/api/webhooks/slack", {
+      method: "POST",
+      body,
+      headers: {
+        "content-type": "application/json",
+        "x-slack-request-timestamp": timestamp,
+        "x-slack-signature": signature,
+      },
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      matchedAgents: 1,
+      ok: true,
+    });
+    expect(queueSlackThreadInvestigation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentId: "17171717-1717-4717-8717-171717171717",
+        attributes: expect.objectContaining({
+          channelId: "C123",
+          integrationAccountId: "04040404-0404-4404-8404-040404040404",
+          slackUserId: "U123",
+          teamId: "T123",
+          threadTimestamp: "1700000006.000001",
+        }),
+        externalEventId:
+          "EvMention:17171717-1717-4717-8717-171717171717",
+        provider: "slack",
+      }),
+      {
+        channelId: "C123",
+        teamId: "T123",
+        threadTimestamp: "1700000006.000001",
+      },
+    );
+    expect(queueInvestigation).not.toHaveBeenCalled();
   });
 
   it("ignores resolved app alerts that start with a white check mark", async () => {
@@ -1068,7 +1147,7 @@ describe("control-plane API", () => {
     expect(message.blocks).toContainEqual(
       expect.objectContaining({
         type: "plan",
-        title: "Investigation trace",
+        title: "Trace",
         tasks: [
           expect.objectContaining({
             status: "in_progress",
@@ -1083,6 +1162,24 @@ describe("control-plane API", () => {
         ],
       }),
     );
+  });
+
+  it("omits the investigation link from tag mode acknowledgements", () => {
+    const message = investigatingSlackMessage({
+      agentId: "17171717-1717-4717-8717-171717171717",
+      investigationId: "01010101-0101-4101-8101-010101010101",
+      threadMode: true,
+      title: "Investigate checkout latency",
+    });
+
+    expect(message.blocks).toEqual([
+      expect.objectContaining({
+        type: "plan",
+        tasks: [
+          expect.not.objectContaining({ sources: expect.anything() }),
+        ],
+      }),
+    ]);
   });
 
   it("logs Slack acknowledgement failures with alert context", () => {

--- a/apps/control-plane/server/investigations/queue.ts
+++ b/apps/control-plane/server/investigations/queue.ts
@@ -7,6 +7,7 @@ import { notifyBillingLimitReached } from "../../../../packages/core/src/billing
 import { captureAnalyticsEvent } from "../../../../packages/core/src/analytics.js";
 import {
   beginInvestigation,
+  beginSlackThreadInvestigation,
   discardPendingInvestigation,
   failInvestigation,
   prepareInvestigationRetry,
@@ -21,6 +22,7 @@ import {
   createJobBoss,
   investigationQueue,
   prepareWorkerQueues,
+  slackThreadInvestigationQueue,
 } from "../../../../packages/core/src/jobs.js";
 
 type QueueResult =
@@ -123,6 +125,86 @@ export async function queueInvestigation(
       { singletonKey: result.investigationId },
     );
     if (!jobId) throw new Error("The investigation job was not created");
+    return { investigationId: result.investigationId, jobId, kind: "queued" };
+  } catch (error) {
+    await failInvestigation(
+      result.investigationId,
+      error instanceof Error ? error.message : "Unable to queue investigation",
+    );
+    throw new Error("Investigation worker is unavailable", { cause: error });
+  }
+}
+
+export async function queueSlackThreadInvestigation(
+  request: InvestigationRequest,
+  thread: { teamId: string; channelId: string; threadTimestamp: string },
+): Promise<QueueResult> {
+  const input = toInvestigationInput(request);
+  const result = await beginSlackThreadInvestigation({
+    agentId: request.agentId,
+    investigationInput: input,
+    ...thread,
+  });
+  if (!result.created) {
+    return { investigationId: result.investigationId, kind: "duplicate" };
+  }
+
+  try {
+    const access = await consumeInvestigation(
+      result.config.organizationId,
+      result.investigationId,
+    );
+    if (!access.allowed) {
+      await discardPendingInvestigation(result.investigationId);
+      await notifyBillingLimitReached(
+        result.config.organizationId,
+        access.nextResetAt,
+      ).catch(() => undefined);
+      return { kind: "blocked" };
+    }
+  } catch (error) {
+    await discardPendingInvestigation(result.investigationId);
+    throw new Error("Billing service unavailable", { cause: error });
+  }
+
+  await captureAnalyticsEvent({
+    distinctId: `investigation:${result.investigationId}`,
+    event: "investigation created",
+    organizationId: result.config.organizationId,
+    properties: {
+      $process_person_profile: false,
+      agent_config_version_id: result.config.id,
+      agent_id: result.config.agentId,
+      investigation_id: result.investigationId,
+      is_replay: false,
+      provider: "slack",
+      slack_thread_mode: true,
+    },
+  });
+
+  try {
+    const jobId = await (await getBoss()).send(
+      slackThreadInvestigationQueue,
+      {
+        kind: "slack_thread_investigation",
+        config: {
+          agentId: result.config.agentId,
+          id: result.config.id,
+          model: result.config.model,
+          organizationId: result.config.organizationId,
+          prMode: "disabled",
+          prompt: result.config.prompt,
+        },
+        investigationId: result.investigationId,
+        queuedAt: new Date().toISOString(),
+        refreshWorkspace: result.configurationChanged,
+        request,
+        runtimeProfileId: result.runtimeProfileId,
+        slackInvestigationSessionId: result.slackInvestigationSessionId,
+      },
+      { singletonKey: result.slackInvestigationSessionId },
+    );
+    if (!jobId) throw new Error("The Slack investigation turn was not created");
     return { investigationId: result.investigationId, jobId, kind: "queued" };
   } catch (error) {
     await failInvestigation(

--- a/apps/control-plane/server/webhooks/slack-acknowledgement.test.ts
+++ b/apps/control-plane/server/webhooks/slack-acknowledgement.test.ts
@@ -116,6 +116,26 @@ describe("Slack alert acknowledgement", () => {
     );
   });
 
+  it("posts the tag-mode plan while keeping eyes active until completion", async () => {
+    mocks.recordInvestigationSlackMessage.mockResolvedValue("investigating");
+
+    await expect(
+      acknowledgeSlackAlert({
+        ...input,
+        threadMode: true,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(mocks.addSlackReaction).toHaveBeenCalledBefore(
+      mocks.postSlackMessage,
+    );
+    expect(mocks.setSlackThreadStatus).not.toHaveBeenCalled();
+    expect(
+      mocks.reconcileCompletedInvestigationSlackCard,
+    ).not.toHaveBeenCalled();
+    expect(mocks.failInvestigationSlackCard).not.toHaveBeenCalled();
+  });
+
   it("reconciles a fast failure after recording the live message", async () => {
     mocks.recordInvestigationSlackMessage.mockResolvedValue("failed");
 

--- a/apps/control-plane/server/webhooks/slack.ts
+++ b/apps/control-plane/server/webhooks/slack.ts
@@ -38,7 +38,10 @@ import {
   type SlackIssuePullRequestCard,
 } from "../../../../packages/core/src/integrations/slack-remediations.js";
 import { startSlackIssueRemediation } from "../issues/remediation.js";
-import { queueInvestigation } from "../investigations/queue.js";
+import {
+  queueInvestigation,
+  queueSlackThreadInvestigation,
+} from "../investigations/queue.js";
 
 const slackUrlVerificationSchema = z.object({
   type: z.literal("url_verification"),
@@ -422,11 +425,14 @@ async function forwardSlackEvent(input: {
   body: string;
   channelId: string;
   eventId: string;
+  integrationAccountId: string;
   teamId: string;
   threadTimestamp: string;
   timestamp: string;
+  threadMode?: boolean;
+  userId?: string;
 }) {
-  const result = await queueInvestigation({
+  const request = {
     agentId: input.agentId,
     provider: "slack",
     externalEventId: `${input.eventId}:${input.agentId}`,
@@ -448,12 +454,25 @@ async function forwardSlackEvent(input: {
         : {}),
       ...(input.awsAlarm ? { awsAlarmState: input.awsAlarm.state } : {}),
       channelId: input.channelId,
+      ...(input.threadMode
+        ? {
+            integrationAccountId: input.integrationAccountId,
+            ...(input.userId ? { slackUserId: input.userId } : {}),
+          }
+        : {}),
       slackEventId: input.eventId,
       teamId: input.teamId,
       threadTimestamp: input.threadTimestamp,
       timestamp: input.timestamp,
     },
-  });
+  } as const;
+  const result = input.threadMode
+    ? await queueSlackThreadInvestigation(request, {
+        teamId: input.teamId,
+        channelId: input.channelId,
+        threadTimestamp: input.threadTimestamp,
+      })
+    : await queueInvestigation(request);
   if (result.kind === "blocked") {
     throw new Error("Monthly investigation allowance exhausted");
   }
@@ -472,6 +491,7 @@ export async function acknowledgeSlackAlert(input: {
   messageTimestamp: string;
   title: string;
   threadTimestamp: string;
+  threadMode?: boolean;
 }): Promise<void> {
   const connection = await getSlackChannelConnection({
     organizationId: input.organizationId,
@@ -487,8 +507,23 @@ export async function acknowledgeSlackAlert(input: {
   const message = investigatingSlackMessage({
     agentId: input.agentId,
     investigationId: input.investigationId,
+    threadMode: input.threadMode,
     title: input.title,
   });
+  const failures: unknown[] = [];
+  if (input.threadMode) {
+    try {
+      await addSlackReaction({
+        accessToken: credentials.accessToken,
+        channelId: input.channelId,
+        name: "eyes",
+        timestamp: input.messageTimestamp,
+      });
+      await setInvestigationSlackReaction(input.investigationId, "eyes", true);
+    } catch (error) {
+      failures.push(error);
+    }
+  }
   const liveMessageTimestamp = await postSlackMessage({
     accessToken: credentials.accessToken,
     blocks: message.blocks,
@@ -506,7 +541,6 @@ export async function acknowledgeSlackAlert(input: {
     );
     throw new Error("Slack did not return the live investigation message timestamp");
   }
-  const failures: unknown[] = [];
   let investigationStatus:
     | "pending"
     | "investigating"
@@ -536,31 +570,35 @@ export async function acknowledgeSlackAlert(input: {
     failures.push(error);
   }
   const results = await Promise.allSettled([
-    addSlackReaction({
-      accessToken: credentials.accessToken,
-      channelId: input.channelId,
-      name: "eyes",
-      timestamp: input.messageTimestamp,
-    }),
-    setSlackThreadStatus({
-      accessToken: credentials.accessToken,
-      channelId: input.channelId,
-      loadingMessages: [
-        "Gathering evidence…",
-        "Checking telemetry…",
-        "Inspecting relevant code…",
-        "Connecting the dots…",
-      ],
-      status: "is investigating this alert…",
-      threadTimestamp: input.threadTimestamp,
-    }),
+    input.threadMode
+      ? Promise.resolve()
+      : addSlackReaction({
+          accessToken: credentials.accessToken,
+          channelId: input.channelId,
+          name: "eyes",
+          timestamp: input.messageTimestamp,
+        }),
+    input.threadMode
+      ? Promise.resolve()
+      : setSlackThreadStatus({
+          accessToken: credentials.accessToken,
+          channelId: input.channelId,
+          loadingMessages: [
+            "Gathering evidence…",
+            "Checking telemetry…",
+            "Inspecting relevant code…",
+            "Connecting the dots…",
+          ],
+          status: "is investigating this alert…",
+          threadTimestamp: input.threadTimestamp,
+        }),
   ]);
   failures.push(
     ...results.flatMap((result) =>
       result.status === "rejected" ? [result.reason] : [],
     ),
   );
-  if (results[0]?.status === "fulfilled") {
+  if (!input.threadMode && results[0]?.status === "fulfilled") {
     try {
       await setInvestigationSlackReaction(
         input.investigationId,
@@ -576,7 +614,7 @@ export async function acknowledgeSlackAlert(input: {
       input.investigationId,
       liveMessageTimestamp,
     );
-    if (investigationStatus && investigationStatus !== "failed") {
+    if (investigationStatus === "resolved") {
       await reconcileCompletedInvestigationSlackCard(input.investigationId);
     } else if (investigationStatus === "failed") {
       await failInvestigationSlackCard(input.investigationId);
@@ -629,12 +667,14 @@ export function logSlackAcknowledgementFailure(input: {
 export function investigatingSlackMessage(input: {
   agentId: string;
   investigationId: string;
+  threadMode?: boolean;
   title?: string;
 }): { blocks: unknown[]; text: string } {
   return slackInvestigationCard({
     agentId: input.agentId,
     detail: "Responder is gathering evidence and preparing the investigation.",
     investigationId: input.investigationId,
+    showInvestigationLink: input.threadMode !== true,
     status: "in_progress",
     title: input.title ?? "Investigating alert",
   });
@@ -744,7 +784,10 @@ export const slackWebhookRoutes = new Hono().post("/", async (context) => {
     return context.json({ ok: true, ignored: true });
   }
 
-  const body = slackMessageBody(event);
+  const rawMessageBody = slackMessageBody(event);
+  const body = event.type === "app_mention"
+    ? rawMessageBody.replace(/^\s*<@[A-Z0-9]+>\s*/iu, "").trim() || rawMessageBody
+    : rawMessageBody;
   let alertProvider: SlackAlertProvider | null = null;
   let awsAlarm: SlackAwsAlarm | null = null;
   if (event.type === "message") {
@@ -867,9 +910,12 @@ export const slackWebhookRoutes = new Hono().post("/", async (context) => {
         body,
         channelId: event.channel,
         eventId: callback.data.event_id,
+        integrationAccountId: match.integrationAccountId,
         teamId: callback.data.team_id,
         threadTimestamp: event.thread_ts ?? event.ts,
         timestamp: event.ts,
+        threadMode: match.trigger === "slack_thread",
+        userId: event.user,
       });
       await recordInvestigationSlackSource(result.investigationId, {
         attachments: event.attachments ?? [],
@@ -878,7 +924,10 @@ export const slackWebhookRoutes = new Hono().post("/", async (context) => {
         slackTimestamp: event.ts,
         text: event.text,
       });
-      if (!result.duplicate && match.trigger === "slack_channel") {
+      if (
+        !result.duplicate &&
+        (match.trigger === "slack_channel" || match.trigger === "slack_thread")
+      ) {
         await acknowledgeSlackAlert({
           agentId: match.agentId,
           channelId: event.channel,
@@ -888,6 +937,7 @@ export const slackWebhookRoutes = new Hono().post("/", async (context) => {
           messageTimestamp: event.ts,
           title: slackMessageTitle(body),
           threadTimestamp: event.thread_ts ?? event.ts,
+          threadMode: match.trigger === "slack_thread",
         }).catch((error: unknown) => {
           logSlackAcknowledgementFailure({
             alertProvider,

--- a/apps/control-plane/src/agents-api.ts
+++ b/apps/control-plane/src/agents-api.ts
@@ -54,6 +54,16 @@ export interface AgentConfiguration {
   reporting: AgentReporting;
 }
 
+export interface SlackThreadModeConfiguration {
+  enabled: boolean;
+  model: string;
+  instructions: string;
+  repositoryIds: string[];
+  contextAccountIds: string[];
+  contextResourceIds: string[];
+  secretIds: string[];
+}
+
 export interface AgentOptions {
   accounts: Array<{
     id: string;
@@ -505,6 +515,28 @@ export async function retryInvestigation(
 
 export async function fetchAgentOptions(): Promise<AgentOptions> {
   return apiJson<AgentOptions>("/api/agents/options");
+}
+
+export async function fetchSlackThreadModeConfiguration(): Promise<
+  SlackThreadModeConfiguration | null
+> {
+  const response = await apiJson<{
+    configuration: SlackThreadModeConfiguration | null;
+  }>("/api/agents/thread-mode");
+  return response.configuration;
+}
+
+export async function saveSlackThreadModeConfiguration(
+  configuration: SlackThreadModeConfiguration,
+): Promise<SlackThreadModeConfiguration> {
+  const response = await apiJson<{
+    configuration: SlackThreadModeConfiguration;
+  }>("/api/agents/thread-mode", {
+    method: "PUT",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(configuration),
+  });
+  return response.configuration;
 }
 
 export async function refreshSlackAgentOptions(): Promise<AgentOptions> {

--- a/apps/control-plane/src/app.tsx
+++ b/apps/control-plane/src/app.tsx
@@ -19,6 +19,7 @@ import {
 import { SettingsPage } from "./pages/settings";
 import { SuperuserUsersPage } from "./pages/superuser-users";
 import { WorkspaceSettingsPage } from "./pages/workspace-settings";
+import { TagModeSettingsPage } from "./pages/tag-mode-settings";
 import { blogArticlePath } from "./public-routes";
 import { usePageMetadata } from "./use-page-metadata";
 
@@ -77,6 +78,7 @@ export function App() {
         <Route element={<SettingsPage />} path="/settings" />
         <Route element={<BillingPage />} path="/settings/billing" />
         <Route element={<WorkspaceSettingsPage />} path="/settings/workspace" />
+        <Route element={<TagModeSettingsPage />} path="/settings/tag-mode" />
         <Route element={<SuperuserUsersPage />} path="/superuser/users" />
       </Route>
       <Route element={<Navigate replace to="/" />} path="*" />

--- a/apps/control-plane/src/components/agent-context-controls.tsx
+++ b/apps/control-plane/src/components/agent-context-controls.tsx
@@ -1,0 +1,94 @@
+import type { ReactNode } from "react";
+import { IconButton } from "../design-system";
+import { CogIcon, ProviderGlyph } from "./icons";
+import type { ProviderGlyphId } from "./provider-glyphs";
+
+type ProviderId = Exclude<ProviderGlyphId, "google">;
+
+export function AgentContextProviderMark({
+  connected = false,
+  provider,
+}: {
+  connected?: boolean;
+  provider: ProviderId;
+}) {
+  return (
+    <ProviderGlyph
+      className={`providerMark providerMark--${provider} ${
+        connected ? "isConnected" : ""
+      }`}
+      decorative
+      provider={provider}
+    />
+  );
+}
+
+export function AgentContextRow({
+  action,
+  detail,
+  label,
+  provider,
+}: {
+  action: ReactNode;
+  detail: string;
+  label: string;
+  provider: ProviderId;
+}) {
+  return (
+    <div className="contextRow">
+      <AgentContextProviderMark provider={provider} />
+      <span className="contextRow__copy">
+        <strong>{label}</strong>
+        <small>{detail}</small>
+      </span>
+      <span className="contextRow__action">{action}</span>
+    </div>
+  );
+}
+
+export function AgentContextIntegrationControls({
+  disabled = false,
+  enabled,
+  label,
+  onConfigure,
+  onToggle,
+  toggleAriaLabel,
+}: {
+  disabled?: boolean;
+  enabled: boolean;
+  label: string;
+  onConfigure?: () => void;
+  onToggle: () => void;
+  toggleAriaLabel?: string;
+}) {
+  return (
+    <div className="contextIntegrationControls">
+      {onConfigure ? (
+        <IconButton
+          aria-label={`Configure ${label}`}
+          disabled={disabled}
+          onClick={onConfigure}
+          size="small"
+          type="button"
+          variant="ghost"
+        >
+          <CogIcon />
+        </IconButton>
+      ) : null}
+      <button
+        aria-checked={enabled}
+        aria-label={
+          toggleAriaLabel ??
+          `${enabled ? "Disable" : "Enable"} ${label} for this agent`
+        }
+        className="contextIntegrationToggle"
+        disabled={disabled}
+        onClick={onToggle}
+        role="switch"
+        type="button"
+      >
+        <i aria-hidden="true"><i /></i>
+      </button>
+    </div>
+  );
+}

--- a/apps/control-plane/src/components/settings-tabs.tsx
+++ b/apps/control-plane/src/components/settings-tabs.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 
-type SettingsSection = "billing" | "integrations" | "workspace";
+type SettingsSection = "billing" | "integrations" | "tag-mode" | "workspace";
 
 export function SettingsTabs({ active }: { active: SettingsSection }) {
   const [billingEnabled, setBillingEnabled] = useState(false);
@@ -31,6 +31,13 @@ export function SettingsTabs({ active }: { active: SettingsSection }) {
         to="/settings"
       >
         Integrations
+      </Link>
+      <Link
+        aria-current={active === "tag-mode" ? "page" : undefined}
+        className={active === "tag-mode" ? "isActive" : undefined}
+        to="/settings/tag-mode"
+      >
+        Tag mode
       </Link>
       <Link
         aria-current={active === "workspace" ? "page" : undefined}

--- a/apps/control-plane/src/pages/agent-create.tsx
+++ b/apps/control-plane/src/pages/agent-create.tsx
@@ -24,6 +24,11 @@ import {
 } from "../agents-api";
 import { defaultAgentContext } from "../agent-context-defaults";
 import { AppShell } from "../components/app-shell";
+import {
+  AgentContextIntegrationControls as ContextIntegrationControls,
+  AgentContextProviderMark as ProviderMark,
+  AgentContextRow as ContextRow,
+} from "../components/agent-context-controls";
 import { AgentSetupSkeleton } from "../components/screen-skeletons";
 import {
   DatadogConnectionDialog,
@@ -35,14 +40,12 @@ import { UpstashConnectionDialog } from "../components/upstash-connection-dialog
 import { LangfuseConnectionDialog } from "../components/langfuse-connection-dialog";
 import {
   ChevronDownIcon,
-  CogIcon,
   ProviderGlyph,
   RepositoryIcon,
   SearchIcon,
 } from "../components/icons";
 import {
   providerDisplayName,
-  type ProviderGlyphId,
 } from "../components/provider-glyphs";
 import {
   Alert,
@@ -2857,26 +2860,6 @@ function ChoiceCard({
   );
 }
 
-type ProviderId = Exclude<ProviderGlyphId, "google">;
-
-function ProviderMark({
-  connected = false,
-  provider,
-}: {
-  connected?: boolean;
-  provider: ProviderId;
-}) {
-  return (
-    <ProviderGlyph
-      className={`providerMark providerMark--${provider} ${
-        connected ? "isConnected" : ""
-      }`}
-      decorative
-      provider={provider}
-    />
-  );
-}
-
 function ConnectionPrompt({
   actionLabel,
   compact = false,
@@ -3136,76 +3119,5 @@ function SeverityFilter({
         ))}
       </div>
     </fieldset>
-  );
-}
-
-function ContextRow({
-  action,
-  detail,
-  label,
-  provider,
-}: {
-  action: ReactNode;
-  detail: string;
-  label: string;
-  provider:
-    | "aws"
-    | "github"
-    | "slack"
-    | "sentry"
-    | "datadog"
-    | "axiom"
-    | "upstash"
-    | "langfuse"
-    | "vercel"
-    | "custom_mcp"
-    | "clickstack"
-    | "linear";
-}) {
-  return (
-    <div className="contextRow">
-      <ProviderMark provider={provider} />
-      <span className="contextRow__copy">
-        <strong>{label}</strong>
-        <small>{detail}</small>
-      </span>
-      <span className="contextRow__action">{action}</span>
-    </div>
-  );
-}
-
-function ContextIntegrationControls({
-  enabled,
-  label,
-  onConfigure,
-  onToggle,
-}: {
-  enabled: boolean;
-  label: string;
-  onConfigure: () => void;
-  onToggle: () => void;
-}) {
-  return (
-    <div className="contextIntegrationControls">
-      <IconButton
-        aria-label={`Configure ${label}`}
-        onClick={onConfigure}
-        size="small"
-        type="button"
-        variant="ghost"
-      >
-        <CogIcon />
-      </IconButton>
-      <button
-        aria-checked={enabled}
-        aria-label={`${enabled ? "Disable" : "Enable"} ${label} for this agent`}
-        className="contextIntegrationToggle"
-        onClick={onToggle}
-        role="switch"
-        type="button"
-      >
-        <i aria-hidden="true"><i /></i>
-      </button>
-    </div>
   );
 }

--- a/apps/control-plane/src/pages/tag-mode-settings.tsx
+++ b/apps/control-plane/src/pages/tag-mode-settings.tsx
@@ -1,0 +1,946 @@
+import { useEffect, useMemo, useState, type FormEvent } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+  fetchAgentOptions,
+  fetchIntegrations,
+  fetchSlackThreadModeConfiguration,
+  saveSlackThreadModeConfiguration,
+  type AgentOptions,
+  type IntegrationSummary,
+  type SlackThreadModeConfiguration,
+} from "../agents-api";
+import { AwsConnectionDialog } from "../components/aws-connection-dialog";
+import { ClickStackConnectionDialog } from "../components/clickstack-connection-dialog";
+import { CustomMcpConnectionDialog } from "../components/custom-mcp-dialog";
+import { DatadogConnectionDialog } from "../components/datadog-site-dialog";
+import {
+  AgentContextIntegrationControls,
+  AgentContextProviderMark,
+  AgentContextRow,
+} from "../components/agent-context-controls";
+import { AppShell } from "../components/app-shell";
+import { LangfuseConnectionDialog } from "../components/langfuse-connection-dialog";
+import { RepositoryIcon, SearchIcon } from "../components/icons";
+import { providerDisplayName } from "../components/provider-glyphs";
+import { SettingsTabs } from "../components/settings-tabs";
+import { UpstashConnectionDialog } from "../components/upstash-connection-dialog";
+import { Button, Checkbox, IconButton, TextAreaField } from "../design-system";
+import { useDocumentTitle } from "../use-document-title";
+
+const defaultConfiguration: SlackThreadModeConfiguration = {
+  enabled: false,
+  model: "instance/default",
+  instructions:
+    "Investigate the request using connected context and attached repositories. Report what you found, the supporting evidence, and the recommended next step.",
+  repositoryIds: [],
+  contextAccountIds: [],
+  contextResourceIds: [],
+  secretIds: [],
+};
+
+type ContextAccount = AgentOptions["accounts"][number];
+type ConfigurationTarget = ContextAccount | "github" | "vercel" | "secrets";
+type ContextCategory =
+  | "Observability"
+  | "Code & deployment"
+  | "Communication & workflow"
+  | "Data & infrastructure";
+
+const tagModeDraftKey = "responder:tag-mode-settings-draft";
+const contextCategoryOrder: ContextCategory[] = [
+  "Observability",
+  "Code & deployment",
+  "Communication & workflow",
+  "Data & infrastructure",
+];
+const contextCategoryDescriptions: Record<ContextCategory, string> = {
+  Observability: "Errors, logs, traces, and service health",
+  "Code & deployment": "Source code, releases, and runtime changes",
+  "Communication & workflow": "Team conversations and incident follow-up",
+  "Data & infrastructure": "Cloud resources, databases, and custom tools",
+};
+const contextProviderMetadata: Record<
+  IntegrationSummary["id"],
+  { category: ContextCategory; searchTerms: string }
+> = {
+  sentry: { category: "Observability", searchTerms: "errors exceptions monitoring" },
+  datadog: { category: "Observability", searchTerms: "apm logs monitors" },
+  axiom: { category: "Observability", searchTerms: "logs traces metrics monitors" },
+  clickstack: { category: "Observability", searchTerms: "hyperdx logs traces" },
+  langfuse: { category: "Observability", searchTerms: "llm traces prompts projects" },
+  github: { category: "Code & deployment", searchTerms: "repositories code pull requests" },
+  vercel: { category: "Code & deployment", searchTerms: "deployments projects hosting" },
+  slack: { category: "Communication & workflow", searchTerms: "channels messages chat" },
+  linear: { category: "Communication & workflow", searchTerms: "issues projects tickets" },
+  aws: { category: "Data & infrastructure", searchTerms: "cloud accounts iam services" },
+  upstash: { category: "Data & infrastructure", searchTerms: "redis vector qstash workflow" },
+  custom_mcp: { category: "Data & infrastructure", searchTerms: "custom tools server mcp" },
+};
+const multiAccountContextProviders = new Set<IntegrationSummary["id"]>([
+  "aws",
+  "custom_mcp",
+  "langfuse",
+]);
+
+const contextProviderOrder: ContextAccount["provider"][] = [
+  "sentry",
+  "aws",
+  "upstash",
+  "langfuse",
+  "datadog",
+  "axiom",
+  "linear",
+  "custom_mcp",
+  "clickstack",
+];
+
+function toggle(values: string[], value: string, checked: boolean): string[] {
+  return checked
+    ? [...new Set([...values, value])]
+    : values.filter((candidate) => candidate !== value);
+}
+
+function accountDetail(account: ContextAccount): string {
+  const prefix = `${account.displayName} · `;
+  switch (account.provider) {
+    case "sentry":
+      return `${prefix}Issues, events, and traces`;
+    case "aws":
+      return "Infrastructure, telemetry, configuration, and service health";
+    case "upstash":
+      return `${prefix}Redis, Vector, Search, QStash, and Workflow`;
+    case "langfuse":
+      return "Traces, observations, scores, metrics, prompts, and alerts";
+    case "datadog":
+      return `${prefix}Logs, traces, monitors, and service health`;
+    case "axiom":
+      return `${prefix}Logs, traces, metrics, and monitor history`;
+    case "linear":
+      return `${prefix}Projects and issues · Context only`;
+    case "custom_mcp":
+      return "Remote tools exposed by this MCP server";
+    case "clickstack":
+      return `${prefix}Logs, traces, metrics, and service health`;
+    default:
+      return account.displayName;
+  }
+}
+
+function accountLabel(account: ContextAccount, accounts: ContextAccount[]): string {
+  const providerAccounts = accounts.filter(
+    (candidate) => candidate.provider === account.provider,
+  );
+  if (providerAccounts.length > 1) return account.displayName;
+  if (account.provider === "clickstack") return "ClickStack / HyperDX";
+  return providerDisplayName(account.provider);
+}
+
+export function TagModeSettingsPage() {
+  useDocumentTitle("Tag mode settings");
+  const navigate = useNavigate();
+  const [options, setOptions] = useState<AgentOptions | null>(null);
+  const [integrations, setIntegrations] = useState<IntegrationSummary[]>([]);
+  const [integrationQuery, setIntegrationQuery] = useState("");
+  const [connectingProvider, setConnectingProvider] =
+    useState<IntegrationSummary["id"] | null>(null);
+  const [connectingAws, setConnectingAws] = useState(false);
+  const [choosingDatadogSite, setChoosingDatadogSite] = useState(false);
+  const [configuringCustomMcp, setConfiguringCustomMcp] = useState(false);
+  const [connectingUpstash, setConnectingUpstash] = useState(false);
+  const [connectingLangfuse, setConnectingLangfuse] = useState(false);
+  const [connectingClickStack, setConnectingClickStack] = useState(false);
+  const [configuration, setConfiguration] =
+    useState<SlackThreadModeConfiguration>(defaultConfiguration);
+  const [configurationTarget, setConfigurationTarget] =
+    useState<ConfigurationTarget | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    void Promise.all([
+      fetchAgentOptions(),
+      fetchIntegrations(),
+      fetchSlackThreadModeConfiguration(),
+    ])
+      .then(([loadedOptions, loadedIntegrations, loadedConfiguration]) => {
+        if (cancelled) return;
+        setOptions(loadedOptions);
+        setIntegrations(loadedIntegrations);
+        const storedDraft = window.sessionStorage.getItem(tagModeDraftKey);
+        if (storedDraft) {
+          window.sessionStorage.removeItem(tagModeDraftKey);
+          try {
+            setConfiguration(JSON.parse(storedDraft) as SlackThreadModeConfiguration);
+          } catch {
+            setConfiguration(loadedConfiguration ?? defaultConfiguration);
+          }
+        } else {
+          setConfiguration(loadedConfiguration ?? defaultConfiguration);
+        }
+      })
+      .catch((caught: unknown) => {
+        if (!cancelled) {
+          setError(caught instanceof Error ? caught.message : "Unable to load tag mode");
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const contextAccounts = useMemo(() => {
+    if (!options) return [];
+    return contextProviderOrder.flatMap((provider) =>
+      options.accounts.filter((account) => account.provider === provider),
+    );
+  }, [options]);
+  const vercelAccounts = useMemo(
+    () => options?.accounts.filter((account) => account.provider === "vercel") ?? [],
+    [options],
+  );
+  const githubConnected = options?.accounts.some(
+    (account) => account.provider === "github",
+  ) ?? false;
+  const vercelProjects = useMemo(
+    () => options?.resources.filter((resource) => resource.kind === "vercel_project") ?? [],
+    [options],
+  );
+  const selectedVercelProjects = vercelProjects.filter((project) =>
+    configuration.contextResourceIds.includes(project.id),
+  );
+  const selectedRepositories = options?.repositories.filter((repository) =>
+    configuration.repositoryIds.includes(repository.id),
+  ) ?? [];
+  const selectedSecrets = options?.secrets.filter((secret) =>
+    configuration.secretIds.includes(secret.id),
+  ) ?? [];
+  const connectedContextCount =
+    contextAccounts.filter((account) =>
+      configuration.contextAccountIds.includes(account.id),
+    ).length +
+    Number(selectedRepositories.length > 0) +
+    Number(selectedVercelProjects.length > 0);
+  const normalizedIntegrationQuery = integrationQuery.trim().toLocaleLowerCase();
+  const visibleContextIntegrations = integrations.filter((integration) => {
+    if (integration.id === "slack") return false;
+    if (
+      integration.accountCount > 0 &&
+      !multiAccountContextProviders.has(integration.id)
+    ) {
+      return false;
+    }
+    const metadata = contextProviderMetadata[integration.id];
+    return `${integration.name} ${integration.description} ${metadata.category} ${metadata.searchTerms}`
+      .toLocaleLowerCase()
+      .includes(normalizedIntegrationQuery);
+  });
+
+  function update(patch: Partial<SlackThreadModeConfiguration>) {
+    setConfiguration((current) => ({ ...current, ...patch }));
+    setNotice(null);
+  }
+
+  function toggleContextAccount(accountId: string) {
+    update({
+      contextAccountIds: toggle(
+        configuration.contextAccountIds,
+        accountId,
+        !configuration.contextAccountIds.includes(accountId),
+      ),
+    });
+  }
+
+  function toggleGithubContext() {
+    if (configuration.repositoryIds.length > 0) {
+      update({ repositoryIds: [] });
+      return;
+    }
+    const firstRepository = options?.repositories[0];
+    if (!firstRepository) {
+      setConfigurationTarget("github");
+      return;
+    }
+    update({ repositoryIds: [firstRepository.id] });
+  }
+
+  function updateVercelSelection(contextResourceIds: string[]) {
+    const selectedAccountIds = new Set(
+      vercelProjects
+        .filter((project) => contextResourceIds.includes(project.id))
+        .map((project) => project.integrationAccountId),
+    );
+    const vercelAccountIds = new Set(vercelAccounts.map((account) => account.id));
+    update({
+      contextResourceIds,
+      contextAccountIds: [
+        ...configuration.contextAccountIds.filter(
+          (id) => !vercelAccountIds.has(id) || selectedAccountIds.has(id),
+        ),
+        ...[...selectedAccountIds].filter(
+          (id) => !configuration.contextAccountIds.includes(id),
+        ),
+      ],
+    });
+  }
+
+  function toggleVercelContext() {
+    if (selectedVercelProjects.length > 0) {
+      updateVercelSelection(
+        configuration.contextResourceIds.filter(
+          (id) => !vercelProjects.some((project) => project.id === id),
+        ),
+      );
+      return;
+    }
+    const firstProject = vercelProjects[0];
+    if (firstProject) {
+      updateVercelSelection([...configuration.contextResourceIds, firstProject.id]);
+    } else if (vercelAccounts.length > 0) {
+      setConfigurationTarget("vercel");
+    }
+  }
+
+  function connectIntegration(integration: IntegrationSummary) {
+    const connectionUrl = integration.state === "connected"
+      ? integration.configurationUrl ?? integration.connectUrl
+      : integration.connectUrl;
+    if (!connectionUrl) {
+      setError(
+        integration.state === "coming_soon"
+          ? `${integration.name} connection support is coming soon.`
+          : `${integration.name} is not configured for this deployment.`,
+      );
+      return;
+    }
+    window.sessionStorage.setItem(tagModeDraftKey, JSON.stringify(configuration));
+    if (integration.id === "aws") {
+      setConnectingAws(true);
+      return;
+    }
+    if (integration.id === "datadog") {
+      setChoosingDatadogSite(true);
+      return;
+    }
+    if (integration.id === "custom_mcp") {
+      setConfiguringCustomMcp(true);
+      return;
+    }
+    if (integration.id === "upstash") {
+      setConnectingUpstash(true);
+      return;
+    }
+    if (integration.id === "langfuse") {
+      setConnectingLangfuse(true);
+      return;
+    }
+    if (integration.id === "clickstack") {
+      setConnectingClickStack(true);
+      return;
+    }
+    setConnectingProvider(integration.id);
+    const url = new URL(connectionUrl, window.location.origin);
+    url.searchParams.set("returnTo", "/settings/tag-mode");
+    window.location.assign(`${url.pathname}${url.search}`);
+  }
+
+  async function submit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setSaving(true);
+    setError(null);
+    setNotice(null);
+    try {
+      const saved = await saveSlackThreadModeConfiguration(configuration);
+      setConfiguration(saved);
+      setNotice("Tag mode settings saved.");
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "Unable to save tag mode");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function toggleTagMode() {
+    const nextConfiguration = {
+      ...configuration,
+      enabled: !configuration.enabled,
+    };
+    setConfiguration(nextConfiguration);
+    setSaving(true);
+    setError(null);
+    setNotice(null);
+    try {
+      const saved = await saveSlackThreadModeConfiguration(nextConfiguration);
+      setConfiguration(saved);
+      setNotice(`Tag mode ${saved.enabled ? "enabled" : "disabled"}.`);
+    } catch (caught) {
+      setConfiguration(configuration);
+      setError(caught instanceof Error ? caught.message : "Unable to save tag mode");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <AppShell active="settings" density="settings">
+      <DatadogConnectionDialog
+        connectUrl={integrations.find((item) => item.id === "datadog")?.connectUrl ?? ""}
+        onCancel={() => setChoosingDatadogSite(false)}
+        open={choosingDatadogSite}
+        returnTo="/settings/tag-mode"
+      />
+      <CustomMcpConnectionDialog
+        connectUrl={integrations.find((item) => item.id === "custom_mcp")?.connectUrl ?? ""}
+        onCancel={() => setConfiguringCustomMcp(false)}
+        open={configuringCustomMcp}
+        returnTo="/settings/tag-mode"
+      />
+      <UpstashConnectionDialog
+        connectUrl={integrations.find((item) => item.id === "upstash")?.connectUrl ?? ""}
+        onCancel={() => setConnectingUpstash(false)}
+        open={connectingUpstash}
+        returnTo="/settings/tag-mode"
+      />
+      <LangfuseConnectionDialog
+        connectUrl={integrations.find((item) => item.id === "langfuse")?.connectUrl ?? ""}
+        onCancel={() => setConnectingLangfuse(false)}
+        open={connectingLangfuse}
+        returnTo="/settings/tag-mode"
+      />
+      <ClickStackConnectionDialog
+        connectUrl={integrations.find((item) => item.id === "clickstack")?.connectUrl ?? ""}
+        onCancel={() => setConnectingClickStack(false)}
+        open={connectingClickStack}
+        returnTo="/settings/tag-mode"
+      />
+      <AwsConnectionDialog
+        connectUrl={integrations.find((item) => item.id === "aws")?.connectUrl ?? ""}
+        onCancel={() => setConnectingAws(false)}
+        open={connectingAws}
+        returnTo="/settings/tag-mode"
+      />
+      <section className="settingsHeading">
+        <h1>Settings</h1>
+        <p>Manage your workspace, members, and connected services.</p>
+      </section>
+      <SettingsTabs active="tag-mode" />
+
+      <form className="tagModeSettings" onSubmit={submit}>
+        {error ? <p className="settingsNotice settingsNotice--error">{error}</p> : null}
+        {notice ? <p className="settingsNotice settingsNotice--success">{notice}</p> : null}
+
+        <section className="tagModeSettings__toggleSection">
+          <div className="contextToolbar">
+            <span className="configurationDialog__copy">
+              <strong>Tag mode</strong>
+              <small>Control whether Slack mentions start ad-hoc investigations.</small>
+            </span>
+            <AgentContextIntegrationControls
+              disabled={saving || !options}
+              enabled={configuration.enabled}
+              label="Slack tag mode"
+              onToggle={() => void toggleTagMode()}
+              toggleAriaLabel={`${configuration.enabled ? "Disable" : "Enable"} Slack tag mode`}
+            />
+          </div>
+        </section>
+
+        <section className="contextPanel">
+          <div className="contextToolbar">
+            <span className="configurationDialog__copy">
+              <strong>Connected integrations</strong>
+              <small>
+                Tag mode can inspect {connectedContextCount}{" "}
+                {connectedContextCount === 1 ? "source" : "sources"}.
+              </small>
+            </span>
+          </div>
+
+          <div className="contextList">
+            {!options ? (
+              <div className="contextIntegrationsEmpty">Loading integrations…</div>
+            ) : null}
+            {options &&
+            contextAccounts.length === 0 &&
+            !githubConnected &&
+            vercelAccounts.length === 0 ? (
+              <div className="contextIntegrationsEmpty">
+                No integrations connected yet. Add one from Integrations settings.
+              </div>
+            ) : null}
+
+            {contextAccounts.map((account) => {
+              const enabled = configuration.contextAccountIds.includes(account.id);
+              const label = accountLabel(account, contextAccounts);
+              return (
+                <AgentContextRow
+                  action={
+                    <AgentContextIntegrationControls
+                      enabled={enabled}
+                      label={label}
+                      onConfigure={() => setConfigurationTarget(account)}
+                      onToggle={() => toggleContextAccount(account.id)}
+                      toggleAriaLabel={`${enabled ? "Disable" : "Enable"} ${label} for tag mode`}
+                    />
+                  }
+                  detail={accountDetail(account)}
+                  key={account.id}
+                  label={label}
+                  provider={account.provider}
+                />
+              );
+            })}
+
+            {options && githubConnected ? (
+              <AgentContextRow
+                action={
+                  <AgentContextIntegrationControls
+                    enabled={selectedRepositories.length > 0}
+                    label="GitHub"
+                    onConfigure={() => setConfigurationTarget("github")}
+                    onToggle={toggleGithubContext}
+                    toggleAriaLabel={`${selectedRepositories.length > 0 ? "Disable" : "Enable"} GitHub for tag mode`}
+                  />
+                }
+                detail={`${selectedRepositories.length} ${selectedRepositories.length === 1 ? "repository" : "repositories"} selected · Read-only code context`}
+                label="GitHub"
+                provider="github"
+              />
+            ) : null}
+
+            {vercelAccounts.length > 0 ? (
+              <AgentContextRow
+                action={
+                  <AgentContextIntegrationControls
+                    enabled={selectedVercelProjects.length > 0}
+                    label="Vercel"
+                    onConfigure={() => setConfigurationTarget("vercel")}
+                    onToggle={toggleVercelContext}
+                    toggleAriaLabel={`${selectedVercelProjects.length > 0 ? "Disable" : "Enable"} Vercel for tag mode`}
+                  />
+                }
+                detail={
+                  selectedVercelProjects.length > 0
+                    ? `${selectedVercelProjects.length} ${selectedVercelProjects.length === 1 ? "project" : "projects"} selected · Deployments, domains, and logs`
+                    : "Choose which projects Tag mode may inspect"
+                }
+                label="Vercel"
+                provider="vercel"
+              />
+            ) : null}
+          </div>
+
+          <section
+            aria-labelledby="tag-mode-add-integration-title"
+            className="contextIntegrationCatalog"
+          >
+            <header className="contextIntegrationCatalog__header">
+              <span className="configurationDialog__copy">
+                <strong id="tag-mode-add-integration-title">Add integration</strong>
+                <small>Browse by category or search by the context you need.</small>
+              </span>
+              <label className="contextIntegrationSearch">
+                <SearchIcon />
+                <span className="srOnly">Search integrations</span>
+                <input
+                  onChange={(event) => setIntegrationQuery(event.target.value)}
+                  placeholder="Search integrations…"
+                  type="search"
+                  value={integrationQuery}
+                />
+                {integrationQuery ? (
+                  <button
+                    aria-label="Clear integration search"
+                    onClick={() => setIntegrationQuery("")}
+                    type="button"
+                  >
+                    ×
+                  </button>
+                ) : null}
+              </label>
+            </header>
+
+            {visibleContextIntegrations.length > 0 ? (
+              <div className="contextIntegrationCategories">
+                {contextCategoryOrder.map((category) => {
+                  const categoryIntegrations = visibleContextIntegrations.filter(
+                    (integration) =>
+                      contextProviderMetadata[integration.id].category === category,
+                  );
+                  if (categoryIntegrations.length === 0) return null;
+                  return (
+                    <section className="contextIntegrationCategory" key={category}>
+                      <header>
+                        <strong>{category}</strong>
+                        <small>{contextCategoryDescriptions[category]}</small>
+                      </header>
+                      <div className="contextIntegrationGrid">
+                        {categoryIntegrations.map((integration) => {
+                          const unavailable =
+                            integration.state === "coming_soon" ||
+                            integration.state === "setup_required";
+                          return (
+                            <article className="contextIntegrationCard" key={integration.id}>
+                              <AgentContextProviderMark provider={integration.id} />
+                              <span className="contextIntegrationCard__copy">
+                                <strong>{integration.name}</strong>
+                                <small>{integration.description}</small>
+                              </span>
+                              <footer>
+                                <Button
+                                  disabled={unavailable}
+                                  loading={connectingProvider === integration.id}
+                                  onClick={() => connectIntegration(integration)}
+                                  size="small"
+                                  type="button"
+                                  variant="secondary"
+                                >
+                                  {integration.state === "coming_soon"
+                                    ? "Coming soon"
+                                    : integration.state === "setup_required"
+                                      ? "Setup required"
+                                      : "Add"}
+                                </Button>
+                              </footer>
+                            </article>
+                          );
+                        })}
+                      </div>
+                    </section>
+                  );
+                })}
+              </div>
+            ) : (
+              <div className="contextIntegrationsEmpty">
+                No integrations match “{integrationQuery}”.
+              </div>
+            )}
+          </section>
+        </section>
+
+        <section className="workspaceSecretsPanel">
+          <div className="contextToolbar">
+            <span className="configurationDialog__copy">
+              <strong>Workspace secrets</strong>
+              <small>
+                Selected secrets are exposed as opaque environment variables and only
+                resolve for allowed hosts.
+              </small>
+            </span>
+            <Button
+              onClick={() => setConfigurationTarget("secrets")}
+              size="small"
+              type="button"
+              variant="secondary"
+            >
+              Choose secrets
+            </Button>
+          </div>
+          {selectedSecrets.length > 0 ? (
+            <div className="workspaceSelectedSecretList">
+              {selectedSecrets.map((secret) => (
+                <div className="workspaceSelectedSecret" key={secret.id}>
+                  <span className="configurationDialog__copy">
+                    <strong>{secret.name}</strong>
+                    <small>Allowed for {secret.allowedHosts.join(", ")}</small>
+                  </span>
+                  <Button
+                    onClick={() => update({
+                      secretIds: configuration.secretIds.filter((id) => id !== secret.id),
+                    })}
+                    size="small"
+                    type="button"
+                    variant="ghost"
+                  >
+                    Remove
+                  </Button>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div className="workspaceSecretsEmpty">No secrets added to Tag mode.</div>
+          )}
+
+          <section className="tagModeSettings__prompt">
+            <div className="tagModeSettings__sectionHeading">
+              <h2>Prompt</h2>
+              <p>Tell Responder how to investigate and answer thread requests.</p>
+            </div>
+            <TextAreaField
+              className="tagModeSettings__promptField"
+              label="Agent prompt"
+              maxLength={20_000}
+              onChange={(event) => update({ instructions: event.target.value })}
+              rows={4}
+              value={configuration.instructions}
+            />
+          </section>
+        </section>
+
+        <div className="tagModeSettings__actions">
+          <Button disabled={saving || !options} type="submit" variant="secondary">
+            {saving ? "Saving…" : "Save tag mode"}
+          </Button>
+        </div>
+
+        {configurationTarget === "github" && options ? (
+          <div
+            className="configurationDialogBackdrop"
+            onMouseDown={(event) => {
+              if (event.target === event.currentTarget) setConfigurationTarget(null);
+            }}
+          >
+            <section
+              aria-labelledby="tag-mode-github-title"
+              aria-modal="true"
+              className="configurationDialog"
+              role="dialog"
+            >
+              <header className="configurationDialog__header">
+                <AgentContextProviderMark provider="github" />
+                <span className="configurationDialog__copy">
+                  <strong id="tag-mode-github-title">Configure GitHub</strong>
+                  <small>Choose the repositories Tag mode may inspect.</small>
+                </span>
+                <IconButton
+                  aria-label="Close GitHub configuration"
+                  onClick={() => setConfigurationTarget(null)}
+                  size="small"
+                  type="button"
+                  variant="ghost"
+                >
+                  ×
+                </IconButton>
+              </header>
+              <div className="configurationDialog__body">
+                <div className="repositoryConnectList">
+                  {options.repositories.map((repository) => {
+                    const selected = configuration.repositoryIds.includes(repository.id);
+                    return (
+                      <div className="repositoryConnectRow" key={repository.id}>
+                        <span className="repositoryConnectRow__icon"><RepositoryIcon /></span>
+                        <span className="repositoryConnectRow__copy">
+                          <strong>{repository.fullName}</strong>
+                          <small>{repository.private ? "Private" : "Public"} · {repository.defaultBranch}</small>
+                        </span>
+                        <Button
+                          aria-pressed={selected}
+                          className={`repositoryConnectButton ${selected ? "isConnected" : ""}`}
+                          onClick={() => update({
+                            repositoryIds: toggle(
+                              configuration.repositoryIds,
+                              repository.id,
+                              !selected,
+                            ),
+                          })}
+                          size="small"
+                          type="button"
+                          variant={selected ? "secondary" : "primary"}
+                        >
+                          {selected ? "Selected" : "Select"}
+                        </Button>
+                      </div>
+                    );
+                  })}
+                  {options.repositories.length === 0 ? (
+                    <p>No repositories are available for this connection.</p>
+                  ) : null}
+                </div>
+              </div>
+              <footer className="configurationDialog__footer">
+                <span>{selectedRepositories.length} selected</span>
+                <Button onClick={() => setConfigurationTarget(null)} size="small" type="submit">
+                  Done
+                </Button>
+              </footer>
+            </section>
+          </div>
+        ) : null}
+
+        {configurationTarget === "vercel" ? (
+          <div
+            className="configurationDialogBackdrop"
+            onMouseDown={(event) => {
+              if (event.target === event.currentTarget) setConfigurationTarget(null);
+            }}
+          >
+            <section
+              aria-labelledby="tag-mode-vercel-title"
+              aria-modal="true"
+              className="configurationDialog"
+              role="dialog"
+            >
+              <header className="configurationDialog__header">
+                <AgentContextProviderMark provider="vercel" />
+                <span className="configurationDialog__copy">
+                  <strong id="tag-mode-vercel-title">Configure Vercel context</strong>
+                  <small>Choose only the projects Tag mode may inspect.</small>
+                </span>
+                <IconButton
+                  aria-label="Close Vercel configuration"
+                  onClick={() => setConfigurationTarget(null)}
+                  size="small"
+                  type="button"
+                  variant="ghost"
+                >
+                  ×
+                </IconButton>
+              </header>
+              <div className="configurationDialog__body">
+                <div className="projectPicker">
+                  <span>Projects</span>
+                  <div>
+                    {vercelProjects.map((project) => (
+                      <Checkbox
+                        checked={configuration.contextResourceIds.includes(project.id)}
+                        key={project.id}
+                        label={project.displayName}
+                        onChange={() => updateVercelSelection(toggle(
+                          configuration.contextResourceIds,
+                          project.id,
+                          !configuration.contextResourceIds.includes(project.id),
+                        ))}
+                      />
+                    ))}
+                    {vercelProjects.length === 0 ? (
+                      <p className="workspaceSecretsEmpty">
+                        No projects are available for this connection.
+                      </p>
+                    ) : null}
+                  </div>
+                </div>
+              </div>
+              <footer className="configurationDialog__footer">
+                <span>{selectedVercelProjects.length} selected</span>
+                <Button onClick={() => setConfigurationTarget(null)} size="small" type="submit">
+                  Done
+                </Button>
+              </footer>
+            </section>
+          </div>
+        ) : null}
+
+        {configurationTarget === "secrets" && options ? (
+          <div
+            className="configurationDialogBackdrop"
+            onMouseDown={(event) => {
+              if (event.target === event.currentTarget) setConfigurationTarget(null);
+            }}
+          >
+            <section
+              aria-labelledby="tag-mode-secrets-title"
+              aria-modal="true"
+              className="configurationDialog workspaceSecretDialog"
+              role="dialog"
+            >
+              <header className="configurationDialog__header">
+                <div aria-hidden="true" className="workspaceSecretDialogIcon">•••</div>
+                <span className="configurationDialog__copy">
+                  <strong id="tag-mode-secrets-title">Choose workspace secrets</strong>
+                  <small>Select the secrets Tag mode may use.</small>
+                </span>
+                <IconButton
+                  aria-label="Close workspace secret configuration"
+                  onClick={() => setConfigurationTarget(null)}
+                  size="small"
+                  type="button"
+                  variant="ghost"
+                >
+                  ×
+                </IconButton>
+              </header>
+              <div className="configurationDialog__body">
+                <div className="workspaceSecretList">
+                  {options.secrets.map((secret) => (
+                    <Checkbox
+                      checked={configuration.secretIds.includes(secret.id)}
+                      description={`Allowed for ${secret.allowedHosts.join(", ")}`}
+                      key={secret.id}
+                      label={secret.name}
+                      onChange={() => update({
+                        secretIds: toggle(
+                          configuration.secretIds,
+                          secret.id,
+                          !configuration.secretIds.includes(secret.id),
+                        ),
+                      })}
+                    />
+                  ))}
+                  {options.secrets.length === 0 ? (
+                    <p className="workspaceSecretsEmpty">No workspace secrets are available.</p>
+                  ) : null}
+                </div>
+              </div>
+              <footer className="configurationDialog__footer">
+                <span>{selectedSecrets.length} selected</span>
+                <Button onClick={() => setConfigurationTarget(null)} size="small" type="submit">
+                  Done
+                </Button>
+              </footer>
+            </section>
+          </div>
+        ) : null}
+
+        {configurationTarget &&
+        typeof configurationTarget === "object" ? (
+          <div
+            className="configurationDialogBackdrop"
+            onMouseDown={(event) => {
+              if (event.target === event.currentTarget) setConfigurationTarget(null);
+            }}
+          >
+            <section
+              aria-labelledby="tag-mode-integration-title"
+              aria-modal="true"
+              className="configurationDialog"
+              role="dialog"
+            >
+              <header className="configurationDialog__header">
+                <AgentContextProviderMark provider={configurationTarget.provider} />
+                <span className="configurationDialog__copy">
+                  <strong id="tag-mode-integration-title">
+                    Configure {configurationTarget.displayName}
+                  </strong>
+                  <small>{providerDisplayName(configurationTarget.provider)} connection</small>
+                </span>
+                <IconButton
+                  aria-label="Close integration configuration"
+                  onClick={() => setConfigurationTarget(null)}
+                  size="small"
+                  type="button"
+                  variant="ghost"
+                >
+                  ×
+                </IconButton>
+              </header>
+              <div className="configurationDialog__body">
+                <div className="contextConnectionSummary">
+                  <span>Connected account</span>
+                  <strong>{configurationTarget.displayName}</strong>
+                  <small>
+                    This integration is enabled as a whole. Manage credentials and
+                    provider access from integration settings.
+                  </small>
+                </div>
+              </div>
+              <footer className="configurationDialog__footer">
+                <Button
+                  onClick={() => navigate("/settings")}
+                  size="small"
+                  type="button"
+                  variant="secondary"
+                >
+                  Manage integration
+                </Button>
+                <Button onClick={() => setConfigurationTarget(null)} size="small" type="submit">
+                  Done
+                </Button>
+              </footer>
+            </section>
+          </div>
+        ) : null}
+      </form>
+    </AppShell>
+  );
+}

--- a/apps/control-plane/src/styles.css
+++ b/apps/control-plane/src/styles.css
@@ -88,6 +88,152 @@ body:has(.appShell--investigation) {
   gap: 32px;
 }
 
+.appShell--settings .tagModeSettings {
+  width: 100%;
+  max-width: 900px;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 33px;
+}
+
+.appShell--settings .tagModeSettings__toggleSection .contextToolbar {
+  min-height: 42px;
+  padding-bottom: 0;
+}
+
+.appShell--settings .tagModeSettings__toggleSection .contextToolbar > span {
+  gap: 3px;
+}
+
+.appShell--settings .tagModeSettings .contextToolbar {
+  align-items: center;
+}
+
+.appShell--settings .tagModeSettings .contextToolbar strong,
+.appShell--settings .tagModeSettings__sectionHeading h2,
+.appShell--settings .tagModeSettings .contextIntegrationCatalog__header strong {
+  color: var(--ds-text-primary);
+  font-size: 16px;
+  font-weight: 500;
+  line-height: 22px;
+}
+
+.appShell--settings .tagModeSettings .contextToolbar small,
+.appShell--settings .tagModeSettings__sectionHeading p,
+.appShell--settings .tagModeSettings .contextIntegrationCatalog__header small {
+  color: var(--ds-text-muted);
+  font-size: 12px;
+  line-height: 17px;
+}
+
+.appShell--settings .tagModeSettings .contextPanel {
+  gap: 20px;
+}
+
+.appShell--settings .tagModeSettings .contextIntegrationCatalog {
+  padding-top: 8px;
+  gap: 20px;
+  border-top: 0;
+}
+
+.appShell--settings .tagModeSettings .contextIntegrationCatalog__header {
+  align-items: center;
+}
+
+.appShell--settings .tagModeSettings .contextIntegrationSearch {
+  width: min(280px, 45%);
+  height: 36px;
+  border-radius: var(--ds-radius-pill);
+  background: var(--ds-surface-raised);
+}
+
+.appShell--settings .tagModeSettings .contextIntegrationCategories {
+  gap: 24px;
+}
+
+.appShell--settings .tagModeSettings .contextIntegrationCategory {
+  gap: 9px;
+}
+
+.appShell--settings .tagModeSettings .contextIntegrationGrid {
+  gap: 8px;
+}
+
+.appShell--settings .tagModeSettings .contextIntegrationCard {
+  min-height: 76px;
+  padding: 12px 14px;
+  gap: 11px;
+  border-radius: var(--ds-radius-small);
+  background: var(--ds-surface-base);
+}
+
+.appShell--settings .tagModeSettings .contextIntegrationCard__copy strong {
+  color: var(--ds-text-secondary);
+  font-size: 13px;
+  line-height: 18px;
+}
+
+.appShell--settings .tagModeSettings .contextIntegrationCard__copy small {
+  color: var(--ds-text-muted);
+  font-size: 11px;
+  line-height: 15px;
+}
+
+.appShell--settings .tagModeSettings .contextIntegrationCard .dsButton {
+  min-height: 32px;
+  padding-inline: 12px;
+}
+
+.appShell--settings .tagModeSettings .workspaceSecretsPanel {
+  gap: 12px;
+}
+
+.appShell--settings .tagModeSettings__prompt {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.appShell--settings .tagModeSettings__sectionHeading {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 5px;
+}
+
+.appShell--settings .tagModeSettings__sectionHeading h2,
+.appShell--settings .tagModeSettings__sectionHeading p {
+  margin: 0;
+}
+
+.appShell--settings .tagModeSettings__promptField > .dsField__label {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.appShell--settings .tagModeSettings__promptField .dsField__control--textarea {
+  height: 112px;
+  min-height: 112px;
+  border-radius: var(--ds-radius-small);
+  background: var(--ds-surface-raised);
+  color: var(--ds-text-primary);
+  font-size: 13px;
+  line-height: 20px;
+}
+
+.tagModeSettings__actions {
+  display: flex;
+  justify-content: flex-end;
+  padding-bottom: 36px;
+}
+
 .appShell--settings .workspaceSettings__intro {
   gap: 14px;
 }
@@ -6517,6 +6663,11 @@ button:disabled {
   cursor: pointer;
 }
 
+.contextIntegrationToggle:disabled {
+  cursor: not-allowed;
+  opacity: 0.48;
+}
+
 .contextIntegrationToggle > i {
   width: 34px;
   height: 20px;
@@ -9168,6 +9319,15 @@ a.issueLine:focus-visible {
   }
 
   .contextIntegrationSearch {
+    width: 100%;
+  }
+
+  .appShell--settings .tagModeSettings__toggleSection .contextToolbar {
+    align-items: center;
+    flex-direction: row;
+  }
+
+  .appShell--settings .tagModeSettings .contextIntegrationSearch {
     width: 100%;
   }
 

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -12,14 +12,18 @@ import {
   type LinearTicketJob,
   type RemediationJob,
   responderJobSchema,
+  slackThreadInvestigationJobSchema,
+  slackThreadInvestigationQueue,
   workerHealthJobSchema,
   workerHealthQueue,
 } from "@responder/core/jobs";
 import {
   appendInvestigationTraceEvent,
+  completeSlackThreadInvestigationTurn,
   failInvestigation,
   failInvestigationReplayRequest,
   markInvestigationStarted,
+  getInvestigationReportMarkdown,
 } from "@responder/core/db/investigations";
 import {
   failPendingInvestigationPullRequests,
@@ -41,6 +45,7 @@ import {
   slackProgressFromTrace,
   type SlackInvestigationTraceItem,
 } from "@responder/core/integrations/slack-live-progress";
+import { deliverSlackThreadInvestigationResponse } from "@responder/core/integrations/slack-delivery";
 import {
   completeInvestigationRun,
   deliverPersistedInvestigationAfterFailure,
@@ -331,6 +336,89 @@ await boss.work(pullRequestReviewQueue, { localConcurrency: 1 }, async ([job]) =
   const payload = pullRequestReviewJobSchema.parse(job.data);
   return processPullRequestReviewJob(job.id, payload, process.env);
 });
+await boss.work(
+  slackThreadInvestigationQueue,
+  { localConcurrency: 1 },
+  async ([job]) => {
+    const payload = slackThreadInvestigationJobSchema.parse(job.data);
+    const investigationState = await markInvestigationStarted(
+      payload.investigationId,
+      `openai-daytona:${job.id}`,
+    );
+    if (investigationState === "completed") {
+      const response = await getInvestigationReportMarkdown(
+        payload.investigationId,
+      );
+      if (response) {
+        await deliverSlackThreadInvestigationResponse({
+          deliveryRunId: job.id,
+          investigationId: payload.investigationId,
+          response,
+        });
+      }
+      return { investigationId: payload.investigationId };
+    }
+
+    let lastSlackProgressAt = 0;
+    let slackTraceItems: SlackInvestigationTraceItem[] = [];
+    try {
+      const result = await runInvestigationAgent(
+        payload,
+        process.env,
+        async (event) => {
+          await appendInvestigationTraceEvent(payload.investigationId, event);
+          const progress = slackProgressFromTrace(event);
+          if (!progress) return;
+          slackTraceItems = applySlackTraceUpdate(slackTraceItems, progress);
+          const now = Date.now();
+          if (!progress.finalizing && now - lastSlackProgressAt < 3_000) return;
+          lastSlackProgressAt = now;
+          await updateInvestigationSlackProgress(
+            payload.investigationId,
+            progress.detail,
+            slackTraceItems,
+          ).catch(() => undefined);
+        },
+        { jobId: job.id },
+      );
+      if (!result.sandboxSessionState) {
+        throw new Error("Slack investigation sandbox state was not returned");
+      }
+      await completeSlackThreadInvestigationTurn({
+        investigationId: payload.investigationId,
+        sessionId: payload.slackInvestigationSessionId,
+        reportMarkdown: result.report,
+        sandboxSessionState: result.sandboxSessionState,
+        previousResponseId: result.previousResponseId,
+      });
+      await deliverSlackThreadInvestigationResponse({
+        deliveryRunId: job.id,
+        investigationId: payload.investigationId,
+        response: result.report,
+      });
+      return { investigationId: payload.investigationId };
+    } catch (error) {
+      const message = safeInvestigationError(error);
+      await reportWorkerException(error, {
+        investigationId: payload.investigationId,
+        jobId: job.id,
+        operation: "investigation",
+        organizationId: payload.config.organizationId,
+      });
+      const investigationFailed = await failInvestigation(
+        payload.investigationId,
+        message,
+      );
+      if (investigationFailed) {
+        await failInvestigationSlackCard(
+          payload.investigationId,
+          slackTraceItems.length > 0 ? slackTraceItems : undefined,
+        ).catch(() => undefined);
+      }
+      throw new Error(message, { cause: error });
+    }
+  },
+);
 // Only investigation consumption waits for the one-time legacy handoff. The
 // other queues above remain available, with shutdown handling already active.
 await migrateLegacyInvestigationHeartbeats(boss, {
@@ -383,7 +471,7 @@ await boss.work(investigationQueue, { localConcurrency: 1 }, async ([job]) => {
   let slackTraceItems: SlackInvestigationTraceItem[] = [];
 
   try {
-    const report = await runInvestigationAgent(
+    const result = await runInvestigationAgent(
       payload,
       process.env,
       async (event) => {
@@ -491,7 +579,7 @@ await boss.work(investigationQueue, { localConcurrency: 1 }, async ([job]) => {
       deliveryRunId: job.id,
       investigationId: payload.investigationId,
       replay: payload.replay,
-      report,
+      report: result.report,
     });
     await reportIncompleteSlackDelivery({
       deliveryWarnings,

--- a/apps/worker/src/investigate.test.ts
+++ b/apps/worker/src/investigate.test.ts
@@ -158,6 +158,24 @@ describe("sandbox agent configuration", () => {
     );
   });
 
+  it("keeps Slack thread turns sandbox-only without issue or PR workflows", () => {
+    const instructions = investigationInstructions({
+      agentPrompt: "Investigate what the person asked.",
+      clickStackConnected: false,
+      datadogConnected: false,
+      repositories: [],
+      sentryConnected: false,
+      threadMode: true,
+    });
+
+    expect(instructions).toContain("ad-hoc Slack thread investigation");
+    expect(instructions).toContain("Never create or update issues");
+    expect(instructions).toContain("nothing in it is published");
+    expect(instructions).toContain("response directly to the Slack thread");
+    expect(instructions).not.toContain("search_existing_issues");
+    expect(instructions).not.toContain("submit_investigation_report");
+  });
+
   it("keeps ClickStack investigation access read-only", () => {
     const instructions = investigationInstructions({
       agentPrompt: "Inspect the reported failure.",

--- a/apps/worker/src/investigate.ts
+++ b/apps/worker/src/investigate.ts
@@ -16,6 +16,7 @@ import {
   getRuntimeSentryConnection,
   getRuntimeUpstashConnection,
   getRuntimeVercelConnections,
+  getSlackInvestigationSessionRuntime,
   SentryConnectionUnavailableError,
   type RuntimeSentryConnection,
 } from "@responder/core/db/investigations";
@@ -30,7 +31,10 @@ import type {
   InvestigationInput,
   InvestigationTraceEvent,
 } from "@responder/core/db/schema";
-import type { InvestigationJob } from "@responder/core/jobs";
+import type {
+  InvestigationJob,
+  SlackThreadInvestigationJob,
+} from "@responder/core/jobs";
 import { investigationPrompt, toInvestigationInput } from "@responder/core/investigations/input";
 import {
   createAwsMcpServer,
@@ -45,6 +49,8 @@ import { createLangfuseMcpServer } from "./langfuse.js";
 import { createSearchExistingIssuesTool } from "./issue-search.js";
 import {
   checkoutRuntimeRepositories,
+  loadCheckedOutRepositories,
+  refreshRuntimeRepositories,
   type CheckedOutRepository,
 } from "./repositories.js";
 import { createRepositoryInspectionTools } from "./repository-inspection.js";
@@ -56,6 +62,7 @@ import {
   closeDaytonaSandbox,
   configureDaytonaSandboxLifecycle,
   createDaytonaSandboxSession,
+  pauseDaytonaSandbox,
   prepareDaytonaSandbox,
 } from "./sandbox.js";
 import {
@@ -274,6 +281,7 @@ export function investigationInstructions(input: {
     allowedHosts: string[];
   }>;
   vercelAccountIds?: string[];
+  threadMode?: boolean;
 }): string {
   const awsAccountNames = input.awsAccountNames ?? [];
   const customMcpNames = input.customMcpNames ?? [];
@@ -353,15 +361,29 @@ export function investigationInstructions(input: {
           "Inspect the relevant files before claiming a code-level root cause.",
         ].join("\n")
       : "No repositories are attached to this Agent version. Clearly distinguish code-level hypotheses from verified root causes.",
-    "Use the read-only repository inspection tools to list, search, and read attached repository files.",
-    "This run is only for investigation and reporting. Do not modify repository code or create pull requests. Pull request remediation, when enabled, runs separately after the report is saved.",
+    input.threadMode
+      ? "Use the sandbox tools and attached code to investigate the request."
+      : "Use the read-only repository inspection tools to list, search, and read attached repository files.",
+    input.threadMode
+      ? null
+      : "This run is only for investigation and reporting. Do not modify repository code or create pull requests. Pull request remediation, when enabled, runs separately after the report is saved.",
     "Do not expose credentials or secret values.",
     workspaceSecretUsageInstructions(workspaceSecrets),
-    "For every distinct problem you find, call search_existing_issues before deciding whether it is a new issue or a recurrence. Use an existing issue ID when the evidence matches; this attaches the investigation to that issue instead of creating a duplicate.",
-    "For every new issue, submit one or more concrete remediation options with the report. Keep each remediation description to at most one sentence. A code_change must include a complete unified git diff based on files you inspected. Use external_action for work outside the attached repositories, describe the action for a human, and include a self-contained prompt they can pass to an agent with access to that system. Do not claim that a proposed diff has been applied.",
-    "Do not include actions performed by Responder during the investigation in an issue timeline; include only events in the incident's causal sequence.",
-    "Before your final response, you must call submit_investigation_report exactly once with the structured result. That action saves or attaches the issues and posts the report to Slack.",
-    "After submitting, return a concise Markdown report with: Summary, Evidence, Impact, and Recommended next step.",
+    input.threadMode
+      ? "This is an ad-hoc Slack thread investigation. Never create or update issues, tickets, branches, commits, or pull requests. You may use the sandbox for notes, experiments, and local code changes, but nothing in it is published."
+      : "For every distinct problem you find, call search_existing_issues before deciding whether it is a new issue or a recurrence. Use an existing issue ID when the evidence matches; this attaches the investigation to that issue instead of creating a duplicate.",
+    input.threadMode
+      ? null
+      : "For every new issue, submit one or more concrete remediation options with the report. Keep each remediation description to at most one sentence. A code_change must include a complete unified git diff based on files you inspected. Use external_action for work outside the attached repositories, describe the action for a human, and include a self-contained prompt they can pass to an agent with access to that system. Do not claim that a proposed diff has been applied.",
+    input.threadMode
+      ? null
+      : "Do not include actions performed by Responder during the investigation in an issue timeline; include only events in the incident's causal sequence.",
+    input.threadMode
+      ? "Return a concise Markdown response directly to the Slack thread. Answer the latest request using evidence gathered in this session."
+      : "Before your final response, you must call submit_investigation_report exactly once with the structured result. That action saves or attaches the issues and posts the report to Slack.",
+    input.threadMode
+      ? null
+      : "After submitting, return a concise Markdown report with: Summary, Evidence, Impact, and Recommended next step.",
     "Clearly say when the available evidence is insufficient.",
   ]
     .filter((instruction): instruction is string => Boolean(instruction))
@@ -387,7 +409,7 @@ export function investigationInstructionsTraceEvent(
 }
 
 export async function runInvestigationAgent(
-  job: InvestigationJob,
+  job: InvestigationJob | SlackThreadInvestigationJob,
   environment: NodeJS.ProcessEnv = process.env,
   onTraceEvent: (event: InvestigationTraceEvent) => Promise<void>,
   traceContext: { jobId: string },
@@ -396,7 +418,13 @@ export async function runInvestigationAgent(
   onRecoverableSentryFailure?: (
     error: SentryConnectionUnavailableError,
   ) => Promise<void>,
-): Promise<string> {
+): Promise<{
+  report: string;
+  previousResponseId?: string;
+  sandboxSessionState?: Record<string, unknown>;
+}> {
+  const threadMode = job.kind === "slack_thread_investigation";
+  const replay = job.kind === "investigation" && job.replay;
   const investigationInput = toInvestigationInput(job.request);
   let sentryConnectionDegraded = false;
   const awsAlarmTriggered =
@@ -514,7 +542,7 @@ export async function runInvestigationAgent(
   const client = new DaytonaSandboxClient({
     ...daytonaClientOptions(config),
     name: sandboxName,
-    pauseOnExit: false,
+    pauseOnExit: threadMode,
   });
 
   let session: DaytonaSandboxSession | null = null;
@@ -566,19 +594,54 @@ export async function runInvestigationAgent(
         );
       }
     }
-    session = await createDaytonaSandboxSession(client, config, sandboxName);
-    await configureDaytonaSandboxLifecycle(session, config, workspaceSecrets);
-    await prepareDaytonaSandbox(session);
-    const repositories = await checkoutRuntimeRepositories(
-      session,
-      job.config.id,
+    const sessionRuntime = threadMode
+      ? await getSlackInvestigationSessionRuntime(
+          job.slackInvestigationSessionId,
+        )
+      : null;
+    if (threadMode && !sessionRuntime) {
+      throw new Error("Slack investigation session not found");
+    }
+    const persistedState = sessionRuntime?.sandboxSessionState;
+    if (threadMode && persistedState) {
+      session = await client.resume(
+        await client.deserializeSessionState(persistedState),
+      );
+    } else {
+      session = await createDaytonaSandboxSession(client, config, sandboxName);
+    }
+    const sessionMarker = "/home/daytona/workspace/.responder/thread-session-ready";
+    const sessionReady = Boolean(
+      persistedState && await session.pathExists(sessionMarker),
     );
-    const reportTool = job.replay
+    if (!sessionReady) {
+      await configureDaytonaSandboxLifecycle(
+        session,
+        config,
+        workspaceSecrets,
+        threadMode ? -1 : 0,
+      );
+      await prepareDaytonaSandbox(session);
+    }
+    const repositories = sessionReady
+      ? threadMode && job.refreshWorkspace
+        ? await refreshRuntimeRepositories(session, job.config.id)
+        : await loadCheckedOutRepositories(session)
+      : await checkoutRuntimeRepositories(session, job.config.id);
+    if (threadMode && !sessionReady) {
+      await session.materializeEntry({
+        entry: { type: "file", content: "ready\n" },
+        path: sessionMarker,
+      });
+    }
+    const reportTool = replay
       ? createCaptureInvestigationReplayReportTool({
           investigationId: job.investigationId,
           organizationId: job.config.organizationId,
         })
-      : createSubmitInvestigationReportTool({
+      : threadMode
+        ? null
+        : createSubmitInvestigationReportTool({
           investigationId: job.investigationId,
           organizationId: job.config.organizationId,
           environment,
@@ -621,6 +684,7 @@ export async function runInvestigationAgent(
       upstashConnected: upstashServer !== null,
       workspaceSecrets,
       vercelAccountIds: vercelConnections.map((connection) => connection.accountId),
+      threadMode,
     });
     // Save the same string passed to the agent so the trace never reconstructs it.
     await writeTrace(investigationInstructionsTraceEvent(instructions));
@@ -628,11 +692,10 @@ export async function runInvestigationAgent(
       name: "Responder investigator",
       model: config.model,
       instructions,
-      capabilities: investigationCapabilities(job.replay),
+      capabilities: investigationCapabilities(replay),
       mcpServers: contextServers,
       tools: [
-        issueSearchTool,
-        reportTool,
+        ...(threadMode ? [] : [issueSearchTool, reportTool!]),
         ...awsInspectionTools,
         ...repositoryInspectionTools,
         ...upstashTools,
@@ -646,6 +709,9 @@ export async function runInvestigationAgent(
         maxTurns: 20,
         sandbox: { session },
         stream: true,
+        ...(sessionRuntime?.previousResponseId
+          ? { previousResponseId: sessionRuntime.previousResponseId }
+          : {}),
       },
     );
     for await (const streamEvent of result) {
@@ -660,8 +726,25 @@ export async function runInvestigationAgent(
     if (typeof result.finalOutput !== "string" || !result.finalOutput.trim()) {
       throw new Error("OpenAI agent returned an empty report");
     }
+    const report = redactDaytonaSecretPlaceholders(result.finalOutput.trim());
     await writeTrace(traceEvent("session.completed"));
-    return redactDaytonaSecretPlaceholders(result.finalOutput.trim());
+    if (threadMode) {
+      const sandboxSessionState = await client.serializeSessionState(
+        session.state,
+      );
+      delete sandboxSessionState.apiKey;
+      return {
+        report,
+        sandboxSessionState,
+        ...(result.lastResponseId
+          ? { previousResponseId: result.lastResponseId }
+          : {}),
+      };
+    }
+    return {
+      report,
+      ...(result.lastResponseId ? { previousResponseId: result.lastResponseId } : {}),
+    };
   } catch (error) {
     await writeTrace(
       traceEvent("session.failed", {
@@ -671,10 +754,14 @@ export async function runInvestigationAgent(
     throw error;
   } finally {
     if (session) {
-      await closeDaytonaSandbox(session, config, {
-        investigationId: job.investigationId,
-        organizationId: job.config.organizationId,
-      });
+      if (threadMode) {
+        await pauseDaytonaSandbox(session);
+      } else {
+        await closeDaytonaSandbox(session, config, {
+          investigationId: job.investigationId,
+          organizationId: job.config.organizationId,
+        });
+      }
     }
     await Promise.all(
       contextServers.map((server) =>

--- a/apps/worker/src/repositories.test.ts
+++ b/apps/worker/src/repositories.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   checkoutRuntimeRepositories,
   checkoutRuntimeRepositoriesAtRefs,
+  refreshRuntimeRepositories,
   repositoryWorkspacePath,
 } from "./repositories.js";
 
@@ -568,5 +569,32 @@ describe("Daytona repository checkout", () => {
     ).resolves.toEqual([]);
     expect(session.materializeEntry).not.toHaveBeenCalled();
     expect(session.execCommand).not.toHaveBeenCalled();
+  });
+
+  it("clears repositories and records an empty manifest when configuration changes", async () => {
+    const session = fakeSession();
+
+    await expect(
+      refreshRuntimeRepositories(session, "version-id", {
+        createInstallationToken: vi.fn(),
+        fetch: vi.fn(),
+        getRepositories: vi.fn().mockResolvedValue([]),
+      }),
+    ).resolves.toEqual([]);
+
+    expect(session.execCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cmd: expect.stringContaining(
+          "rm -rf '/home/daytona/workspace/repositories'",
+        ),
+      }),
+    );
+    expect(session.materializeEntry).toHaveBeenCalledWith({
+      entry: {
+        type: "file",
+        content: '{\n  "repositories": []\n}\n',
+      },
+      path: "/home/daytona/workspace/.responder/repositories.json",
+    });
   });
 });

--- a/apps/worker/src/repositories.ts
+++ b/apps/worker/src/repositories.ts
@@ -8,6 +8,7 @@ import { dirname, join } from "node:path";
 import { Readable, Transform } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import { promisify } from "node:util";
+import { z } from "zod";
 import {
   getRuntimeRepositories,
   type RuntimeRepository,
@@ -87,6 +88,30 @@ export interface CheckedOutRepository {
   repository: string;
   sha: string;
   workspaceBaseSha: string;
+}
+
+const checkedOutRepositoriesSchema = z.object({
+  repositories: z.array(z.object({
+    branch: z.string(),
+    path: z.string(),
+    repository: z.string(),
+    sha: z.string(),
+    workspaceBaseSha: z.string(),
+  })),
+});
+
+export async function loadCheckedOutRepositories(
+  session: DaytonaSandboxSession,
+): Promise<CheckedOutRepository[]> {
+  const manifestPath = `${workspaceRoot}/.responder/repositories.json`;
+  if (!(await session.pathExists(manifestPath))) return [];
+  const contents = await session.readFile({
+    path: manifestPath,
+    maxBytes: 1_000_000,
+  });
+  return checkedOutRepositoriesSchema.parse(
+    JSON.parse(new TextDecoder().decode(contents)),
+  ).repositories;
 }
 
 export interface RuntimeRepositoryReference {
@@ -567,6 +592,38 @@ export async function checkoutRuntimeRepositories(
     new Map(),
     dependencies,
   );
+}
+
+export async function refreshRuntimeRepositories(
+  session: DaytonaSandboxSession,
+  versionId: string,
+  dependencies: RepositoryCheckoutDependencies = defaultDependencies,
+): Promise<CheckedOutRepository[]> {
+  await runSandboxCommand(
+    session,
+    [
+      "set -eu",
+      `rm -rf ${shellQuote(`${workspaceRoot}/repositories`)}`,
+      `mkdir -p ${shellQuote(`${workspaceRoot}/repositories`)}`,
+      `rm -f ${shellQuote(`${workspaceRoot}/.responder/repositories.json`)}`,
+    ].join("\n"),
+    "refresh configured repositories",
+  );
+  const repositories = await checkoutRuntimeRepositories(
+    session,
+    versionId,
+    dependencies,
+  );
+  if (repositories.length === 0) {
+    await session.materializeEntry({
+      entry: {
+        type: "file",
+        content: `${JSON.stringify({ repositories: [] }, null, 2)}\n`,
+      },
+      path: `${workspaceRoot}/.responder/repositories.json`,
+    });
+  }
+  return repositories;
 }
 
 export async function checkoutRuntimeRepositoriesAtRefs(

--- a/apps/worker/src/sandbox.test.ts
+++ b/apps/worker/src/sandbox.test.ts
@@ -176,6 +176,25 @@ describe("Daytona sandbox cleanup", () => {
     expect(harness.dispose).toHaveBeenCalledOnce();
   });
 
+  it("keeps a thread sandbox after it pauses", async () => {
+    const harness = cleanupHarness();
+    const setAutoDeleteInterval = vi.fn().mockResolvedValue(undefined);
+    harness.get.mockResolvedValue({
+      id: "sandbox-1",
+      setAutoDeleteInterval,
+    });
+
+    await configureDaytonaSandboxLifecycle(
+      harness.session,
+      { daytonaApiKey: "daytona-test" },
+      [],
+      -1,
+      harness.dependencies,
+    );
+
+    expect(setAutoDeleteInterval).toHaveBeenCalledWith(-1);
+  });
+
   it("retries transient lifecycle failures", async () => {
     const harness = cleanupHarness();
     const gatewayError = Object.assign(new Error("bad gateway"), {

--- a/apps/worker/src/sandbox.ts
+++ b/apps/worker/src/sandbox.ts
@@ -156,8 +156,16 @@ export async function configureDaytonaSandboxLifecycle(
   session: DaytonaSandboxSession,
   config: DaytonaCleanupConfig,
   secrets: DaytonaSandboxSecretMount[] = [],
-  dependencies: DaytonaCleanupDependencies = defaultCleanupDependencies,
+  lifecycleOrDependencies: number | DaytonaCleanupDependencies =
+    defaultCleanupDependencies,
+  persistentDependencies: DaytonaCleanupDependencies = defaultCleanupDependencies,
 ): Promise<void> {
+  const autoDeleteInterval = typeof lifecycleOrDependencies === "number"
+    ? lifecycleOrDependencies
+    : 0;
+  const dependencies = typeof lifecycleOrDependencies === "number"
+    ? persistentDependencies
+    : lifecycleOrDependencies;
   const client = dependencies.createClient(config);
   try {
     const sandbox = await retryTransientDaytonaOperation(
@@ -181,12 +189,18 @@ export async function configureDaytonaSandboxLifecycle(
       await retryTransientDaytonaOperation(() => sandbox.start(), dependencies);
     }
     await retryTransientDaytonaOperation(
-      () => sandbox.setAutoDeleteInterval(0),
+      () => sandbox.setAutoDeleteInterval(autoDeleteInterval),
       dependencies,
     );
   } finally {
     await client[Symbol.asyncDispose]().catch(() => undefined);
   }
+}
+
+export async function pauseDaytonaSandbox(
+  session: DaytonaSandboxSession,
+): Promise<void> {
+  await session.close();
 }
 
 export async function closeDaytonaSandbox(

--- a/drizzle/0032_flippant_stryfe.sql
+++ b/drizzle/0032_flippant_stryfe.sql
@@ -1,0 +1,25 @@
+CREATE TABLE "slack_investigation_sessions" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"organization_id" uuid NOT NULL,
+	"agent_id" uuid NOT NULL,
+	"agent_config_version_id" uuid NOT NULL,
+	"runtime_profile_id" uuid NOT NULL,
+	"team_id" text NOT NULL,
+	"channel_id" text NOT NULL,
+	"thread_timestamp" text NOT NULL,
+	"sandbox_session_state" jsonb,
+	"previous_response_id" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "agents" ADD COLUMN "purpose" text DEFAULT 'standard' NOT NULL;--> statement-breakpoint
+ALTER TABLE "investigations" ADD COLUMN "execution_mode" text DEFAULT 'standard' NOT NULL;--> statement-breakpoint
+ALTER TABLE "investigations" ADD COLUMN "slack_investigation_session_id" uuid;--> statement-breakpoint
+ALTER TABLE "slack_investigation_sessions" ADD CONSTRAINT "slack_investigation_sessions_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "slack_investigation_sessions" ADD CONSTRAINT "slack_investigation_sessions_agent_id_agents_id_fk" FOREIGN KEY ("agent_id") REFERENCES "public"."agents"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "slack_investigation_sessions" ADD CONSTRAINT "slack_investigation_sessions_agent_config_version_id_agent_config_versions_id_fk" FOREIGN KEY ("agent_config_version_id") REFERENCES "public"."agent_config_versions"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "slack_investigation_sessions" ADD CONSTRAINT "slack_investigation_sessions_runtime_profile_id_runtime_profiles_id_fk" FOREIGN KEY ("runtime_profile_id") REFERENCES "public"."runtime_profiles"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "slack_investigation_sessions_thread_idx" ON "slack_investigation_sessions" USING btree ("organization_id","agent_id","team_id","channel_id","thread_timestamp");--> statement-breakpoint
+ALTER TABLE "investigations" ADD CONSTRAINT "investigations_slack_investigation_session_id_slack_investigation_sessions_id_fk" FOREIGN KEY ("slack_investigation_session_id") REFERENCES "public"."slack_investigation_sessions"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "agents_organization_slack_thread_idx" ON "agents" USING btree ("organization_id") WHERE "agents"."purpose" = 'slack_thread';

--- a/drizzle/meta/0032_snapshot.json
+++ b/drizzle/meta/0032_snapshot.json
@@ -1,0 +1,4026 @@
+{
+  "id": "ef0238dc-3acf-4fb1-b2dc-72b0cc14d59a",
+  "prevId": "b580e696-e21e-4475-b931-3b30afb1256b",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "invitation_organizationId_idx": {
+          "name": "invitation_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_email_idx": {
+          "name": "invitation_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "member_organizationId_idx": {
+          "name": "member_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_userId_idx": {
+          "name": "member_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'user'"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_organization_id": {
+          "name": "last_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_config_versions": {
+      "name": "agent_config_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "trigger_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_config": {
+          "name": "trigger_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "report_config": {
+          "name": "report_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context_account_ids": {
+          "name": "context_account_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "context_resource_ids": {
+          "name": "context_resource_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "pr_mode": {
+          "name": "pr_mode",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pr_mode_policy": {
+          "name": "pr_mode_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'disabled'"
+        },
+        "create_linear_tickets": {
+          "name": "create_linear_tickets",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "linear_issue_template": {
+          "name": "linear_issue_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'## Responder issue\n[{{issue_id}}]({{issue_url}})\n\n## Description\n{{description}}\n\n## Evidence\n{{evidence}}\n\n## Recommended remediation\n{{remediation}}'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_config_versions_agent_version_idx": {
+          "name": "agent_config_versions_agent_version_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_config_versions_agent_idx": {
+          "name": "agent_config_versions_agent_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_config_versions_agent_id_agents_id_fk": {
+          "name": "agent_config_versions_agent_id_agents_id_fk",
+          "tableFrom": "agent_config_versions",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_config_versions_created_by_user_id_fk": {
+          "name": "agent_config_versions_created_by_user_id_fk",
+          "tableFrom": "agent_config_versions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_version_repositories": {
+      "name": "agent_version_repositories",
+      "schema": "",
+      "columns": {
+        "agent_config_version_id": {
+          "name": "agent_config_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_version_repositories_agent_config_version_id_agent_config_versions_id_fk": {
+          "name": "agent_version_repositories_agent_config_version_id_agent_config_versions_id_fk",
+          "tableFrom": "agent_version_repositories",
+          "tableTo": "agent_config_versions",
+          "columnsFrom": [
+            "agent_config_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_version_repositories_repository_id_repositories_id_fk": {
+          "name": "agent_version_repositories_repository_id_repositories_id_fk",
+          "tableFrom": "agent_version_repositories",
+          "tableTo": "repositories",
+          "columnsFrom": [
+            "repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_version_repositories_agent_config_version_id_repository_id_pk": {
+          "name": "agent_version_repositories_agent_config_version_id_repository_id_pk",
+          "columns": [
+            "agent_config_version_id",
+            "repository_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_version_secrets": {
+      "name": "agent_version_secrets",
+      "schema": "",
+      "columns": {
+        "agent_config_version_id": {
+          "name": "agent_config_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_secret_id": {
+          "name": "workspace_secret_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_version_secrets_agent_config_version_id_agent_config_versions_id_fk": {
+          "name": "agent_version_secrets_agent_config_version_id_agent_config_versions_id_fk",
+          "tableFrom": "agent_version_secrets",
+          "tableTo": "agent_config_versions",
+          "columnsFrom": [
+            "agent_config_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_version_secrets_workspace_secret_id_workspace_secrets_id_fk": {
+          "name": "agent_version_secrets_workspace_secret_id_workspace_secrets_id_fk",
+          "tableFrom": "agent_version_secrets",
+          "tableTo": "workspace_secrets",
+          "columnsFrom": [
+            "workspace_secret_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_version_secrets_agent_config_version_id_workspace_secret_id_pk": {
+          "name": "agent_version_secrets_agent_config_version_id_workspace_secret_id_pk",
+          "columns": [
+            "agent_config_version_id",
+            "workspace_secret_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'standard'"
+        },
+        "active_version_id": {
+          "name": "active_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agents_organization_idx": {
+          "name": "agents_organization_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agents_organization_slack_thread_idx": {
+          "name": "agents_organization_slack_thread_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"agents\".\"purpose\" = 'slack_thread'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agents_organization_id_organization_id_fk": {
+          "name": "agents_organization_id_organization_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.billing_notification_deliveries": {
+      "name": "billing_notification_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integration_account_id": {
+          "name": "integration_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_key": {
+          "name": "period_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination": {
+          "name": "destination",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "billing_notification_delivery_target_idx": {
+          "name": "billing_notification_delivery_target_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "integration_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "destination",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "billing_notification_delivery_status_idx": {
+          "name": "billing_notification_delivery_status_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "billing_notification_deliveries_organization_id_organization_id_fk": {
+          "name": "billing_notification_deliveries_organization_id_organization_id_fk",
+          "tableFrom": "billing_notification_deliveries",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "billing_notification_deliveries_integration_account_id_integration_accounts_id_fk": {
+          "name": "billing_notification_deliveries_integration_account_id_integration_accounts_id_fk",
+          "tableFrom": "billing_notification_deliveries",
+          "tableTo": "integration_accounts",
+          "columnsFrom": [
+            "integration_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.delivery_attempts": {
+      "name": "delivery_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "investigation_id": {
+          "name": "investigation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination": {
+          "name": "destination",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "delivery_attempts_idempotency_idx": {
+          "name": "delivery_attempts_idempotency_idx",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_attempts_investigation_idx": {
+          "name": "delivery_attempts_investigation_idx",
+          "columns": [
+            {
+              "expression": "investigation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "delivery_attempts_investigation_id_investigations_id_fk": {
+          "name": "delivery_attempts_investigation_id_investigations_id_fk",
+          "tableFrom": "delivery_attempts",
+          "tableTo": "investigations",
+          "columnsFrom": [
+            "investigation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instance_configuration": {
+      "name": "instance_configuration",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "active_runtime_profile_id": {
+          "name": "active_runtime_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "instance_configuration_active_runtime_profile_id_runtime_profiles_id_fk": {
+          "name": "instance_configuration_active_runtime_profile_id_runtime_profiles_id_fk",
+          "tableFrom": "instance_configuration",
+          "tableTo": "runtime_profiles",
+          "columnsFrom": [
+            "active_runtime_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_accounts": {
+      "name": "integration_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "integration_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_account_id": {
+          "name": "external_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'connected'"
+        },
+        "encrypted_credentials": {
+          "name": "encrypted_credentials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_key_version": {
+          "name": "credential_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "integration_accounts_organization_provider_external_idx": {
+          "name": "integration_accounts_organization_provider_external_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_accounts_organization_idx": {
+          "name": "integration_accounts_organization_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_accounts_organization_id_organization_id_fk": {
+          "name": "integration_accounts_organization_id_organization_id_fk",
+          "tableFrom": "integration_accounts",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_connection_states": {
+      "name": "integration_connection_states",
+      "schema": "",
+      "columns": {
+        "state_hash": {
+          "name": "state_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "integration_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_verifier": {
+          "name": "code_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "return_to": {
+          "name": "return_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'/settings'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "integration_connection_states_expires_idx": {
+          "name": "integration_connection_states_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_connection_states_organization_idx": {
+          "name": "integration_connection_states_organization_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_connection_states_owner_provider_idx": {
+          "name": "integration_connection_states_owner_provider_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_connection_states_organization_id_organization_id_fk": {
+          "name": "integration_connection_states_organization_id_organization_id_fk",
+          "tableFrom": "integration_connection_states",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "integration_connection_states_user_id_user_id_fk": {
+          "name": "integration_connection_states_user_id_user_id_fk",
+          "tableFrom": "integration_connection_states",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_resources": {
+      "name": "integration_resources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "integration_account_id": {
+          "name": "integration_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "integration_resource_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "available": {
+          "name": "available",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "integration_resources_account_kind_external_idx": {
+          "name": "integration_resources_account_kind_external_idx",
+          "columns": [
+            {
+              "expression": "integration_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_resources_account_idx": {
+          "name": "integration_resources_account_idx",
+          "columns": [
+            {
+              "expression": "integration_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_resources_integration_account_id_integration_accounts_id_fk": {
+          "name": "integration_resources_integration_account_id_integration_accounts_id_fk",
+          "tableFrom": "integration_resources",
+          "tableTo": "integration_accounts",
+          "columnsFrom": [
+            "integration_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.investigation_issues": {
+      "name": "investigation_issues",
+      "schema": "",
+      "columns": {
+        "investigation_id": {
+          "name": "investigation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relationship": {
+          "name": "relationship",
+          "type": "issue_relationship",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "investigation_issues_issue_idx": {
+          "name": "investigation_issues_issue_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "investigation_issues_investigation_id_investigations_id_fk": {
+          "name": "investigation_issues_investigation_id_investigations_id_fk",
+          "tableFrom": "investigation_issues",
+          "tableTo": "investigations",
+          "columnsFrom": [
+            "investigation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "investigation_issues_issue_id_issues_id_fk": {
+          "name": "investigation_issues_issue_id_issues_id_fk",
+          "tableFrom": "investigation_issues",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "investigation_issues_investigation_id_issue_id_pk": {
+          "name": "investigation_issues_investigation_id_issue_id_pk",
+          "columns": [
+            "investigation_id",
+            "issue_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.investigation_replay_requests": {
+      "name": "investigation_replay_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source_investigation_id": {
+          "name": "source_investigation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "replay_investigation_id": {
+          "name": "replay_investigation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_by": {
+          "name": "requested_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "investigation_replay_request_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "processing_started_at": {
+          "name": "processing_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "queued_at": {
+          "name": "queued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "investigation_replay_requests_replay_idx": {
+          "name": "investigation_replay_requests_replay_idx",
+          "columns": [
+            {
+              "expression": "replay_investigation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "investigation_replay_requests_claim_idx": {
+          "name": "investigation_replay_requests_claim_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "investigation_replay_requests_source_idx": {
+          "name": "investigation_replay_requests_source_idx",
+          "columns": [
+            {
+              "expression": "source_investigation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "investigation_replay_requests_source_investigation_id_investigations_id_fk": {
+          "name": "investigation_replay_requests_source_investigation_id_investigations_id_fk",
+          "tableFrom": "investigation_replay_requests",
+          "tableTo": "investigations",
+          "columnsFrom": [
+            "source_investigation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.investigation_trace_events": {
+      "name": "investigation_trace_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "investigation_id": {
+          "name": "investigation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event": {
+          "name": "event",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "investigation_trace_events_investigation_id_idx": {
+          "name": "investigation_trace_events_investigation_id_idx",
+          "columns": [
+            {
+              "expression": "investigation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "investigation_trace_events_investigation_id_investigations_id_fk": {
+          "name": "investigation_trace_events_investigation_id_investigations_id_fk",
+          "tableFrom": "investigation_trace_events",
+          "tableTo": "investigations",
+          "columnsFrom": [
+            "investigation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.investigations": {
+      "name": "investigations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_config_version_id": {
+          "name": "agent_config_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime_profile_id": {
+          "name": "runtime_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_mode": {
+          "name": "execution_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'standard'"
+        },
+        "slack_investigation_session_id": {
+          "name": "slack_investigation_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "investigation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finding": {
+          "name": "finding",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "structured_report": {
+          "name": "structured_report",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replay_report": {
+          "name": "replay_report",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "report_markdown": {
+          "name": "report_markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_replay": {
+          "name": "is_replay",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "replay_of_investigation_id": {
+          "name": "replay_of_investigation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eve_session_id": {
+          "name": "eve_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_message_timestamp": {
+          "name": "slack_message_timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_trace_items": {
+          "name": "slack_trace_items",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "slack_thread_snapshot": {
+          "name": "slack_thread_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "investigations_organization_created_idx": {
+          "name": "investigations_organization_created_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "investigations_agent_created_idx": {
+          "name": "investigations_agent_created_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "investigations_replay_source_idx": {
+          "name": "investigations_replay_source_idx",
+          "columns": [
+            {
+              "expression": "replay_of_investigation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "investigations_organization_id_organization_id_fk": {
+          "name": "investigations_organization_id_organization_id_fk",
+          "tableFrom": "investigations",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "investigations_agent_id_agents_id_fk": {
+          "name": "investigations_agent_id_agents_id_fk",
+          "tableFrom": "investigations",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "investigations_agent_config_version_id_agent_config_versions_id_fk": {
+          "name": "investigations_agent_config_version_id_agent_config_versions_id_fk",
+          "tableFrom": "investigations",
+          "tableTo": "agent_config_versions",
+          "columnsFrom": [
+            "agent_config_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "investigations_runtime_profile_id_runtime_profiles_id_fk": {
+          "name": "investigations_runtime_profile_id_runtime_profiles_id_fk",
+          "tableFrom": "investigations",
+          "tableTo": "runtime_profiles",
+          "columnsFrom": [
+            "runtime_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "investigations_slack_investigation_session_id_slack_investigation_sessions_id_fk": {
+          "name": "investigations_slack_investigation_session_id_slack_investigation_sessions_id_fk",
+          "tableFrom": "investigations",
+          "tableTo": "slack_investigation_sessions",
+          "columnsFrom": [
+            "slack_investigation_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "investigations_replay_source_fk": {
+          "name": "investigations_replay_source_fk",
+          "tableFrom": "investigations",
+          "tableTo": "investigations",
+          "columnsFrom": [
+            "replay_of_investigation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_linear_tickets": {
+      "name": "issue_linear_tickets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "investigation_id": {
+          "name": "investigation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_config_version_id": {
+          "name": "agent_config_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integration_account_id": {
+          "name": "integration_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linear_issue_id": {
+          "name": "linear_issue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linear_identifier": {
+          "name": "linear_identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linear_issue_url": {
+          "name": "linear_issue_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "issue_linear_tickets_issue_idx": {
+          "name": "issue_linear_tickets_issue_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_linear_tickets_investigation_idx": {
+          "name": "issue_linear_tickets_investigation_idx",
+          "columns": [
+            {
+              "expression": "investigation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_linear_tickets_status_created_idx": {
+          "name": "issue_linear_tickets_status_created_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_linear_tickets_issue_id_issues_id_fk": {
+          "name": "issue_linear_tickets_issue_id_issues_id_fk",
+          "tableFrom": "issue_linear_tickets",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_linear_tickets_investigation_id_investigations_id_fk": {
+          "name": "issue_linear_tickets_investigation_id_investigations_id_fk",
+          "tableFrom": "issue_linear_tickets",
+          "tableTo": "investigations",
+          "columnsFrom": [
+            "investigation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_linear_tickets_agent_config_version_id_agent_config_versions_id_fk": {
+          "name": "issue_linear_tickets_agent_config_version_id_agent_config_versions_id_fk",
+          "tableFrom": "issue_linear_tickets",
+          "tableTo": "agent_config_versions",
+          "columnsFrom": [
+            "agent_config_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "issue_linear_tickets_integration_account_id_integration_accounts_id_fk": {
+          "name": "issue_linear_tickets_integration_account_id_integration_accounts_id_fk",
+          "tableFrom": "issue_linear_tickets",
+          "tableTo": "integration_accounts",
+          "columnsFrom": [
+            "integration_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_pull_request_activities": {
+      "name": "issue_pull_request_activities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_key": {
+          "name": "external_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event": {
+          "name": "event",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_pull_request_activities_request_idx": {
+          "name": "issue_pull_request_activities_request_idx",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_pull_request_activities_external_key_idx": {
+          "name": "issue_pull_request_activities_external_key_idx",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"issue_pull_request_activities\".\"external_key\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_pull_request_activities_request_id_issue_pull_requests_id_fk": {
+          "name": "issue_pull_request_activities_request_id_issue_pull_requests_id_fk",
+          "tableFrom": "issue_pull_request_activities",
+          "tableTo": "issue_pull_requests",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_pull_request_slack_messages": {
+      "name": "issue_pull_request_slack_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integration_account_id": {
+          "name": "integration_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_timestamp": {
+          "name": "message_timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_pull_request_slack_messages_message_idx": {
+          "name": "issue_pull_request_slack_messages_message_idx",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "integration_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "message_timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_pull_request_slack_messages_request_idx": {
+          "name": "issue_pull_request_slack_messages_request_idx",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_pull_request_slack_messages_request_id_issue_pull_requests_id_fk": {
+          "name": "issue_pull_request_slack_messages_request_id_issue_pull_requests_id_fk",
+          "tableFrom": "issue_pull_request_slack_messages",
+          "tableTo": "issue_pull_requests",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_pull_request_slack_messages_integration_account_id_integration_accounts_id_fk": {
+          "name": "issue_pull_request_slack_messages_integration_account_id_integration_accounts_id_fk",
+          "tableFrom": "issue_pull_request_slack_messages",
+          "tableTo": "integration_accounts",
+          "columnsFrom": [
+            "integration_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_pull_requests": {
+      "name": "issue_pull_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "investigation_id": {
+          "name": "investigation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_config_version_id": {
+          "name": "agent_config_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "remediation_id": {
+          "name": "remediation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_full_name": {
+          "name": "repository_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pull_request_number": {
+          "name": "pull_request_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pull_request_url": {
+          "name": "pull_request_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eve_session_id": {
+          "name": "eve_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "issue_pull_requests_active_issue_idx": {
+          "name": "issue_pull_requests_active_issue_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"status\" in ('queued', 'creating', 'created')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_pull_requests_issue_created_idx": {
+          "name": "issue_pull_requests_issue_created_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_pull_requests_investigation_idx": {
+          "name": "issue_pull_requests_investigation_idx",
+          "columns": [
+            {
+              "expression": "investigation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_pull_requests_issue_id_issues_id_fk": {
+          "name": "issue_pull_requests_issue_id_issues_id_fk",
+          "tableFrom": "issue_pull_requests",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_pull_requests_investigation_id_investigations_id_fk": {
+          "name": "issue_pull_requests_investigation_id_investigations_id_fk",
+          "tableFrom": "issue_pull_requests",
+          "tableTo": "investigations",
+          "columnsFrom": [
+            "investigation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_pull_requests_agent_config_version_id_agent_config_versions_id_fk": {
+          "name": "issue_pull_requests_agent_config_version_id_agent_config_versions_id_fk",
+          "tableFrom": "issue_pull_requests",
+          "tableTo": "agent_config_versions",
+          "columnsFrom": [
+            "agent_config_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issues": {
+      "name": "issues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root_cause": {
+          "name": "root_cause",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "timeline": {
+          "name": "timeline",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "severity": {
+          "name": "severity",
+          "type": "severity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "remediation": {
+          "name": "remediation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "remediations": {
+          "name": "remediations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_model": {
+          "name": "embedding_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issues_organization_created_idx": {
+          "name": "issues_organization_created_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issues_organization_id_organization_id_fk": {
+          "name": "issues_organization_id_organization_id_fk",
+          "tableFrom": "issues",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.repositories": {
+      "name": "repositories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "integration_account_id": {
+          "name": "integration_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'main'"
+        },
+        "private": {
+          "name": "private",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "available": {
+          "name": "available",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "repositories_installation_external_idx": {
+          "name": "repositories_installation_external_idx",
+          "columns": [
+            {
+              "expression": "integration_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "repositories_integration_account_id_integration_accounts_id_fk": {
+          "name": "repositories_integration_account_id_integration_accounts_id_fk",
+          "tableFrom": "repositories",
+          "tableTo": "integration_accounts",
+          "columnsFrom": [
+            "integration_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runtime_profiles": {
+      "name": "runtime_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "version": {
+          "name": "version",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_options": {
+          "name": "model_options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "runtime_profiles_version_idx": {
+          "name": "runtime_profiles_version_idx",
+          "columns": [
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_investigation_sessions": {
+      "name": "slack_investigation_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_config_version_id": {
+          "name": "agent_config_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime_profile_id": {
+          "name": "runtime_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_timestamp": {
+          "name": "thread_timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandbox_session_state": {
+          "name": "sandbox_session_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_response_id": {
+          "name": "previous_response_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "slack_investigation_sessions_thread_idx": {
+          "name": "slack_investigation_sessions_thread_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "thread_timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_investigation_sessions_organization_id_organization_id_fk": {
+          "name": "slack_investigation_sessions_organization_id_organization_id_fk",
+          "tableFrom": "slack_investigation_sessions",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "slack_investigation_sessions_agent_id_agents_id_fk": {
+          "name": "slack_investigation_sessions_agent_id_agents_id_fk",
+          "tableFrom": "slack_investigation_sessions",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "slack_investigation_sessions_agent_config_version_id_agent_config_versions_id_fk": {
+          "name": "slack_investigation_sessions_agent_config_version_id_agent_config_versions_id_fk",
+          "tableFrom": "slack_investigation_sessions",
+          "tableTo": "agent_config_versions",
+          "columnsFrom": [
+            "agent_config_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "slack_investigation_sessions_runtime_profile_id_runtime_profiles_id_fk": {
+          "name": "slack_investigation_sessions_runtime_profile_id_runtime_profiles_id_fk",
+          "tableFrom": "slack_investigation_sessions",
+          "tableTo": "runtime_profiles",
+          "columnsFrom": [
+            "runtime_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_receipts": {
+      "name": "webhook_receipts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_event_id": {
+          "name": "external_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "investigation_id": {
+          "name": "investigation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_hash": {
+          "name": "payload_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_receipts_provider_event_idx": {
+          "name": "webhook_receipts_provider_event_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_receipts_organization_id_organization_id_fk": {
+          "name": "webhook_receipts_organization_id_organization_id_fk",
+          "tableFrom": "webhook_receipts",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_secrets": {
+      "name": "workspace_secrets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "daytona_secret_id": {
+          "name": "daytona_secret_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "daytona_secret_name": {
+          "name": "daytona_secret_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allowed_hosts": {
+          "name": "allowed_hosts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workspace_secrets_organization_name_idx": {
+          "name": "workspace_secrets_organization_name_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_secrets_daytona_id_idx": {
+          "name": "workspace_secrets_daytona_id_idx",
+          "columns": [
+            {
+              "expression": "daytona_secret_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_secrets_daytona_name_idx": {
+          "name": "workspace_secrets_daytona_name_idx",
+          "columns": [
+            {
+              "expression": "daytona_secret_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_secrets_organization_id_organization_id_fk": {
+          "name": "workspace_secrets_organization_id_organization_id_fk",
+          "tableFrom": "workspace_secrets",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "workspace_secrets_created_by_user_id_fk": {
+          "name": "workspace_secrets_created_by_user_id_fk",
+          "tableFrom": "workspace_secrets",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.integration_provider": {
+      "name": "integration_provider",
+      "schema": "public",
+      "values": [
+        "aws",
+        "github",
+        "slack",
+        "sentry",
+        "datadog",
+        "axiom",
+        "clickstack",
+        "upstash",
+        "langfuse",
+        "vercel",
+        "custom_mcp",
+        "linear"
+      ]
+    },
+    "public.integration_resource_kind": {
+      "name": "integration_resource_kind",
+      "schema": "public",
+      "values": [
+        "slack_channel",
+        "sentry_project",
+        "datadog_monitor",
+        "vercel_project"
+      ]
+    },
+    "public.investigation_replay_request_status": {
+      "name": "investigation_replay_request_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "queued",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.investigation_status": {
+      "name": "investigation_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "investigating",
+        "resolved",
+        "failed"
+      ]
+    },
+    "public.issue_relationship": {
+      "name": "issue_relationship",
+      "schema": "public",
+      "values": [
+        "new",
+        "recurrence"
+      ]
+    },
+    "public.severity": {
+      "name": "severity",
+      "schema": "public",
+      "values": [
+        "SEV-1",
+        "SEV-2",
+        "SEV-3"
+      ]
+    },
+    "public.trigger_kind": {
+      "name": "trigger_kind",
+      "schema": "public",
+      "values": [
+        "sentry_issue",
+        "datadog_monitor",
+        "slack_channel",
+        "slack_mention"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -225,6 +225,13 @@
       "when": 1787821722547,
       "tag": "0031_nostalgic_angel",
       "breakpoints": true
+    },
+    {
+      "idx": 32,
+      "version": "7",
+      "when": 1787849835131,
+      "tag": "0032_flippant_stryfe",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/src/agents/config.test.ts
+++ b/packages/core/src/agents/config.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { agentConfigurationSchema } from "./config.js";
+import {
+  agentConfigurationSchema,
+  slackThreadModeConfigurationSchema,
+} from "./config.js";
 
 const baseConfiguration = {
   name: "Checkout guardian",
@@ -19,6 +22,27 @@ const baseConfiguration = {
 };
 
 describe("agent configuration", () => {
+  it("keeps tag mode configuration to prompt and context capabilities", () => {
+    const parsed = slackThreadModeConfigurationSchema.parse({
+      enabled: true,
+      model: "instance/default",
+      instructions: "Investigate the request.",
+      repositoryIds: ["14141414-1414-4414-8414-141414141414"],
+    });
+
+    expect(parsed).toEqual({
+      enabled: true,
+      model: "instance/default",
+      instructions: "Investigate the request.",
+      repositoryIds: ["14141414-1414-4414-8414-141414141414"],
+      contextAccountIds: [],
+      contextResourceIds: [],
+      secretIds: [],
+    });
+    expect(parsed).not.toHaveProperty("prMode");
+    expect(parsed).not.toHaveProperty("createLinearTickets");
+  });
+
   it("accepts a Slack mention agent that reports in the source thread", () => {
     const parsed = agentConfigurationSchema.safeParse(baseConfiguration);
 

--- a/packages/core/src/agents/config.ts
+++ b/packages/core/src/agents/config.ts
@@ -118,7 +118,20 @@ export const agentConfigurationSchema = z
     }
   });
 
+export const slackThreadModeConfigurationSchema = z.object({
+  enabled: z.boolean().default(false),
+  model: z.string().trim().min(1, "Model is required").max(160),
+  instructions: z.string().trim().min(1, "Instructions are required").max(20_000),
+  repositoryIds: z.array(z.uuid()).max(100).default([]),
+  contextAccountIds: z.array(z.uuid()).max(20).default([]),
+  contextResourceIds: z.array(z.uuid()).max(100).default([]),
+  secretIds: z.array(z.uuid()).max(20).default([]),
+});
+
 export type AgentConfigurationInput = z.input<typeof agentConfigurationSchema>;
 export type AgentConfiguration = z.output<typeof agentConfigurationSchema>;
 export type AgentTrigger = AgentConfiguration["trigger"];
 export type AgentReporting = AgentConfiguration["reporting"];
+export type SlackThreadModeConfiguration = z.output<
+  typeof slackThreadModeConfigurationSchema
+>;

--- a/packages/core/src/db/agents.ts
+++ b/packages/core/src/db/agents.ts
@@ -1,5 +1,8 @@
 import { and, desc, eq, exists, inArray } from "drizzle-orm";
-import type { AgentConfiguration } from "../agents/config.js";
+import type {
+  AgentConfiguration,
+  SlackThreadModeConfiguration,
+} from "../agents/config.js";
 import { LINEAR_AUTH_VERSION } from "../integrations/linear.js";
 import { getDatabase } from "./client.js";
 import {
@@ -43,7 +46,7 @@ export async function findAgentsForSlackEvent(input: {
     agentId: string;
     integrationAccountId: string;
     organizationId: string;
-    trigger: "slack_channel" | "slack_mention";
+    trigger: "slack_channel" | "slack_mention" | "slack_thread";
   }>
 > {
   const rows = await getDatabase()
@@ -54,6 +57,7 @@ export async function findAgentsForSlackEvent(input: {
       accountMetadata: integrationAccounts.metadata,
       trigger: agentConfigVersions.trigger,
       triggerConfig: agentConfigVersions.triggerConfig,
+      purpose: agents.purpose,
     })
     .from(agents)
     .innerJoin(
@@ -71,6 +75,10 @@ export async function findAgentsForSlackEvent(input: {
     )
     .where(eq(agents.enabled, true));
 
+  const useSlackThreadMode =
+    input.eventType === "app_mention" &&
+    rows.some((row) => row.purpose === "slack_thread");
+
   return rows
     .filter((row) => {
       if (
@@ -81,9 +89,11 @@ export async function findAgentsForSlackEvent(input: {
       ) {
         return false;
       }
-      if (row.triggerConfig.integrationAccountId !== row.integrationAccountId) {
-        return false;
+      if (row.purpose === "slack_thread") {
+        return input.eventType === "app_mention";
       }
+      if (useSlackThreadMode) return false;
+      if (row.triggerConfig.integrationAccountId !== row.integrationAccountId) return false;
       if (row.trigger === "slack_channel" && input.eventType === "message") {
         return (
           "channelId" in row.triggerConfig &&
@@ -103,7 +113,9 @@ export async function findAgentsForSlackEvent(input: {
       agentId: row.agentId,
       integrationAccountId: row.integrationAccountId,
       organizationId: row.organizationId,
-      trigger: row.trigger as "slack_channel" | "slack_mention",
+      trigger: row.purpose === "slack_thread"
+        ? "slack_thread" as const
+        : row.trigger as "slack_channel" | "slack_mention",
     }));
 }
 
@@ -486,6 +498,7 @@ export async function createAgent(input: {
   organizationId: string;
   userId: string;
   configuration: AgentConfiguration;
+  purpose?: "standard" | "slack_thread";
 }): Promise<string> {
   await validateConfigurationResources(input.organizationId, input.configuration);
   const db = getDatabase();
@@ -498,6 +511,7 @@ export async function createAgent(input: {
         name: input.configuration.name,
         description: input.configuration.description,
         enabled: input.configuration.enabled,
+        purpose: input.purpose ?? "standard",
       })
       .returning({ id: agents.id });
     const agent = insertedAgents[0];
@@ -558,6 +572,7 @@ export async function updateAgent(input: {
   organizationId: string;
   userId: string;
   configuration: AgentConfiguration;
+  purpose?: "standard" | "slack_thread";
 }): Promise<void> {
   await validateConfigurationResources(input.organizationId, input.configuration);
   const db = getDatabase();
@@ -570,6 +585,7 @@ export async function updateAgent(input: {
         and(
           eq(agents.id, input.agentId),
           eq(agents.organizationId, input.organizationId),
+          eq(agents.purpose, input.purpose ?? "standard"),
         ),
       )
       .limit(1)
@@ -796,7 +812,12 @@ export async function listAgents(organizationId: string) {
       agentConfigVersions,
       eq(agentConfigVersions.id, agents.activeVersionId),
     )
-    .where(eq(agents.organizationId, organizationId))
+    .where(
+      and(
+        eq(agents.organizationId, organizationId),
+        eq(agents.purpose, "standard"),
+      ),
+    )
     .orderBy(desc(agents.updatedAt));
 
   const agentIds = rows.map((agent) => agent.id);
@@ -879,7 +900,11 @@ export async function getAgent(
       eq(agentConfigVersions.id, agents.activeVersionId),
     )
     .where(
-      and(eq(agents.id, agentId), eq(agents.organizationId, organizationId)),
+      and(
+        eq(agents.id, agentId),
+        eq(agents.organizationId, organizationId),
+        eq(agents.purpose, "standard"),
+      ),
     )
     .limit(1);
   const agent = rows[0];
@@ -979,4 +1004,135 @@ export async function getAgent(
       }),
     ),
   };
+}
+
+export async function getSlackThreadModeConfiguration(
+  organizationId: string,
+): Promise<SlackThreadModeConfiguration | null> {
+  const db = getDatabase();
+  const rows = await db
+    .select({
+      enabled: agents.enabled,
+      versionId: agentConfigVersions.id,
+      model: agentConfigVersions.model,
+      instructions: agentConfigVersions.prompt,
+      contextAccountIds: agentConfigVersions.contextAccountIds,
+      contextResourceIds: agentConfigVersions.contextResourceIds,
+    })
+    .from(agents)
+    .innerJoin(
+      agentConfigVersions,
+      eq(agentConfigVersions.id, agents.activeVersionId),
+    )
+    .where(
+      and(
+        eq(agents.organizationId, organizationId),
+        eq(agents.purpose, "slack_thread"),
+      ),
+    )
+    .limit(1);
+  const configuration = rows[0];
+  if (!configuration) return null;
+
+  const [repositoryRows, secretRows] = await Promise.all([
+    db
+      .select({ id: agentVersionRepositories.repositoryId })
+      .from(agentVersionRepositories)
+      .where(
+        eq(
+          agentVersionRepositories.agentConfigVersionId,
+          configuration.versionId,
+        ),
+      ),
+    db
+      .select({ id: agentVersionSecrets.workspaceSecretId })
+      .from(agentVersionSecrets)
+      .where(
+        eq(agentVersionSecrets.agentConfigVersionId, configuration.versionId),
+      ),
+  ]);
+
+  return {
+    enabled: configuration.enabled,
+    model: configuration.model,
+    instructions: configuration.instructions,
+    repositoryIds: repositoryRows.map((row) => row.id),
+    contextAccountIds: configuration.contextAccountIds,
+    contextResourceIds: configuration.contextResourceIds,
+    secretIds: secretRows.map((row) => row.id),
+  };
+}
+
+export async function saveSlackThreadModeConfiguration(input: {
+  organizationId: string;
+  userId: string;
+  configuration: SlackThreadModeConfiguration;
+}): Promise<void> {
+  const db = getDatabase();
+  const slackAccounts = await db
+    .select({ id: integrationAccounts.id })
+    .from(integrationAccounts)
+    .where(
+      and(
+        eq(integrationAccounts.organizationId, input.organizationId),
+        eq(integrationAccounts.provider, "slack"),
+        eq(integrationAccounts.status, "connected"),
+      ),
+    )
+    .limit(1);
+  const slackAccount = slackAccounts[0];
+  if (!slackAccount) {
+    throw new AgentConfigurationError(
+      "Connect Slack before enabling tag mode",
+      "integration_not_found",
+    );
+  }
+
+  const configuration: AgentConfiguration = {
+    name: "Responder tag mode",
+    description: "Runs ad-hoc investigations from Slack mentions.",
+    model: input.configuration.model,
+    instructions: input.configuration.instructions,
+    enabled: input.configuration.enabled,
+    prMode: "disabled",
+    repositoryIds: input.configuration.repositoryIds,
+    contextAccountIds: input.configuration.contextAccountIds,
+    contextResourceIds: input.configuration.contextResourceIds,
+    secretIds: input.configuration.secretIds,
+    createLinearTickets: false,
+    linearIssueTemplate: "",
+    trigger: {
+      kind: "slack_mention",
+      integrationAccountId: slackAccount.id,
+      channelIds: [],
+    },
+    reporting: { mode: "thread" },
+  };
+  const existing = await db
+    .select({ id: agents.id })
+    .from(agents)
+    .where(
+      and(
+        eq(agents.organizationId, input.organizationId),
+        eq(agents.purpose, "slack_thread"),
+      ),
+    )
+    .limit(1);
+
+  if (existing[0]) {
+    await updateAgent({
+      agentId: existing[0].id,
+      organizationId: input.organizationId,
+      userId: input.userId,
+      configuration,
+      purpose: "slack_thread",
+    });
+    return;
+  }
+  await createAgent({
+    organizationId: input.organizationId,
+    userId: input.userId,
+    configuration,
+    purpose: "slack_thread",
+  });
 }

--- a/packages/core/src/db/investigations.ts
+++ b/packages/core/src/db/investigations.ts
@@ -48,6 +48,7 @@ import {
   investigations,
   repositories,
   runtimeProfiles,
+  slackInvestigationSessions,
   webhookReceipts,
   type InvestigationInput,
   type InvestigationSlackMessageSnapshot,
@@ -90,6 +91,12 @@ export interface BeginInvestigationResult {
   investigationId: string;
   runtimeProfileId: string;
   config: RuntimeAgentConfig;
+}
+
+export interface BeginSlackThreadInvestigationResult
+  extends BeginInvestigationResult {
+  configurationChanged: boolean;
+  slackInvestigationSessionId: string;
 }
 
 export class InstanceRuntimeProfileError extends Error {
@@ -2522,6 +2529,254 @@ export async function beginInvestigation(
   });
 }
 
+export async function beginSlackThreadInvestigation(input: {
+  agentId: string;
+  investigationInput: InvestigationInput;
+  teamId: string;
+  channelId: string;
+  threadTimestamp: string;
+}): Promise<BeginSlackThreadInvestigationResult> {
+  const db = getDatabase();
+  const payloadHash = createHash("sha256")
+    .update(JSON.stringify(input.investigationInput))
+    .digest("hex");
+
+  return db.transaction(async (tx) => {
+    const agentRows = await tx
+      .select({
+        id: agents.id,
+        organizationId: agents.organizationId,
+        activeVersionId: agents.activeVersionId,
+      })
+      .from(agents)
+      .where(
+        and(
+          eq(agents.id, input.agentId),
+          eq(agents.enabled, true),
+          eq(agents.purpose, "slack_thread"),
+        ),
+      )
+      .limit(1);
+    const agent = agentRows[0];
+    if (!agent?.activeVersionId) {
+      throw new Error("Tag mode is missing an active configuration");
+    }
+
+    let sessionRows = await tx
+      .select({
+        id: slackInvestigationSessions.id,
+        agentConfigVersionId: slackInvestigationSessions.agentConfigVersionId,
+        runtimeProfileId: slackInvestigationSessions.runtimeProfileId,
+      })
+      .from(slackInvestigationSessions)
+      .where(
+        and(
+          eq(slackInvestigationSessions.organizationId, agent.organizationId),
+          eq(slackInvestigationSessions.agentId, agent.id),
+          eq(slackInvestigationSessions.teamId, input.teamId),
+          eq(slackInvestigationSessions.channelId, input.channelId),
+          eq(slackInvestigationSessions.threadTimestamp, input.threadTimestamp),
+        ),
+      )
+      .limit(1);
+
+    if (!sessionRows[0]) {
+      const activeProfiles = await tx
+        .select({ id: runtimeProfiles.id })
+        .from(instanceConfiguration)
+        .innerJoin(
+          runtimeProfiles,
+          eq(runtimeProfiles.id, instanceConfiguration.activeRuntimeProfileId),
+        )
+        .where(eq(instanceConfiguration.id, "default"))
+        .limit(1);
+      const activeProfile = activeProfiles[0];
+      if (!activeProfile) throw new InstanceRuntimeProfileError();
+      const inserted = await tx
+        .insert(slackInvestigationSessions)
+        .values({
+          organizationId: agent.organizationId,
+          agentId: agent.id,
+          agentConfigVersionId: agent.activeVersionId,
+          runtimeProfileId: activeProfile.id,
+          teamId: input.teamId,
+          channelId: input.channelId,
+          threadTimestamp: input.threadTimestamp,
+        })
+        .onConflictDoNothing()
+        .returning({
+          id: slackInvestigationSessions.id,
+          agentConfigVersionId: slackInvestigationSessions.agentConfigVersionId,
+          runtimeProfileId: slackInvestigationSessions.runtimeProfileId,
+        });
+      sessionRows = inserted.length > 0
+        ? inserted
+        : await tx
+            .select({
+              id: slackInvestigationSessions.id,
+              agentConfigVersionId:
+                slackInvestigationSessions.agentConfigVersionId,
+              runtimeProfileId: slackInvestigationSessions.runtimeProfileId,
+            })
+            .from(slackInvestigationSessions)
+            .where(
+              and(
+                eq(slackInvestigationSessions.organizationId, agent.organizationId),
+                eq(slackInvestigationSessions.agentId, agent.id),
+                eq(slackInvestigationSessions.teamId, input.teamId),
+                eq(slackInvestigationSessions.channelId, input.channelId),
+                eq(slackInvestigationSessions.threadTimestamp, input.threadTimestamp),
+              ),
+            )
+            .limit(1);
+    }
+    let session = sessionRows[0];
+    if (!session) throw new Error("Unable to create Slack investigation session");
+    const configurationChanged =
+      session.agentConfigVersionId !== agent.activeVersionId;
+    if (configurationChanged) {
+      await tx
+        .update(slackInvestigationSessions)
+        .set({
+          agentConfigVersionId: agent.activeVersionId,
+          updatedAt: new Date(),
+        })
+        .where(eq(slackInvestigationSessions.id, session.id));
+      session = {
+        ...session,
+        agentConfigVersionId: agent.activeVersionId,
+      };
+    }
+
+    const configRows = await tx
+      .select({
+        id: agentConfigVersions.id,
+        agentId: agentConfigVersions.agentId,
+        model: agentConfigVersions.model,
+        prompt: agentConfigVersions.prompt,
+        prMode: agentConfigVersions.prMode,
+        createLinearTickets: agentConfigVersions.createLinearTickets,
+        linearIssueTemplate: agentConfigVersions.linearIssueTemplate,
+      })
+      .from(agentConfigVersions)
+      .where(eq(agentConfigVersions.id, session.agentConfigVersionId))
+      .limit(1);
+    const config = configRows[0];
+    if (!config || config.agentId !== agent.id) {
+      throw new Error("Tag mode configuration is invalid");
+    }
+
+    const investigationId = randomUUID();
+    const insertedReceipt = await tx
+      .insert(webhookReceipts)
+      .values({
+        organizationId: agent.organizationId,
+        provider: "slack",
+        externalEventId: input.investigationInput.externalEventId,
+        investigationId,
+        payloadHash,
+      })
+      .onConflictDoNothing({
+        target: [webhookReceipts.provider, webhookReceipts.externalEventId],
+      })
+      .returning({ investigationId: webhookReceipts.investigationId });
+
+    if (!insertedReceipt[0]) {
+      const existing = await tx
+        .select({ investigationId: webhookReceipts.investigationId })
+        .from(webhookReceipts)
+        .where(
+          and(
+            eq(webhookReceipts.provider, "slack"),
+            eq(
+              webhookReceipts.externalEventId,
+              input.investigationInput.externalEventId,
+            ),
+          ),
+        )
+        .limit(1);
+      if (!existing[0]) throw new Error("Unable to resolve duplicate mention");
+      return {
+        created: false,
+        configurationChanged,
+        investigationId: existing[0].investigationId,
+        slackInvestigationSessionId: session.id,
+        runtimeProfileId: session.runtimeProfileId,
+        config: { ...config, organizationId: agent.organizationId },
+      };
+    }
+
+    await tx.insert(investigations).values({
+      id: investigationId,
+      organizationId: agent.organizationId,
+      agentId: agent.id,
+      agentConfigVersionId: config.id,
+      runtimeProfileId: session.runtimeProfileId,
+      executionMode: "slack_thread",
+      slackInvestigationSessionId: session.id,
+      title: input.investigationInput.title,
+      input: input.investigationInput,
+    });
+    return {
+      created: true,
+      configurationChanged,
+      investigationId,
+      slackInvestigationSessionId: session.id,
+      runtimeProfileId: session.runtimeProfileId,
+      config: { ...config, organizationId: agent.organizationId },
+    };
+  });
+}
+
+export async function getSlackInvestigationSessionRuntime(sessionId: string) {
+  const rows = await getDatabase()
+    .select({
+      sandboxSessionState: slackInvestigationSessions.sandboxSessionState,
+      previousResponseId: slackInvestigationSessions.previousResponseId,
+    })
+    .from(slackInvestigationSessions)
+    .where(eq(slackInvestigationSessions.id, sessionId))
+    .limit(1);
+  return rows[0] ?? null;
+}
+
+export async function completeSlackThreadInvestigationTurn(input: {
+  investigationId: string;
+  sessionId: string;
+  reportMarkdown: string;
+  sandboxSessionState: Record<string, unknown>;
+  previousResponseId?: string;
+}): Promise<void> {
+  await getDatabase().transaction(async (tx) => {
+    const sessions = await tx
+      .update(slackInvestigationSessions)
+      .set({
+        sandboxSessionState: input.sandboxSessionState,
+        previousResponseId: input.previousResponseId ?? null,
+        updatedAt: new Date(),
+      })
+      .where(eq(slackInvestigationSessions.id, input.sessionId))
+      .returning({ id: slackInvestigationSessions.id });
+    if (!sessions[0]) throw new Error("Slack investigation session not found");
+    const completed = await tx
+      .update(investigations)
+      .set({
+        status: "resolved",
+        reportMarkdown: input.reportMarkdown,
+        completedAt: new Date(),
+        updatedAt: new Date(),
+      })
+      .where(
+        and(
+          eq(investigations.id, input.investigationId),
+          eq(investigations.slackInvestigationSessionId, input.sessionId),
+        ),
+      )
+      .returning({ id: investigations.id });
+    if (!completed[0]) throw new Error("Slack investigation turn not found");
+  });
+}
+
 export async function markInvestigationStarted(
   investigationId: string,
   eveSessionId: string,
@@ -2597,6 +2852,17 @@ export async function completeInvestigation(
       updatedAt: new Date(),
     })
     .where(eq(investigations.id, investigationId));
+}
+
+export async function getInvestigationReportMarkdown(
+  investigationId: string,
+): Promise<string | null> {
+  const rows = await getDatabase()
+    .select({ reportMarkdown: investigations.reportMarkdown })
+    .from(investigations)
+    .where(eq(investigations.id, investigationId))
+    .limit(1);
+  return rows[0]?.reportMarkdown ?? null;
 }
 
 export function replayReportMarkdownUpdate(

--- a/packages/core/src/db/issues.ts
+++ b/packages/core/src/db/issues.ts
@@ -627,6 +627,7 @@ export async function getIssueForSlackBackfill(input: {
 
 export interface SlackInvestigationDeliveryContext {
   agentId: string;
+  executionMode: "standard" | "slack_thread";
   investigationId: string;
   prMode: AgentPrMode;
   report: StructuredInvestigationReport;
@@ -671,6 +672,7 @@ export interface SlackInvestigationDeliveryContext {
 
 export interface SlackInvestigationLiveContext {
   agentId: string;
+  executionMode: "standard" | "slack_thread";
   investigationId: string;
   title: string;
   traceItems: InvestigationSlackTraceItem[];
@@ -678,6 +680,8 @@ export interface SlackInvestigationLiveContext {
     channelId: string;
     encryptedCredentials: string;
     messageTimestamp: string | null;
+    reactionTimestamp?: string;
+    responseMessageTimestamp?: string;
     threadTimestamp: string;
   };
 }
@@ -698,10 +702,12 @@ export async function getSlackInvestigationLiveContext(
   const rows = await getDatabase()
     .select({
       agentId: investigations.agentId,
+      executionMode: investigations.executionMode,
       id: investigations.id,
       input: investigations.input,
       messageTimestamp: investigations.slackMessageTimestamp,
       organizationId: investigations.organizationId,
+      slackThreadSnapshot: investigations.slackThreadSnapshot,
       title: investigations.title,
       traceItems: investigations.slackTraceItems,
       trigger: agentConfigVersions.trigger,
@@ -717,10 +723,13 @@ export async function getSlackInvestigationLiveContext(
   const investigation = rows[0];
   if (!investigation || investigation.input.provider !== "slack") return null;
 
-  const accountId = slackSourceAccountId({
-    trigger: investigation.trigger,
-    triggerConfig: investigation.triggerConfig,
-  });
+  const accountId =
+    typeof investigation.input.attributes?.integrationAccountId === "string"
+      ? investigation.input.attributes.integrationAccountId
+      : slackSourceAccountId({
+          trigger: investigation.trigger,
+          triggerConfig: investigation.triggerConfig,
+        });
   const channelId = investigation.input.attributes?.channelId;
   const sourceTimestamp = investigation.input.attributes?.timestamp;
   const threadTimestamp =
@@ -728,6 +737,7 @@ export async function getSlackInvestigationLiveContext(
   if (
     !accountId ||
     typeof channelId !== "string" ||
+    typeof sourceTimestamp !== "string" ||
     typeof threadTimestamp !== "string"
   ) {
     return null;
@@ -747,9 +757,13 @@ export async function getSlackInvestigationLiveContext(
     .limit(1);
   const encryptedCredentials = accounts[0]?.encryptedCredentials;
   if (!encryptedCredentials) return null;
+  const responseMessageTimestamp = investigation.slackThreadSnapshot?.replies.find(
+    (reply) => reply.key === "thread-response",
+  )?.slackTimestamp;
 
   return {
     agentId: investigation.agentId,
+    executionMode: investigation.executionMode,
     investigationId: investigation.id,
     title: investigation.title,
     traceItems: investigation.traceItems,
@@ -757,6 +771,8 @@ export async function getSlackInvestigationLiveContext(
       channelId,
       encryptedCredentials,
       messageTimestamp: investigation.messageTimestamp,
+      reactionTimestamp: sourceTimestamp,
+      ...(responseMessageTimestamp ? { responseMessageTimestamp } : {}),
       threadTimestamp,
     },
   };
@@ -769,6 +785,7 @@ export async function getSlackInvestigationDeliveryContext(
   const rows = await db
     .select({
       agentId: investigations.agentId,
+      executionMode: investigations.executionMode,
       id: investigations.id,
       input: investigations.input,
       messageTimestamp: investigations.slackMessageTimestamp,
@@ -791,13 +808,14 @@ export async function getSlackInvestigationDeliveryContext(
   const investigation = rows[0];
   if (!investigation?.report) return null;
 
-  const sourceAccountId =
-    investigation.input.provider === "slack"
-      ? slackSourceAccountId({
+  const sourceAccountId = investigation.input.provider === "slack"
+    ? typeof investigation.input.attributes?.integrationAccountId === "string"
+      ? investigation.input.attributes.integrationAccountId
+      : slackSourceAccountId({
           trigger: investigation.trigger,
           triggerConfig: investigation.triggerConfig,
         })
-      : null;
+    : null;
   const outputConfig =
     investigation.reportConfig.mode === "thread"
       ? null
@@ -863,6 +881,7 @@ export async function getSlackInvestigationDeliveryContext(
 
   return {
     agentId: investigation.agentId,
+    executionMode: investigation.executionMode,
     investigationId: investigation.id,
     prMode: investigation.prMode,
     report: investigation.report,

--- a/packages/core/src/db/schema.ts
+++ b/packages/core/src/db/schema.ts
@@ -72,6 +72,8 @@ export const issueRelationship = pgEnum("issue_relationship", [
 ]);
 
 export type RuntimeProfileModelOptions = Record<string, unknown>;
+export type AgentPurpose = "standard" | "slack_thread";
+export type InvestigationExecutionMode = "standard" | "slack_thread";
 
 export const runtimeProfiles = pgTable(
   "runtime_profiles",
@@ -109,12 +111,21 @@ export const agents = pgTable(
       .references(() => organization.id, { onDelete: "cascade" }),
     name: text("name").notNull(),
     description: text("description").notNull().default(""),
+    purpose: text("purpose")
+      .$type<AgentPurpose>()
+      .notNull()
+      .default("standard"),
     activeVersionId: uuid("active_version_id"),
     enabled: boolean("enabled").notNull().default(true),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
-  (table) => [index("agents_organization_idx").on(table.organizationId)],
+  (table) => [
+    index("agents_organization_idx").on(table.organizationId),
+    uniqueIndex("agents_organization_slack_thread_idx")
+      .on(table.organizationId)
+      .where(sql`${table.purpose} = 'slack_thread'`),
+  ],
 );
 
 export type AgentTriggerConfig =
@@ -422,6 +433,43 @@ export interface InvestigationSlackThreadSnapshot {
   version: 1;
 }
 
+export const slackInvestigationSessions = pgTable(
+  "slack_investigation_sessions",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    organizationId: uuid("organization_id")
+      .notNull()
+      .references(() => organization.id, { onDelete: "cascade" }),
+    agentId: uuid("agent_id")
+      .notNull()
+      .references(() => agents.id, { onDelete: "cascade" }),
+    agentConfigVersionId: uuid("agent_config_version_id")
+      .notNull()
+      .references(() => agentConfigVersions.id, { onDelete: "restrict" }),
+    runtimeProfileId: uuid("runtime_profile_id")
+      .notNull()
+      .references(() => runtimeProfiles.id, { onDelete: "restrict" }),
+    teamId: text("team_id").notNull(),
+    channelId: text("channel_id").notNull(),
+    threadTimestamp: text("thread_timestamp").notNull(),
+    sandboxSessionState: jsonb("sandbox_session_state").$type<
+      Record<string, unknown>
+    >(),
+    previousResponseId: text("previous_response_id"),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    uniqueIndex("slack_investigation_sessions_thread_idx").on(
+      table.organizationId,
+      table.agentId,
+      table.teamId,
+      table.channelId,
+      table.threadTimestamp,
+    ),
+  ],
+);
+
 export const investigations = pgTable(
   "investigations",
   {
@@ -439,6 +487,12 @@ export const investigations = pgTable(
       () => runtimeProfiles.id,
       { onDelete: "restrict" },
     ),
+    executionMode: text("execution_mode")
+      .$type<InvestigationExecutionMode>()
+      .notNull()
+      .default("standard"),
+    slackInvestigationSessionId: uuid("slack_investigation_session_id")
+      .references(() => slackInvestigationSessions.id, { onDelete: "set null" }),
     status: investigationStatus("status").notNull().default("pending"),
     title: text("title").notNull(),
     input: jsonb("input").$type<InvestigationInput>().notNull(),

--- a/packages/core/src/integrations/slack-delivery.test.ts
+++ b/packages/core/src/integrations/slack-delivery.test.ts
@@ -14,13 +14,14 @@ describe("Slack issue delivery", () => {
     const investigationId = "16161616-1616-4616-8616-161616161616";
     const message = slackCompletedInvestigationCard({
       agentId: "13131313-1313-4313-8313-131313131313",
+      executionMode: "standard",
       investigationId,
       title: "Plant API error rate is elevated",
       traceItems: [],
     });
 
     expect(message.blocks).toEqual([
-      expect.objectContaining({ type: "plan", title: "Investigation trace" }),
+      expect.objectContaining({ type: "plan", title: "Trace" }),
     ]);
   });
 

--- a/packages/core/src/integrations/slack-delivery.ts
+++ b/packages/core/src/integrations/slack-delivery.ts
@@ -5,6 +5,7 @@ import { responderIssueUrl } from "../responder-urls.js";
 import {
   getIssueForSlackBackfill,
   getSlackInvestigationDeliveryContext,
+  getSlackInvestigationLiveContext,
   type SlackInvestigationDeliveryContext,
 } from "../db/issues.js";
 import {
@@ -17,6 +18,7 @@ import {
   postSlackMessage,
   removeSlackReaction,
   setSlackThreadStatus,
+  stopSlackResponseStream,
   updateSlackMessage,
 } from "./slack.js";
 import {
@@ -314,17 +316,127 @@ export async function redeliverInvestigationSlackIssue(
 export function slackCompletedInvestigationCard(
   context: Pick<
     SlackInvestigationDeliveryContext,
-    "agentId" | "investigationId" | "title" | "traceItems"
+    "agentId" | "executionMode" | "investigationId" | "title" | "traceItems"
   >,
 ) {
   return slackInvestigationCard({
     agentId: context.agentId,
     detail: "Completed the investigation plan.",
     investigationId: context.investigationId,
+    showInvestigationLink: context.executionMode !== "slack_thread",
     status: "complete",
     title: context.title,
     traceItems: context.traceItems ?? [],
   });
+}
+
+export async function deliverSlackThreadInvestigationResponse(input: {
+  deliveryRunId: string;
+  investigationId: string;
+  response: string;
+}): Promise<void> {
+  const context = await getSlackInvestigationLiveContext(input.investigationId);
+  if (!context) {
+    throw new Error("Slack thread context is unavailable");
+  }
+  const token = accessToken(context.source.encryptedCredentials);
+  const markdown = input.response.slice(0, 11_900);
+  const message = {
+    text: markdown,
+    blocks: [{ type: "markdown", text: markdown }],
+  };
+  const messageTimestamp = context.source.responseMessageTimestamp
+    ? context.source.responseMessageTimestamp
+    : await postSlackMessage({
+        accessToken: token,
+        blocks: message.blocks,
+        channelId: context.source.channelId,
+        clientMessageId: slackDeliveryClientMessageId(
+          input.deliveryRunId,
+          `thread-response:${input.investigationId}`,
+        ),
+        text: message.text,
+        threadTimestamp: context.source.threadTimestamp,
+      });
+  if (!messageTimestamp) {
+    throw new Error("Slack did not return a response message timestamp");
+  }
+  if (context.source.responseMessageTimestamp) {
+    await stopSlackResponseStream({
+      accessToken: token,
+      channelId: context.source.channelId,
+      markdownText: markdown,
+      timestamp: context.source.responseMessageTimestamp,
+    });
+  }
+  await recordInvestigationSlackReply(input.investigationId, {
+    attachments: [],
+    authorName: "Responder",
+    blocks: message.blocks,
+    key: "thread-response",
+    slackTimestamp: messageTimestamp,
+    text: message.text,
+  });
+
+  const card = slackInvestigationCard({
+    agentId: context.agentId,
+    detail: "Completed the investigation plan.",
+    investigationId: context.investigationId,
+    showInvestigationLink: false,
+    status: "complete",
+    title: context.title,
+    traceItems: context.traceItems,
+  });
+  const results = await Promise.allSettled([
+    context.source.messageTimestamp
+      ? updateSlackMessage({
+          accessToken: token,
+          blocks: card.blocks,
+          channelId: context.source.channelId,
+          text: card.text,
+          timestamp: context.source.messageTimestamp,
+        })
+      : Promise.resolve(),
+  ]);
+  if (context.source.messageTimestamp && results[0]?.status === "fulfilled") {
+    await recordInvestigationSlackReply(input.investigationId, {
+      attachments: [],
+      authorName: "Responder",
+      blocks: card.blocks,
+      key: "investigation-status",
+      slackTimestamp: context.source.messageTimestamp,
+      text: card.text,
+    });
+  }
+  const failures = results.flatMap((result) =>
+    result.status === "rejected" ? [result.reason] : [],
+  );
+  if (failures.length === 0 && context.source.reactionTimestamp) {
+    try {
+      await removeSlackReaction({
+        accessToken: token,
+        channelId: context.source.channelId,
+        name: "eyes",
+        timestamp: context.source.reactionTimestamp,
+      });
+      await setInvestigationSlackReaction(input.investigationId, "eyes", false);
+    } catch (error) {
+      failures.push(error);
+    }
+  }
+  try {
+    await setSlackThreadStatus({
+      accessToken: token,
+      channelId: context.source.channelId,
+      status: "",
+      threadTimestamp: context.source.threadTimestamp,
+    });
+  } catch (error) {
+    failures.push(error);
+  }
+  if (failures.length > 0) {
+    throw new AggregateError(failures, "Slack thread response cleanup failed");
+  }
 }
 
 export function slackDeliveryErrorMessage(error: unknown): string {
@@ -343,7 +455,9 @@ export function slackDeliveryErrorMessage(error: unknown): string {
 export async function reconcileCompletedInvestigationSlackCard(
   investigationId: string,
 ): Promise<boolean> {
-  const context = await getSlackInvestigationDeliveryContext(investigationId);
+  const context =
+    await getSlackInvestigationDeliveryContext(investigationId) ??
+    await getSlackInvestigationLiveContext(investigationId);
   if (!context?.source?.messageTimestamp) return false;
   const token = accessToken(context.source.encryptedCredentials);
   const card = slackCompletedInvestigationCard(context);
@@ -355,12 +469,14 @@ export async function reconcileCompletedInvestigationSlackCard(
       text: card.text,
       timestamp: context.source.messageTimestamp,
     }),
-    removeSlackReaction({
-      accessToken: token,
-      channelId: context.source.channelId,
-      name: "eyes",
-      timestamp: context.source.reactionTimestamp,
-    }),
+    context.source.reactionTimestamp
+      ? removeSlackReaction({
+          accessToken: token,
+          channelId: context.source.channelId,
+          name: "eyes",
+          timestamp: context.source.reactionTimestamp,
+        })
+      : Promise.resolve(),
     setSlackThreadStatus({
       accessToken: token,
       channelId: context.source.channelId,
@@ -385,7 +501,7 @@ export async function reconcileCompletedInvestigationSlackCard(
       failures.push(error);
     }
   }
-  if (results[1]?.status === "fulfilled") {
+  if (context.source.reactionTimestamp && results[1]?.status === "fulfilled") {
     try {
       await setInvestigationSlackReaction(investigationId, "eyes", false);
     } catch (error) {

--- a/packages/core/src/integrations/slack-live-card.test.ts
+++ b/packages/core/src/integrations/slack-live-card.test.ts
@@ -1,10 +1,16 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { decryptCredentials } from "../credentials/encryption.js";
-import { recordInvestigationSlackTrace } from "../db/investigations.js";
+import {
+  recordInvestigationSlackReply,
+  recordInvestigationSlackTrace,
+  setInvestigationSlackReaction,
+} from "../db/investigations.js";
 import { getSlackInvestigationLiveContext } from "../db/issues.js";
 import {
   SlackApiError,
+  removeSlackReaction,
   setSlackThreadStatus,
+  stopSlackResponseStream,
   updateSlackMessage,
 } from "./slack.js";
 import {
@@ -22,18 +28,22 @@ vi.mock("../credentials/encryption.js", () => ({
 vi.mock("../db/investigations.js", () => ({
   recordInvestigationSlackReply: vi.fn(),
   recordInvestigationSlackTrace: vi.fn(),
+  setInvestigationSlackReaction: vi.fn(),
 }));
 vi.mock("../db/issues.js", () => ({
   getSlackInvestigationLiveContext: vi.fn(),
 }));
 vi.mock("./slack.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("./slack.js")>()),
+  removeSlackReaction: vi.fn(),
   setSlackThreadStatus: vi.fn(),
+  stopSlackResponseStream: vi.fn(),
   updateSlackMessage: vi.fn(),
 }));
 
 const context = {
   agentId: "13131313-1313-4313-8313-131313131313",
+  executionMode: "standard" as const,
   investigationId: "16161616-1616-4616-8616-161616161616",
   title: "Plant API error rate is elevated",
   traceItems: [],
@@ -128,7 +138,7 @@ describe("Slack live investigation card", () => {
     expect(message.blocks).toEqual([
       expect.objectContaining({
         type: "plan",
-        title: "Investigation trace",
+        title: "Trace",
         tasks: [
           expect.objectContaining({
             status: "in_progress",
@@ -141,6 +151,26 @@ describe("Slack live investigation card", () => {
               },
             ],
           }),
+        ],
+      }),
+    ]);
+  });
+
+  it("omits the investigation link from tag mode cards", () => {
+    const message = slackInvestigationCard({
+      agentId: context.agentId,
+      detail: "Inspecting the relevant source code.",
+      investigationId: context.investigationId,
+      showInvestigationLink: false,
+      status: "in_progress",
+      title: context.title,
+    });
+
+    expect(message.blocks).toEqual([
+      expect.objectContaining({
+        type: "plan",
+        tasks: [
+          expect.not.objectContaining({ sources: expect.anything() }),
         ],
       }),
     ]);
@@ -178,7 +208,7 @@ describe("Slack live investigation card", () => {
     expect(message.blocks).toEqual([
       expect.objectContaining({
         type: "plan",
-        title: "Investigation trace",
+        title: "Trace",
       }),
     ]);
     expect(message.text).toBe(
@@ -990,6 +1020,49 @@ describe("Slack live investigation card", () => {
     );
     expect(setSlackThreadStatus).toHaveBeenCalledWith(
       expect.objectContaining({ status: "" }),
+    );
+  });
+
+  it("finalizes the tag-mode response stream and removes eyes on failure", async () => {
+    const threadContext = {
+      ...context,
+      executionMode: "slack_thread" as const,
+      source: {
+        ...context.source,
+        reactionTimestamp: "1785500000.000100",
+        responseMessageTimestamp: "1785500002.000300",
+      },
+    };
+    vi.mocked(getSlackInvestigationLiveContext).mockResolvedValue(threadContext);
+    vi.mocked(decryptCredentials).mockReturnValue({ accessToken: "xoxb-test" });
+    vi.mocked(stopSlackResponseStream).mockResolvedValue();
+    vi.mocked(updateSlackMessage).mockResolvedValue();
+    vi.mocked(removeSlackReaction).mockResolvedValue();
+    vi.mocked(setSlackThreadStatus).mockResolvedValue();
+
+    await expect(
+      failInvestigationSlackCard(threadContext.investigationId),
+    ).resolves.toBe(true);
+
+    expect(stopSlackResponseStream).toHaveBeenCalledWith(
+      expect.objectContaining({
+        timestamp: "1785500002.000300",
+      }),
+    );
+    expect(recordInvestigationSlackReply).toHaveBeenCalledWith(
+      threadContext.investigationId,
+      expect.objectContaining({
+        key: "thread-response",
+        slackTimestamp: "1785500002.000300",
+      }),
+    );
+    expect(removeSlackReaction).toHaveBeenCalledWith(
+      expect.objectContaining({ timestamp: "1785500000.000100" }),
+    );
+    expect(setInvestigationSlackReaction).toHaveBeenCalledWith(
+      threadContext.investigationId,
+      "eyes",
+      false,
     );
   });
 });

--- a/packages/core/src/integrations/slack-live-card.ts
+++ b/packages/core/src/integrations/slack-live-card.ts
@@ -5,11 +5,14 @@ import { responderIssueUrl } from "../responder-urls.js";
 import {
   recordInvestigationSlackReply,
   recordInvestigationSlackTrace,
+  setInvestigationSlackReaction,
 } from "../db/investigations.js";
 import { getSlackInvestigationLiveContext } from "../db/issues.js";
 import {
   SlackApiError,
+  removeSlackReaction,
   setSlackThreadStatus,
+  stopSlackResponseStream,
   updateSlackMessage,
 } from "./slack.js";
 import type { SlackInvestigationTraceItem } from "./slack-live-progress.js";
@@ -778,6 +781,7 @@ export function slackInvestigationCard(input: {
   agentId: string;
   detail: string;
   investigationId: string;
+  showInvestigationLink?: boolean;
   status: SlackInvestigationCardStatus;
   title: string;
   traceItems?: SlackInvestigationTraceItem[];
@@ -789,11 +793,6 @@ export function slackInvestigationCard(input: {
       .replace(/:rotating_light:/giu, "🚨"),
     180,
   );
-  const source = {
-    type: "url",
-    text: "View investigation",
-    url: investigationUrl(input.agentId, input.investigationId),
-  };
   const summaryTask = {
     task_id: `${input.investigationId}:current`.slice(0, 255),
     title:
@@ -804,7 +803,17 @@ export function slackInvestigationCard(input: {
           : nonEmptyText(input.detail, 180, "Investigation in progress"),
     status: input.status,
     ...(input.status === "error" ? { output: richText(input.detail) } : {}),
-    sources: [source],
+    ...(input.showInvestigationLink === false
+      ? {}
+      : {
+          sources: [
+            {
+              type: "url",
+              text: "View investigation",
+              url: investigationUrl(input.agentId, input.investigationId),
+            },
+          ],
+        }),
   };
   return {
     text:
@@ -815,7 +824,7 @@ export function slackInvestigationCard(input: {
       {
         type: "plan",
         block_id: `investigation_plan_${input.status}_${randomUUID()}`,
-        title: "Investigation trace",
+        title: "Trace",
         tasks: [
           ...(input.traceItems ?? [])
             .slice(-11)
@@ -951,6 +960,7 @@ async function performInvestigationSlackProgressUpdate(
       agentId: context.agentId,
       detail,
       investigationId: context.investigationId,
+      showInvestigationLink: context.executionMode !== "slack_thread",
       status: "in_progress",
       title: context.title,
       traceItems,
@@ -1025,10 +1035,36 @@ async function performInvestigationSlackCardFailure(
   if (!context) return false;
   const token = accessToken(context.source.encryptedCredentials);
   const failures: unknown[] = [];
+  const failureMessage =
+    "I couldn't complete this investigation. Please try again or add more context.";
 
   if (traceItems) {
     try {
       await recordInvestigationSlackTrace(investigationId, traceItems);
+    } catch (error) {
+      failures.push(error);
+    }
+  }
+
+  if (
+    context.executionMode === "slack_thread" &&
+    context.source.responseMessageTimestamp
+  ) {
+    try {
+      await stopSlackResponseStream({
+        accessToken: token,
+        channelId: context.source.channelId,
+        markdownText: failureMessage,
+        timestamp: context.source.responseMessageTimestamp,
+      });
+      await recordInvestigationSlackReply(investigationId, {
+        attachments: [],
+        authorName: "Responder",
+        blocks: [{ type: "markdown", text: failureMessage }],
+        key: "thread-response",
+        slackTimestamp: context.source.responseMessageTimestamp,
+        text: failureMessage,
+      });
     } catch (error) {
       failures.push(error);
     }
@@ -1039,6 +1075,7 @@ async function performInvestigationSlackCardFailure(
       agentId: context.agentId,
       detail: "The investigation stopped before it could finish.",
       investigationId: context.investigationId,
+      showInvestigationLink: context.executionMode !== "slack_thread",
       status: "error",
       title: context.title,
       traceItems: traceItems ?? context.traceItems,
@@ -1073,6 +1110,19 @@ async function performInvestigationSlackCardFailure(
     });
   } catch (error) {
     failures.push(error);
+  }
+  if (context.source.reactionTimestamp) {
+    try {
+      await removeSlackReaction({
+        accessToken: token,
+        channelId: context.source.channelId,
+        name: "eyes",
+        timestamp: context.source.reactionTimestamp,
+      });
+      await setInvestigationSlackReaction(investigationId, "eyes", false);
+    } catch (error) {
+      failures.push(error);
+    }
   }
   if (failures.length > 0) {
     throw new AggregateError(

--- a/packages/core/src/integrations/slack.test.ts
+++ b/packages/core/src/integrations/slack.test.ts
@@ -5,6 +5,7 @@ import {
   postSlackMessage,
   removeSlackReaction,
   setSlackThreadStatus,
+  stopSlackResponseStream,
   updateSlackMessage,
 } from "./slack.js";
 
@@ -60,6 +61,29 @@ describe("Slack delivery client", () => {
           client_msg_id: "16161616-1616-4616-8616-161616161616",
           text: "I’m investigating this alert.",
           thread_ts: "1785500000.000100",
+        }),
+      }),
+    );
+  });
+
+  it("completes a native Slack response stream", async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(Response.json({ ok: true }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await stopSlackResponseStream({
+      accessToken: "xoxb-test",
+      channelId: "C123",
+      markdownText: "The investigation is complete.",
+      timestamp: "1785500002.000300",
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://slack.com/api/chat.stopStream",
+      expect.objectContaining({
+        body: JSON.stringify({
+          channel: "C123",
+          markdown_text: "The investigation is complete.",
+          ts: "1785500002.000300",
         }),
       }),
     );

--- a/packages/core/src/integrations/slack.ts
+++ b/packages/core/src/integrations/slack.ts
@@ -222,6 +222,19 @@ export async function postSlackMessage(input: {
   }
 }
 
+export async function stopSlackResponseStream(input: {
+  accessToken: string;
+  channelId: string;
+  markdownText: string;
+  timestamp: string;
+}): Promise<void> {
+  await callSlackApi(input.accessToken, "chat.stopStream", {
+    channel: input.channelId,
+    markdown_text: input.markdownText,
+    ts: input.timestamp,
+  });
+}
+
 export async function updateSlackMessage(input: {
   accessToken: string;
   blocks: unknown[];

--- a/packages/core/src/jobs.ts
+++ b/packages/core/src/jobs.ts
@@ -12,6 +12,8 @@ import {
 
 export const workerHealthQueue = "responder-worker-health";
 export const investigationQueue = "responder-investigations";
+export const slackThreadInvestigationQueue =
+  "responder-slack-thread-investigations-v1";
 // Version queue names when introducing a policy: createQueue intentionally
 // leaves an existing queue's policy unchanged.
 export const linearTicketQueue = "responder-linear-tickets-v2";
@@ -58,6 +60,17 @@ export const investigationJobSchema = z.object({
 });
 
 export type InvestigationJob = z.infer<typeof investigationJobSchema>;
+
+export const slackThreadInvestigationJobSchema = investigationJobSchema
+  .omit({ kind: true, replay: true })
+  .extend({
+    refreshWorkspace: z.boolean().default(false),
+    kind: z.literal("slack_thread_investigation"),
+    slackInvestigationSessionId: z.uuid(),
+  });
+export type SlackThreadInvestigationJob = z.infer<
+  typeof slackThreadInvestigationJobSchema
+>;
 
 export const remediationJobSchema = z.object({
   kind: z.literal("remediation"),
@@ -180,6 +193,16 @@ export async function prepareWorkerQueues(boss: PgBoss): Promise<void> {
       expireInSeconds: 3_600,
       heartbeatSeconds: investigationHeartbeatSeconds,
       notify: true,
+      retryBackoff: true,
+      retryDelay: 30,
+      retryLimit: 2,
+    }),
+    boss.createQueue(slackThreadInvestigationQueue, {
+      deleteAfterSeconds: 604_800,
+      expireInSeconds: 3_600,
+      heartbeatSeconds: investigationHeartbeatSeconds,
+      notify: true,
+      policy: "key_strict_fifo",
       retryBackoff: true,
       retryDelay: 30,
       retryLimit: 2,


### PR DESCRIPTION
## Summary
- add configurable Slack tag mode with reusable thread sessions and sandbox context
- post trace/progress/final responses with stable Slack lifecycle and duplicate-event protection
- persist tag conversations and refresh configured repositories for continued sessions

## Validation
- pnpm typecheck
- pnpm lint
- pnpm test (116 files, 868 tests)
- pnpm build

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds configurable Slack tag mode, letting agents investigate requests directly in Slack threads with a reusable sandbox session. Tag-mode runs never create issues or pull requests, reply in the thread, and keep the sandbox alive across turns for continued conversation.

**New Features**
- New Settings → Tag mode page configures the agent model, instructions, and linked repository/context.
- Tag-mode turns refresh configured repositories when settings change and reuse the same sandbox until the thread session ends.

**Migration**
- Requires drizzle migration `0032` for the new `slack_investigation_sessions` table and the `agents.purpose` / `investigations.execution_mode` columns.

<sup>Written for commit 063def326ef83937e198ad826da7f5b233ac8995. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/responder-oss/pull/86?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

