### PR TITLE
Edit agents through a tabbed settings layout

### DIFF
--- a/apps/control-plane/src/pages/agent-create.tsx
+++ b/apps/control-plane/src/pages/agent-create.tsx
@@ -454,10 +454,13 @@ export function AgentCreatePage() {
   );
   const [furthestStep, setFurthestStep] =
     useState<CreateStep>(
-      contextIntegrationJustConnected
-        ? 3
-        : () => readSavedStep(stepStorageKey),
+      isEditing
+        ? 4
+        : contextIntegrationJustConnected
+          ? 3
+          : () => readSavedStep(stepStorageKey),
   );
+  const [saveNotice, setSaveNotice] = useState<string | null>(null);
   const [githubDialogOpen, setGithubDialogOpen] = useState(githubJustConnected);
   const [slackContextDialogOpen, setSlackContextDialogOpen] = useState(false);
   const [vercelDialogOpen, setVercelDialogOpen] = useState(vercelJustConnected);
@@ -863,6 +866,7 @@ export function AgentCreatePage() {
   function updateDraft(update: Partial<CreateDraft>) {
     setDraft((current) => (current ? { ...current, ...update } : current));
     setError(null);
+    setSaveNotice(null);
   }
 
   function refreshSlackChannels(): Promise<void> {
@@ -1101,6 +1105,7 @@ export function AgentCreatePage() {
     if (step === 4) setPromptStepReady(false);
     setActiveStep(step);
     setError(null);
+    setSaveNotice(null);
     window.scrollTo({ top: 0, behavior: "smooth" });
   }
 
@@ -1129,6 +1134,10 @@ export function AgentCreatePage() {
 
   async function submit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
+    if (isEditing) {
+      await persistAgent();
+      return;
+    }
     const submitter = (event.nativeEvent as SubmitEvent).submitter;
     if (
       activeStep !== 4 ||
@@ -1139,6 +1148,10 @@ export function AgentCreatePage() {
       if (activeStep < 4) continueToNextStep();
       return;
     }
+    await persistAgent();
+  }
+
+  async function persistAgent() {
     if (missingRequirement) {
       setError(missingRequirement);
       const blockedStep: CreateStep = inputRequirement
@@ -1210,11 +1223,17 @@ export function AgentCreatePage() {
 
     setSaving(true);
     setError(null);
+    setSaveNotice(null);
     try {
       const savedAgentId = await saveAgent(agentId, configuration);
       window.sessionStorage.removeItem(draftStorageKey);
       window.sessionStorage.removeItem(stepStorageKey);
-      navigate(`/agents/${savedAgentId}`);
+      if (isEditing) {
+        setExistingConfiguration(configuration);
+        setSaveNotice("Changes saved.");
+      } else {
+        navigate(`/agents/${savedAgentId}`);
+      }
     } catch (caught) {
       setError(
         caught instanceof Error
@@ -1330,7 +1349,7 @@ export function AgentCreatePage() {
           <h1>{isEditing ? `Edit ${existingConfiguration?.name ?? "agent"}` : "Create agent"}</h1>
           <p>
             {isEditing
-              ? "Update what starts the agent, where its results go, and what context it can use."
+              ? "Pick a section on the left to update its settings, then save your changes."
               : "Choose what starts the agent, where its results go, and what context it can use."}
           </p>
         </div>
@@ -1348,38 +1367,77 @@ export function AgentCreatePage() {
         <Alert className="createNotice" role="alert" title={error} tone="danger" />
       ) : null}
 
-      <form className="createAgentForm createStepper" onSubmit={submit}>
-        <nav aria-label="Agent setup progress" className="createStepperRail">
-          {CREATE_STEPS.map((step) => {
-            const current = activeStep === step.id;
-            const complete =
-              step.id < furthestStep && !stepRequirements[step.id];
-            return (
-              <button
-                aria-current={current ? "step" : undefined}
-                className={[
-                  "createStepperStep",
-                  current ? "isCurrent" : "",
-                  complete ? "isComplete" : "",
-                ]
-                  .filter(Boolean)
-                  .join(" ")}
-                disabled={step.id > furthestStep}
-                key={step.id}
-                onClick={() => showStep(step.id)}
-                type="button"
-              >
-                <span className="createStepperStep__marker">
-                  {complete ? "✓" : step.id}
-                </span>
-                <span className="createStepperStep__copy">
-                  <strong>{step.title}</strong>
-                  <small>{step.description}</small>
-                </span>
-              </button>
-            );
-          })}
-        </nav>
+      <form
+        className={`createAgentForm ${isEditing ? "agentEditLayout" : "createStepper"}`}
+        onSubmit={submit}
+      >
+        {isEditing ? (
+          <nav aria-label="Agent settings" className="agentEditNav">
+            {CREATE_STEPS.map((step) => {
+              const current = activeStep === step.id;
+              const invalid = Boolean(stepRequirements[step.id]);
+              return (
+                <button
+                  aria-current={current ? "page" : undefined}
+                  className={[
+                    "agentEditNavItem",
+                    current ? "isCurrent" : "",
+                    invalid ? "isInvalid" : "",
+                  ]
+                    .filter(Boolean)
+                    .join(" ")}
+                  key={step.id}
+                  onClick={() => showStep(step.id)}
+                  type="button"
+                >
+                  <span className="agentEditNavItem__copy">
+                    <strong>{step.title}</strong>
+                    <small>{step.description}</small>
+                  </span>
+                  {invalid ? (
+                    <span
+                      aria-label="Needs attention"
+                      className="agentEditNavItem__dot"
+                      role="img"
+                    />
+                  ) : null}
+                </button>
+              );
+            })}
+          </nav>
+        ) : (
+          <nav aria-label="Agent setup progress" className="createStepperRail">
+            {CREATE_STEPS.map((step) => {
+              const current = activeStep === step.id;
+              const complete =
+                step.id < furthestStep && !stepRequirements[step.id];
+              return (
+                <button
+                  aria-current={current ? "step" : undefined}
+                  className={[
+                    "createStepperStep",
+                    current ? "isCurrent" : "",
+                    complete ? "isComplete" : "",
+                  ]
+                    .filter(Boolean)
+                    .join(" ")}
+                  disabled={step.id > furthestStep}
+                  key={step.id}
+                  onClick={() => showStep(step.id)}
+                  type="button"
+                >
+                  <span className="createStepperStep__marker">
+                    {complete ? "✓" : step.id}
+                  </span>
+                  <span className="createStepperStep__copy">
+                    <strong>{step.title}</strong>
+                    <small>{step.description}</small>
+                  </span>
+                </button>
+              );
+            })}
+          </nav>
+        )}
 
         <div className="createStepperPanel">
           {activeStep === 1 ? (
@@ -2831,53 +2889,84 @@ export function AgentCreatePage() {
           ) : null}
 
           <footer className="createAgentActions">
-            {currentRequirement || activeStep >= 3 ? (
-              <span
-                aria-live="polite"
-                className={
-                  currentRequirement
-                    ? "createRequirement"
-                    : "createRequirement isReady"
-                }
-              >
-                {currentRequirement ??
-                  (activeStep === 3
-                    ? "Context is optional. Add only what the agent needs."
-                    : "All required setup is complete.")}
-              </span>
-            ) : null}
-            {activeStep === 1 ? (
-              <Link
-                className="dsButton dsButton--secondary dsButton--medium"
-                to={agentId ? `/agents/${agentId}` : "/agents"}
-              >
-                Cancel
-              </Link>
+            {isEditing ? (
+              <>
+                {saveNotice ? (
+                  <span aria-live="polite" className="createRequirement isReady">
+                    {saveNotice}
+                  </span>
+                ) : currentRequirement ? (
+                  <span aria-live="polite" className="createRequirement">
+                    {currentRequirement}
+                  </span>
+                ) : null}
+                <Link
+                  className="dsButton dsButton--secondary dsButton--medium"
+                  to={`/agents/${agentId}`}
+                >
+                  Done
+                </Link>
+                <Button
+                  data-submit-agent="true"
+                  disabled={Boolean(currentRequirement) || saving}
+                  loading={saving}
+                  type="submit"
+                  variant="primary"
+                >
+                  Save changes
+                </Button>
+              </>
             ) : (
-              <Button onClick={returnToPreviousStep} variant="secondary">
-                Back
-              </Button>
-            )}
-            {activeStep < 4 ? (
-              <Button
-                disabled={Boolean(currentRequirement)}
-                onClick={continueToNextStep}
-                variant="primary"
-              >
-                Continue
-              </Button>
-            ) : (
-              <Button
-                data-submit-agent="true"
-                disabled={
-                  Boolean(missingRequirement) || !promptStepReady || saving
-                }
-                loading={saving}
-                type="submit"
-                variant="primary"
-              >
-                {isEditing ? "Save changes" : "Create agent"}
-              </Button>
+              <>
+                {currentRequirement || activeStep >= 3 ? (
+                  <span
+                    aria-live="polite"
+                    className={
+                      currentRequirement
+                        ? "createRequirement"
+                        : "createRequirement isReady"
+                    }
+                  >
+                    {currentRequirement ??
+                      (activeStep === 3
+                        ? "Context is optional. Add only what the agent needs."
+                        : "All required setup is complete.")}
+                  </span>
+                ) : null}
+                {activeStep === 1 ? (
+                  <Link
+                    className="dsButton dsButton--secondary dsButton--medium"
+                    to={agentId ? `/agents/${agentId}` : "/agents"}
+                  >
+                    Cancel
+                  </Link>
+                ) : (
+                  <Button onClick={returnToPreviousStep} variant="secondary">
+                    Back
+                  </Button>
+                )}
+                {activeStep < 4 ? (
+                  <Button
+                    disabled={Boolean(currentRequirement)}
+                    onClick={continueToNextStep}
+                    variant="primary"
+                  >
+                    Continue
+                  </Button>
+                ) : (
+                  <Button
+                    data-submit-agent="true"
+                    disabled={
+                      Boolean(missingRequirement) || !promptStepReady || saving
+                    }
+                    loading={saving}
+                    type="submit"
+                    variant="primary"
+                  >
+                    Create agent
+                  </Button>
+                )}
+              </>
             )}
           </footer>
         </div>

--- a/apps/control-plane/src/pages/agents.tsx
+++ b/apps/control-plane/src/pages/agents.tsx
@@ -13,7 +13,7 @@ import {
   integrationsForAgent,
 } from "../agent-list-presentation";
 import { AppShell } from "../components/app-shell";
-import { ArrowIcon, PlusIcon } from "../components/icons";
+import { ArrowIcon, CogIcon, PlusIcon } from "../components/icons";
 import { AgentListSkeleton } from "../components/screen-skeletons";
 import { Badge, DataTable } from "../design-system";
 import { useDocumentTitle } from "../use-document-title";
@@ -164,15 +164,24 @@ export function AgentsPage() {
                 header: "",
                 key: "open",
                 render: (agent) => (
-                  <Link
-                    aria-label={`Open ${agent.name}`}
-                    className="agentTableArrow"
-                    to={`/agents/${agent.id}`}
-                  >
-                    <ArrowIcon />
-                  </Link>
+                  <span className="agentTableActions">
+                    <Link
+                      aria-label={`Edit ${agent.name} settings`}
+                      className="agentTableSettings"
+                      to={`/agents/${agent.id}/edit`}
+                    >
+                      <CogIcon />
+                    </Link>
+                    <Link
+                      aria-label={`Open ${agent.name}`}
+                      className="agentTableArrow"
+                      to={`/agents/${agent.id}`}
+                    >
+                      <ArrowIcon />
+                    </Link>
+                  </span>
                 ),
-                width: "5%",
+                width: "8%",
               },
             ]}
             filters={[

--- a/apps/control-plane/src/styles.css
+++ b/apps/control-plane/src/styles.css
@@ -1551,7 +1551,21 @@ button:disabled {
   color: var(--ds-text-muted);
 }
 
+.agentTableActions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 6px;
+}
+
+.agentTableSettings {
+  display: flex;
+  align-items: center;
+  color: var(--ds-text-muted);
+}
+
 .agentTableTitle:focus-visible,
+.agentTableSettings:focus-visible,
 .agentTableArrow:focus-visible {
   border-radius: 4px;
   outline: 2px solid var(--ds-text-primary);
@@ -1559,6 +1573,7 @@ button:disabled {
 }
 
 .agentTableTitle:hover strong,
+.agentTableSettings:hover,
 .agentTableArrow:hover {
   color: var(--ds-text-primary);
 }
@@ -4711,6 +4726,84 @@ button:disabled {
   grid-template-columns: 230px minmax(0, 1fr);
   align-items: start;
   gap: 56px;
+}
+
+.agentEditLayout {
+  display: grid;
+  grid-template-columns: 230px minmax(0, 1fr);
+  align-items: start;
+  gap: 56px;
+}
+
+.agentEditNav {
+  position: sticky;
+  top: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.agentEditNavItem {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 12px 10px 14px;
+  border: 0;
+  border-left: 2px solid transparent;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--ds-text-secondary);
+  text-align: left;
+  cursor: pointer;
+  transition:
+    background-color 140ms ease,
+    border-color 140ms ease,
+    color 140ms ease;
+}
+
+.agentEditNavItem:hover {
+  background: var(--ds-surface-hover);
+  color: var(--ds-text-primary);
+}
+
+.agentEditNavItem:focus-visible {
+  outline: 2px solid var(--ds-text-primary);
+  outline-offset: 2px;
+}
+
+.agentEditNavItem.isCurrent {
+  border-left-color: var(--ds-text-primary);
+  background: var(--ds-surface-raised);
+  color: var(--ds-text-primary);
+}
+
+.agentEditNavItem__copy {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.agentEditNavItem__copy strong {
+  color: inherit;
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 18px;
+}
+
+.agentEditNavItem__copy small {
+  color: var(--ds-text-muted);
+  font-size: 11px;
+  line-height: 15px;
+}
+
+.agentEditNavItem__dot {
+  flex: none;
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  background: var(--ds-danger);
 }
 
 .createStepperRail {


### PR DESCRIPTION
## Motivation

Editing an existing agent reused the four-step **create** stepper. Users editing an agent almost always want to change one specific setting, but the stepper forced them to click **Continue** through earlier sections to reach it.

## What changes

Editing now presents the four configuration sections as a **settings-style layout** instead of a stepper:

- **Left category rail** — `Input · Output · Agent context · Prompt`, each directly selectable. No step gating; jump straight to the section you need.
- **Per-section "Save changes"** — persists the agent in place (`PUT /api/agents/:id`) and shows a "Changes saved." confirmation, instead of navigating away. Sections with validation problems are flagged in the rail, and saving from a valid section jumps to any blocking section.
- **Done** returns to the agent detail page.
- **Creating a new agent keeps the sequential stepper unchanged.**

Also adds a settings shortcut (gear) to each row of the agents list linking straight to the edit page.

## Implementation notes

- Single component (`agent-create.tsx`) still serves both create and edit, keyed on the `agentId` route param. The shared `CreateDraft` state, validation helpers, and `saveAgent()` are reused unchanged — only the navigation chrome differs between modes (`isEditing`).
- No API or schema changes.

## Files
- `apps/control-plane/src/pages/agent-create.tsx` — conditional settings rail + footer for edit mode; `submit` split into a reusable `persistAgent()`.
- `apps/control-plane/src/pages/agents.tsx` — per-row settings shortcut.
- `apps/control-plane/src/styles.css` — `.agentEditLayout` / `.agentEditNav*` and list action styles.

## Checks
`pnpm typecheck` · `pnpm lint` · `pnpm test` (717 passed) · `vite build` — all green. Rendered and clicked through all four sections with no runtime errors.