### PR TITLE
Use active agent config for investigation replays

### DIFF
--- a/packages/core/src/db/investigations.test.ts
+++ b/packages/core/src/db/investigations.test.ts
@@ -16,6 +16,7 @@ import {
   getInvestigationForSlackAction,
   investigationCanBeRetried,
   markInvestigationStarted,
+  prepareInvestigationReplay,
   prepareInvestigationRetry,
   replayReportMarkdownUpdate,
 } from "./investigations.js";
@@ -144,6 +145,98 @@ describe("investigation retry", () => {
     expect(set).toHaveBeenCalledWith(expect.objectContaining({
       agentConfigVersionId: "active-config",
       runtimeProfileId: "active-runtime",
+    }));
+  });
+});
+
+describe("investigation replay", () => {
+  it("uses the agent's active configuration for a new replay", async () => {
+    const sourceInput = {
+      agentId: "agent-1",
+      body: "Original alert",
+      externalEventId: "event-1",
+      provider: "sentry" as const,
+      title: "Production error",
+    };
+    const sourceQuery = {
+      from: vi.fn(),
+      innerJoin: vi.fn(),
+      where: vi.fn(),
+      limit: vi.fn().mockResolvedValue([{
+        agentId: "agent-1",
+        configId: "latest-config",
+        createLinearTickets: true,
+        input: sourceInput,
+        linearIssueTemplate: "Latest template",
+        model: "latest-model",
+        organizationId: "organization-1",
+        prMode: "always",
+        prompt: "Latest instructions",
+        status: "resolved",
+        title: "Production error",
+      }]),
+    };
+    sourceQuery.from.mockReturnValue(sourceQuery);
+    sourceQuery.innerJoin.mockReturnValue(sourceQuery);
+    sourceQuery.where.mockReturnValue(sourceQuery);
+    const profileQuery = {
+      from: vi.fn(),
+      innerJoin: vi.fn(),
+      where: vi.fn(),
+      limit: vi.fn().mockResolvedValue([{ id: "active-runtime" }]),
+    };
+    profileQuery.from.mockReturnValue(profileQuery);
+    profileQuery.innerJoin.mockReturnValue(profileQuery);
+    profileQuery.where.mockReturnValue(profileQuery);
+    const existingQuery = {
+      from: vi.fn(),
+      where: vi.fn(),
+      limit: vi.fn().mockResolvedValue([]),
+    };
+    existingQuery.from.mockReturnValue(existingQuery);
+    existingQuery.where.mockReturnValue(existingQuery);
+    const select = vi
+      .fn()
+      .mockReturnValueOnce(sourceQuery)
+      .mockReturnValueOnce(profileQuery)
+      .mockReturnValueOnce(existingQuery);
+    const values = vi.fn().mockResolvedValue(undefined);
+    const tx = {
+      insert: vi.fn(() => ({ values })),
+      select,
+    };
+    const transaction = vi.fn(async (callback) => callback(tx));
+    vi.mocked(getDatabase).mockReturnValue({ transaction } as never);
+
+    await expect(
+      prepareInvestigationReplay({
+        agentId: "agent-1",
+        investigationId: "investigation-1",
+        organizationId: "organization-1",
+        replayInvestigationId: "replay-1",
+      }),
+    ).resolves.toEqual({
+      config: {
+        agentId: "agent-1",
+        createLinearTickets: true,
+        id: "latest-config",
+        linearIssueTemplate: "Latest template",
+        model: "latest-model",
+        organizationId: "organization-1",
+        prMode: "always",
+        prompt: "Latest instructions",
+      },
+      created: true,
+      input: sourceInput,
+      investigationId: "replay-1",
+      replayStatus: "pending",
+      runtimeProfileId: "active-runtime",
+    });
+    expect(values).toHaveBeenCalledWith(expect.objectContaining({
+      agentConfigVersionId: "latest-config",
+      id: "replay-1",
+      isReplay: true,
+      replayOfInvestigationId: "investigation-1",
     }));
   });
 });

--- a/packages/core/src/db/investigations.ts
+++ b/packages/core/src/db/investigations.ts
@@ -600,10 +600,13 @@ export async function prepareInvestigationReplay(input: {
       })
       .from(investigations)
       .innerJoin(
-        agentConfigVersions,
-        eq(agentConfigVersions.id, investigations.agentConfigVersionId),
+        agents,
+        eq(agents.id, investigations.agentId),
       )
-      .innerJoin(agents, eq(agents.id, investigations.agentId))
+      .innerJoin(
+        agentConfigVersions,
+        eq(agentConfigVersions.id, agents.activeVersionId),
+      )
       .where(
         and(
           eq(investigations.id, input.investigationId),


### PR DESCRIPTION
## Summary\n- resolve new replays against the agent's active configuration\n- keep source alert input and add regression coverage\n\n## Validation\n- pnpm vitest run packages/core/src/db/investigations.test.ts\n- pnpm eslint packages/core/src/db/investigations.ts packages/core/src/db/investigations.test.ts\n- pnpm typecheck

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Changes investigation replays to resolve against the agent's active configuration instead of the configuration used on the original investigation. Previously, a replay copied the original investigation's config version; now it uses the agent's current active version, so replays reflect the latest settings. Adds regression coverage for the new behavior.

<sup>Written for commit b87db74600050c5b64f5273f7ebca8722b774cb2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/responder-oss/pull/90?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

