### PR TITLE
Fix Slack investigation workspace links

### DIFF
--- a/apps/control-plane/server/webhooks/slack.ts
+++ b/apps/control-plane/server/webhooks/slack.ts
@@ -507,6 +507,7 @@ export async function acknowledgeSlackAlert(input: {
   const message = investigatingSlackMessage({
     agentId: input.agentId,
     investigationId: input.investigationId,
+    organizationId: input.organizationId,
     threadMode: input.threadMode,
     title: input.title,
   });
@@ -667,6 +668,7 @@ export function logSlackAcknowledgementFailure(input: {
 export function investigatingSlackMessage(input: {
   agentId: string;
   investigationId: string;
+  organizationId?: string;
   threadMode?: boolean;
   title?: string;
 }): { blocks: unknown[]; text: string } {
@@ -674,6 +676,7 @@ export function investigatingSlackMessage(input: {
     agentId: input.agentId,
     detail: "Responder is gathering evidence and preparing the investigation.",
     investigationId: input.investigationId,
+    organizationId: input.organizationId,
     showInvestigationLink: input.threadMode !== true,
     status: "in_progress",
     title: input.title ?? "Investigating alert",

--- a/apps/control-plane/src/components/auth-gate.tsx
+++ b/apps/control-plane/src/components/auth-gate.tsx
@@ -465,13 +465,69 @@ function InvitationGate({
   );
 }
 
+function WorkspaceActivation({
+  organizationId,
+  refetch,
+}: {
+  organizationId: string;
+  refetch: () => Promise<unknown>;
+}) {
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    void authClient.organization
+      .setActive({ organizationId })
+      .then(async (result) => {
+        if (cancelled) return;
+        if (result.error) {
+          setError(result.error.message ?? "Could not open the workspace");
+          return;
+        }
+        const url = new URL(window.location.href);
+        url.searchParams.delete("organization_id");
+        window.history.replaceState(window.history.state, "", url);
+        await refetch();
+      })
+      .catch((cause: unknown) => {
+        if (!cancelled) {
+          setError(
+            cause instanceof Error
+              ? cause.message
+              : "Could not open the workspace",
+          );
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [organizationId, refetch]);
+
+  return (
+    <AuthFrame>
+      {error ? (
+        <div className="authIntro">
+          <h1>Workspace unavailable</h1>
+          <p>{error}</p>
+        </div>
+      ) : (
+        <p className="authMuted">Opening workspace…</p>
+      )}
+    </AuthFrame>
+  );
+}
+
 export function AuthGate({ children }: AuthGateProps) {
   const session = authClient.useSession();
   const invitationMatch = window.location.pathname.match(
     /^\/invite\/([0-9a-f-]+)$/i,
   );
+  const requestedOrganizationId = new URL(window.location.href).searchParams.get(
+    "organization_id",
+  );
 
   const signedInUserId = session.data?.user.id;
+  const activeOrganizationId = session.data?.session.activeOrganizationId;
   useEffect(() => {
     if (!signedInUserId) return;
     const url = new URL(window.location.href);
@@ -515,6 +571,18 @@ export function AuthGate({ children }: AuthGateProps) {
       <AuthFrame>
         <SignIn isInvitation={Boolean(invitationMatch?.[1])} />
       </AuthFrame>
+    );
+  }
+
+  if (
+    requestedOrganizationId &&
+    requestedOrganizationId !== activeOrganizationId
+  ) {
+    return (
+      <WorkspaceActivation
+        organizationId={requestedOrganizationId}
+        refetch={session.refetch}
+      />
     );
   }
 

--- a/packages/core/src/db/issues.ts
+++ b/packages/core/src/db/issues.ts
@@ -629,6 +629,7 @@ export interface SlackInvestigationDeliveryContext {
   agentId: string;
   executionMode: "standard" | "slack_thread";
   investigationId: string;
+  organizationId?: string;
   prMode: AgentPrMode;
   report: StructuredInvestigationReport;
   title: string;
@@ -674,6 +675,7 @@ export interface SlackInvestigationLiveContext {
   agentId: string;
   executionMode: "standard" | "slack_thread";
   investigationId: string;
+  organizationId?: string;
   title: string;
   traceItems: InvestigationSlackTraceItem[];
   source: {
@@ -765,6 +767,7 @@ export async function getSlackInvestigationLiveContext(
     agentId: investigation.agentId,
     executionMode: investigation.executionMode,
     investigationId: investigation.id,
+    organizationId: investigation.organizationId,
     title: investigation.title,
     traceItems: investigation.traceItems,
     source: {
@@ -883,6 +886,7 @@ export async function getSlackInvestigationDeliveryContext(
     agentId: investigation.agentId,
     executionMode: investigation.executionMode,
     investigationId: investigation.id,
+    organizationId: investigation.organizationId,
     prMode: investigation.prMode,
     report: investigation.report,
     title: investigation.title,

--- a/packages/core/src/integrations/slack-delivery.ts
+++ b/packages/core/src/integrations/slack-delivery.ts
@@ -316,13 +316,19 @@ export async function redeliverInvestigationSlackIssue(
 export function slackCompletedInvestigationCard(
   context: Pick<
     SlackInvestigationDeliveryContext,
-    "agentId" | "executionMode" | "investigationId" | "title" | "traceItems"
+    | "agentId"
+    | "executionMode"
+    | "investigationId"
+    | "organizationId"
+    | "title"
+    | "traceItems"
   >,
 ) {
   return slackInvestigationCard({
     agentId: context.agentId,
     detail: "Completed the investigation plan.",
     investigationId: context.investigationId,
+    organizationId: context.organizationId,
     showInvestigationLink: context.executionMode !== "slack_thread",
     status: "complete",
     title: context.title,
@@ -382,6 +388,7 @@ export async function deliverSlackThreadInvestigationResponse(input: {
     agentId: context.agentId,
     detail: "Completed the investigation plan.",
     investigationId: context.investigationId,
+    organizationId: context.organizationId,
     showInvestigationLink: false,
     status: "complete",
     title: context.title,

--- a/packages/core/src/integrations/slack-live-card.test.ts
+++ b/packages/core/src/integrations/slack-live-card.test.ts
@@ -176,6 +176,36 @@ describe("Slack live investigation card", () => {
     ]);
   });
 
+  it("includes the investigation workspace in Slack links", () => {
+    vi.stubEnv("RESPONDER_APP_URL", "https://responder.example");
+
+    const message = slackInvestigationCard({
+      agentId: context.agentId,
+      detail: "Inspecting the relevant source code.",
+      investigationId: context.investigationId,
+      organizationId: "24242424-2424-4424-8424-242424242424",
+      status: "in_progress",
+      title: context.title,
+    });
+
+    expect(message.blocks).toEqual([
+      expect.objectContaining({
+        type: "plan",
+        tasks: [
+          expect.objectContaining({
+            sources: [
+              {
+                type: "url",
+                text: "View investigation",
+                url: `https://responder.example/agents/${context.agentId}/investigations/${context.investigationId}?organization_id=24242424-2424-4424-8424-242424242424`,
+              },
+            ],
+          }),
+        ],
+      }),
+    ]);
+  });
+
   it("reads an investigation ID only from its feedback block", () => {
     expect(
       investigationIdFromFeedbackBlockId(

--- a/packages/core/src/integrations/slack-live-card.ts
+++ b/packages/core/src/integrations/slack-live-card.ts
@@ -88,9 +88,18 @@ function responderAppUrl(): string {
   ).replace(/\/$/, "");
 }
 
-function investigationUrl(agentId: string, investigationId: string): string {
+function investigationUrl(
+  agentId: string,
+  investigationId: string,
+  organizationId?: string,
+): string {
   const origin = responderAppUrl();
-  return `${origin}/agents/${encodeURIComponent(agentId)}/investigations/${encodeURIComponent(investigationId)}`;
+  const url = new URL(origin);
+  url.pathname = `${url.pathname.replace(/\/+$/, "")}/agents/${encodeURIComponent(agentId)}/investigations/${encodeURIComponent(investigationId)}`;
+  url.search = "";
+  url.hash = "";
+  if (organizationId) url.searchParams.set("organization_id", organizationId);
+  return url.toString();
 }
 
 function richText(value: string, preformatted = false) {
@@ -781,6 +790,7 @@ export function slackInvestigationCard(input: {
   agentId: string;
   detail: string;
   investigationId: string;
+  organizationId?: string;
   showInvestigationLink?: boolean;
   status: SlackInvestigationCardStatus;
   title: string;
@@ -810,7 +820,11 @@ export function slackInvestigationCard(input: {
             {
               type: "url",
               text: "View investigation",
-              url: investigationUrl(input.agentId, input.investigationId),
+              url: investigationUrl(
+                input.agentId,
+                input.investigationId,
+                input.organizationId,
+              ),
             },
           ],
         }),
@@ -960,6 +974,7 @@ async function performInvestigationSlackProgressUpdate(
       agentId: context.agentId,
       detail,
       investigationId: context.investigationId,
+      organizationId: context.organizationId,
       showInvestigationLink: context.executionMode !== "slack_thread",
       status: "in_progress",
       title: context.title,
@@ -1075,6 +1090,7 @@ async function performInvestigationSlackCardFailure(
       agentId: context.agentId,
       detail: "The investigation stopped before it could finish.",
       investigationId: context.investigationId,
+      organizationId: context.organizationId,
       showInvestigationLink: context.executionMode !== "slack_thread",
       status: "error",
       title: context.title,


### PR DESCRIPTION
Include the originating workspace in Slack investigation links and activate it before loading the investigation. This prevents valid links from falling back to /agents when a user has another workspace active.

Tests: pnpm typecheck; pnpm lint; targeted integration tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Slack investigation links so they open the correct workspace instead of falling back to the agents list when a user has another workspace active.

**Bug Fixes**
- Investigation links now include the workspace's `organization_id` in the URL.
- The app activates that workspace before loading the investigation and removes the `organization_id` query parameter from the URL afterward.

<sup>Written for commit 13ad152ecc44c2a4e96582890f5d03159f5eee66. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/responder-oss/pull/91?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

