### PR TITLE
Namespace MCP tools and backfill collision failures

### DIFF
--- a/apps/worker/src/backfill-mcp-tool-collision.ts
+++ b/apps/worker/src/backfill-mcp-tool-collision.ts
@@ -1,0 +1,89 @@
+import { closeDatabase } from "@responder/core/db/client";
+import {
+  prepareInvestigationRetry,
+  InvestigationRetryError,
+} from "@responder/core/db/investigations";
+import {
+  createJobBoss,
+  investigationQueue,
+  prepareWorkerQueues,
+} from "@responder/core/jobs";
+import { loadResponderSecrets } from "@responder/core/secrets";
+import { z } from "zod";
+
+const investigationIdSchema = z.uuid();
+const expectedFailureReason =
+  "Duplicate tool names found across MCP servers";
+const investigationIds = process.argv.slice(2).map((value) =>
+  investigationIdSchema.parse(value),
+);
+
+if (investigationIds.length === 0) {
+  throw new Error(
+    "Usage: backfill-mcp-tool-collision <failed-investigation-id> [...]",
+  );
+}
+
+loadResponderSecrets();
+const boss = createJobBoss();
+
+try {
+  await boss.start();
+  await prepareWorkerQueues(boss);
+
+  for (const investigationId of investigationIds) {
+    try {
+      const retry = await prepareInvestigationRetry(investigationId, {
+        expectedFailureReason,
+      });
+      const jobId = await boss.send(
+        investigationQueue,
+        {
+          kind: "investigation",
+          config: retry.config,
+          investigationId: retry.investigationId,
+          queuedAt: new Date().toISOString(),
+          request: {
+            agentId: retry.config.agentId,
+            body: retry.input.body,
+            externalEventId: retry.input.externalEventId,
+            provider: retry.input.provider,
+            title: retry.input.title,
+            ...(retry.input.sourceUrl
+              ? { sourceUrl: retry.input.sourceUrl }
+              : {}),
+            ...(retry.input.attributes
+              ? { attributes: retry.input.attributes }
+              : {}),
+          },
+          runtimeProfileId: retry.runtimeProfileId,
+        },
+        { singletonKey: `mcp-tool-collision-backfill:${investigationId}` },
+      );
+      if (!jobId) throw new Error("The backfill job was not created");
+      console.log(
+        JSON.stringify({
+          event: "mcp_tool_collision_backfill_queued",
+          investigationId,
+          jobId,
+        }),
+      );
+    } catch (error) {
+      if (error instanceof InvestigationRetryError) {
+        console.error(
+          JSON.stringify({
+            code: error.code,
+            error: error.message,
+            event: "mcp_tool_collision_backfill_skipped",
+            investigationId,
+          }),
+        );
+        continue;
+      }
+      throw error;
+    }
+  }
+} finally {
+  await boss.stop({ graceful: true, timeout: 10_000 });
+  await closeDatabase();
+}

--- a/apps/worker/src/investigate.ts
+++ b/apps/worker/src/investigate.ts
@@ -693,6 +693,11 @@ export async function runInvestigationAgent(
       model: config.model,
       instructions,
       capabilities: investigationCapabilities(replay),
+      // MCP servers are tenant-configurable and may expose the same generic
+      // tool names (for example, `search` or `execute`). Prefix each tool
+      // with its server name so one connection cannot prevent an entire
+      // investigation from starting.
+      mcpConfig: { includeServerInToolNames: true },
       mcpServers: contextServers,
       tools: [
         ...(threadMode ? [] : [issueSearchTool, reportTool!]),

--- a/packages/core/src/db/investigations.ts
+++ b/packages/core/src/db/investigations.ts
@@ -440,6 +440,7 @@ export async function listInvestigationTraceEvents(
 
 export async function prepareInvestigationRetry(
   investigationId: string,
+  options?: { expectedFailureReason?: string },
 ): Promise<{
   investigationId: string;
   input: InvestigationInput;
@@ -461,6 +462,7 @@ export async function prepareInvestigationRetry(
         prompt: agentConfigVersions.prompt,
         createLinearTickets: agentConfigVersions.createLinearTickets,
         linearIssueTemplate: agentConfigVersions.linearIssueTemplate,
+        failureReason: investigations.failureReason,
       })
       .from(investigations)
       .innerJoin(
@@ -479,6 +481,16 @@ export async function prepareInvestigationRetry(
       throw new InvestigationRetryError(
         "not_found",
         "Investigation not found",
+      );
+    }
+    if (
+      options?.expectedFailureReason &&
+      (investigation.status !== "failed" ||
+        !investigation.failureReason?.includes(options.expectedFailureReason))
+    ) {
+      throw new InvestigationRetryError(
+        "not_retryable",
+        "Investigation does not match the expected backfill failure",
       );
     }
     if (!investigationCanBeRetried(investigation.status)) {


### PR DESCRIPTION
## Summary
- qualify MCP tool names by server so multiple tenant-configured MCPs can coexist
- add a guarded, idempotent backfill command for investigations failed by duplicate MCP tool names

## Validation
- pnpm typecheck
- pnpm lint
- pnpm test
- pnpm --dir open-core typecheck
- pnpm --dir open-core lint
- pnpm --dir open-core test -- packages/core/src/db/investigations.test.ts apps/worker/src/investigate.test.ts


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Namespaces MCP tool names by server so investigations no longer fail when multiple tenant-configured MCP servers expose the same tool names. Adds a guarded, idempotent backfill command to retry investigations that previously failed from duplicate tool names.

- MCP tool names are now prefixed with their server name via `mcpConfig.includeServerInToolNames`.
- Adds `apps/worker/src/backfill-mcp-tool-collision.ts`, a one-off command that queues retries for investigations whose failure matches the duplicate tool name reason.
- `prepareInvestigationRetry` accepts an optional expected failure reason and skips retries for investigations that don't match it.

<sup>Written for commit 30e70c263f5e27cdc7dd4408a51f69926c795cb1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/responder-oss/pull/88?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

