### PR TITLE
Route legacy accounts and public pages during Superlog migration

### DIFF
--- a/apps/control-plane/server/app.ts
+++ b/apps/control-plane/server/app.ts
@@ -13,6 +13,11 @@ import {
   getAuth,
   platformRoleForIdentity,
 } from "./auth.js";
+import {
+  clearLegacyAccountRedirect,
+  legacyProductUrl,
+  shouldRedirectLegacyAccount,
+} from "../../../packages/core/src/db/legacy-account-redirect.js";
 import { billingRoutes } from "./billing/routes.js";
 import { integrationRoutes } from "./integrations/routes.js";
 import { issueRoutes } from "./issues/routes.js";
@@ -266,6 +271,49 @@ export const app = instrumentedApp
       status: "ok",
     }),
   )
+  .get("/api/legacy-account-redirect", async (context) => {
+    const session = await getAuth().api
+      .getSession({ headers: context.req.raw.headers })
+      .catch(() => null);
+    if (!session) return context.json({ error: "Unauthorized" }, 401);
+
+    try {
+      const redirect = await shouldRedirectLegacyAccount(session.user.email);
+      return context.json({
+        redirect,
+        ...(redirect ? { targetUrl: legacyProductUrl() } : {}),
+      });
+    } catch (error) {
+      console.error(
+        JSON.stringify({
+          event: "legacy_account_redirect_lookup_failed",
+          errorCode: error instanceof Error ? error.constructor.name : "unknown",
+          errorMessage: authHandlerErrorMessage(error),
+        }),
+      );
+      return context.json({ error: "Could not determine account routing" }, 500);
+    }
+  })
+  .post("/api/legacy-account-redirect/clear", async (context) => {
+    const session = await getAuth().api
+      .getSession({ headers: context.req.raw.headers })
+      .catch(() => null);
+    if (!session) return context.json({ error: "Unauthorized" }, 401);
+
+    try {
+      await clearLegacyAccountRedirect(session.user.email);
+      return context.json({ redirect: false });
+    } catch (error) {
+      console.error(
+        JSON.stringify({
+          event: "legacy_account_redirect_clear_failed",
+          errorCode: error instanceof Error ? error.constructor.name : "unknown",
+          errorMessage: authHandlerErrorMessage(error),
+        }),
+      );
+      return context.json({ error: "Could not update account routing" }, 500);
+    }
+  })
   .get("/api/auth/github/callback", (context) => {
     const callbackUrl = new URL(context.req.url);
     callbackUrl.pathname = "/api/integrations/github/callback";

--- a/apps/control-plane/server/auth.ts
+++ b/apps/control-plane/server/auth.ts
@@ -115,7 +115,7 @@ export function createResponderAuth() {
   const githubClientSecret = process.env.AUTH_GITHUB_CLIENT_SECRET;
 
   return betterAuth({
-    appName: "Responder",
+    appName: "Superlog",
     baseURL,
     database: drizzleAdapter(getDatabase(), {
       provider: "pg",
@@ -253,7 +253,7 @@ export function createResponderAuth() {
               idempotencyKey: `workspace-invitation/${id}/${new Date(
                 invitation.expiresAt,
               ).getTime()}`,
-              subject: `You're invited to ${organization.name} in Responder`,
+              subject: `You're invited to ${organization.name} in Superlog`,
               to: email,
             });
             console.info(

--- a/apps/control-plane/server/email.test.ts
+++ b/apps/control-plane/server/email.test.ts
@@ -18,7 +18,7 @@ describe("workspaceInvitationEmailBody", () => {
     });
 
     expect(body.text).toContain(
-      "Ada invited you to join the Acme workspace in Responder as a member.",
+      "Ada invited you to join the Acme workspace in Superlog as a member.",
     );
     expect(body.text).toContain(`Accept invitation: ${invitationUrl}`);
     expect(body.html).toContain("<strong>Acme</strong>");
@@ -63,14 +63,14 @@ describe("sendEmail", () => {
       deliver,
       environment: {
         RESEND_API_KEY: "test-key",
-        RESPONDER_FROM_EMAIL: "Responder <invite@example.com>",
+        RESPONDER_FROM_EMAIL: "Superlog <invite@example.com>",
         RESPONDER_REPLY_TO_EMAIL: "support@example.com",
       } as NodeJS.ProcessEnv,
     });
 
     expect(deliver).toHaveBeenCalledWith(
       {
-        from: "Responder <invite@example.com>",
+        from: "Superlog <invite@example.com>",
         html: message.html,
         replyTo: "support@example.com",
         subject: message.subject,

--- a/apps/control-plane/server/email.ts
+++ b/apps/control-plane/server/email.ts
@@ -5,7 +5,7 @@ import {
   type CreateEmailResponse,
 } from "resend";
 
-const defaultFrom = "Responder <no-reply@superlog.sh>";
+const defaultFrom = "Superlog <no-reply@superlog.sh>";
 
 type EmailDelivery = (
   message: CreateEmailOptions,
@@ -89,8 +89,8 @@ export function workspaceInvitationEmailBody(args: {
   const safeUrl = escapeHtml(args.invitationUrl);
 
   return {
-    text: `${inviter} invited you to join the ${args.organizationName} workspace in Responder as a ${args.role}.\n\nAccept invitation: ${args.invitationUrl}\n\nIf you weren't expecting this invitation, you can ignore this email.`,
-    html: `<p>${safeInviter} invited you to join the <strong>${safeOrganization}</strong> workspace in Responder as a ${safeRole}.</p>
+    text: `${inviter} invited you to join the ${args.organizationName} workspace in Superlog as a ${args.role}.\n\nAccept invitation: ${args.invitationUrl}\n\nIf you weren't expecting this invitation, you can ignore this email.`,
+    html: `<p>${safeInviter} invited you to join the <strong>${safeOrganization}</strong> workspace in Superlog as a ${safeRole}.</p>
 <p><a href="${safeUrl}">Accept invitation</a></p>
 <p style="color:#888">If you weren't expecting this invitation, you can ignore this email.</p>`,
   };

--- a/apps/control-plane/server/legacy-account-redirect-routes.test.ts
+++ b/apps/control-plane/server/legacy-account-redirect-routes.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  clear: vi.fn(),
+  getSession: vi.fn(),
+  shouldRedirect: vi.fn(),
+}));
+
+vi.mock("./auth.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./auth.js")>()),
+  getAuth: () => ({ api: { getSession: mocks.getSession } }),
+}));
+
+vi.mock("../../../packages/core/src/db/legacy-account-redirect.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../packages/core/src/db/legacy-account-redirect.js")>()),
+  clearLegacyAccountRedirect: mocks.clear,
+  shouldRedirectLegacyAccount: mocks.shouldRedirect,
+}));
+
+import { app } from "./app.js";
+
+describe("legacy account redirect routes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getSession.mockResolvedValue(null);
+  });
+
+  it("requires a Responder session for the lookup", async () => {
+    const response = await app.request("/api/legacy-account-redirect");
+
+    expect(response.status).toBe(401);
+    expect(mocks.shouldRedirect).not.toHaveBeenCalled();
+  });
+
+  it("returns the fixed legacy target for a marked session", async () => {
+    mocks.getSession.mockResolvedValue({ user: { email: "legacy@example.com" } });
+    mocks.shouldRedirect.mockResolvedValue(true);
+
+    const response = await app.request("/api/legacy-account-redirect");
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      redirect: true,
+      targetUrl: "https://telemetry.superlog.sh/",
+    });
+    expect(mocks.shouldRedirect).toHaveBeenCalledWith("legacy@example.com");
+  });
+
+  it("clears a marker only for the authenticated user's email", async () => {
+    mocks.getSession.mockResolvedValue({ user: { email: "legacy@example.com" } });
+
+    const response = await app.request("/api/legacy-account-redirect/clear", {
+      method: "POST",
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ redirect: false });
+    expect(mocks.clear).toHaveBeenCalledWith("legacy@example.com");
+  });
+});

--- a/apps/control-plane/src/app.tsx
+++ b/apps/control-plane/src/app.tsx
@@ -16,6 +16,7 @@ import {
   HomePage,
   PrivacyPage,
   PricingPage,
+  ProductUpdateArticlePage,
   TeamPage,
   TermsPage,
 } from "./edition-pages";
@@ -55,6 +56,7 @@ export function App() {
         element={<BlogArticlePage />}
         path={blogArticlePath}
       />
+      <Route element={<ProductUpdateArticlePage />} path="/blog/quieter-incidents-slack-and-connectors" />
       {import.meta.env.DEV ? (
         <>
           <Route element={<DesignLibraryPage />} path="/_design" />

--- a/apps/control-plane/src/app.tsx
+++ b/apps/control-plane/src/app.tsx
@@ -14,7 +14,10 @@ import {
   BlogArticlePage,
   BlogIndexPage,
   HomePage,
+  PrivacyPage,
   PricingPage,
+  TeamPage,
+  TermsPage,
 } from "./edition-pages";
 import { SettingsPage } from "./pages/settings";
 import { SuperuserUsersPage } from "./pages/superuser-users";
@@ -45,6 +48,9 @@ export function App() {
       <Route element={<HomePage />} path="/" />
       <Route element={<PricingPage />} path="/pricing" />
       <Route element={<BlogIndexPage />} path="/blog" />
+      <Route element={<TeamPage />} path="/team" />
+      <Route element={<PrivacyPage />} path="/privacy" />
+      <Route element={<TermsPage />} path="/tos" />
       <Route
         element={<BlogArticlePage />}
         path={blogArticlePath}

--- a/apps/control-plane/src/components/app-shell.tsx
+++ b/apps/control-plane/src/components/app-shell.tsx
@@ -113,9 +113,8 @@ export function AppShell({ active, children, density = "default" }: AppShellProp
     <main className={`appShell appShell--${density}`}>
       <header className="globalHeader">
         <div className="globalHeader__left">
-          <Link aria-label="Superlog Responder home" className="brand" to="/agents">
+          <Link aria-label="Superlog home" className="brand" to="/agents">
             <img alt="Superlog" draggable={false} src="/superlog-wordmark.svg" />
-            <span>Responder</span>
           </Link>
           <nav aria-label="Primary navigation" className="primaryNav">
             <Link

--- a/apps/control-plane/src/components/auth-gate.tsx
+++ b/apps/control-plane/src/components/auth-gate.tsx
@@ -23,7 +23,7 @@ function AuthFrame({ children }: AuthGateProps) {
       <section className="authCard">
         <div className="authBrand">
           <img alt="Superlog" draggable={false} src="/superlog-wordmark.svg" />
-          <span>Responder</span>
+          <span>Superlog</span>
         </div>
         {children}
       </section>
@@ -94,6 +94,12 @@ function SignIn({ isInvitation = false }: { isInvitation?: boolean }) {
     const data = new FormData(event.currentTarget);
     const email = String(data.get("email") ?? "");
     const password = String(data.get("password") ?? "");
+    if (isCreatingAccount) {
+      // AuthGate clears a legacy marker after the newly-created session is
+      // visible. Keeping this intent in sessionStorage closes the race between
+      // Better Auth returning a session and the clear request completing.
+      sessionStorage.setItem("superlog_explicit_signup", "1");
+    }
     const result = isCreatingAccount
       ? await authClient.signUp.email({
           email,
@@ -104,6 +110,7 @@ function SignIn({ isInvitation = false }: { isInvitation?: boolean }) {
 
     setIsSubmitting(false);
     if (result.error) {
+      if (isCreatingAccount) sessionStorage.removeItem("superlog_explicit_signup");
       console.error(
         JSON.stringify({
           event: isCreatingAccount
@@ -475,10 +482,48 @@ export function AuthGate({ children }: AuthGateProps) {
   useEffect(() => {
     if (!signedInUserId) return;
     const url = new URL(window.location.href);
-    if (url.searchParams.get("signed_up") !== "1") return;
-    url.searchParams.delete("signed_up");
-    window.history.replaceState(window.history.state, "", url);
-    trackXSignupPixel(signedInUserId);
+    const socialSignup = url.searchParams.get("signed_up") === "1";
+    const explicitSignup =
+      socialSignup || sessionStorage.getItem("superlog_explicit_signup") === "1";
+    if (!explicitSignup) return;
+    sessionStorage.removeItem("superlog_explicit_signup");
+    void fetch("/api/legacy-account-redirect/clear", {
+      credentials: "include",
+      method: "POST",
+    }).catch(() => undefined);
+    if (socialSignup) {
+      url.searchParams.delete("signed_up");
+      window.history.replaceState(window.history.state, "", url);
+      trackXSignupPixel(signedInUserId);
+    }
+  }, [signedInUserId]);
+
+  useEffect(() => {
+    if (!signedInUserId) return;
+    const url = new URL(window.location.href);
+    if (
+      url.searchParams.get("signed_up") === "1" ||
+      sessionStorage.getItem("superlog_explicit_signup") === "1"
+    ) {
+      return;
+    }
+    let cancelled = false;
+    void fetch("/api/legacy-account-redirect", { credentials: "include" })
+      .then(async (response) => {
+        if (!response.ok) return null;
+        return (await response.json()) as {
+          redirect?: boolean;
+          targetUrl?: string;
+        };
+      })
+      .then((routing) => {
+        if (cancelled || !routing?.redirect || !routing.targetUrl) return;
+        window.location.replace(routing.targetUrl);
+      })
+      .catch(() => undefined);
+    return () => {
+      cancelled = true;
+    };
   }, [signedInUserId]);
 
   if (session.isPending) {

--- a/apps/control-plane/src/components/auth-gate.tsx
+++ b/apps/control-plane/src/components/auth-gate.tsx
@@ -224,7 +224,7 @@ function SignIn({ isInvitation = false }: { isInvitation?: boolean }) {
       >
         {isCreatingAccount
           ? "Already have an account? Sign in"
-          : "New to Responder? Create an account"}
+          : "New to Superlog? Create an account"}
       </button>
     </>
   );
@@ -529,7 +529,7 @@ export function AuthGate({ children }: AuthGateProps) {
   if (session.isPending) {
     return (
       <AuthFrame>
-        <p className="authMuted">Loading Responder…</p>
+        <p className="authMuted">Loading Superlog…</p>
       </AuthFrame>
     );
   }

--- a/apps/control-plane/src/edition-pages.tsx
+++ b/apps/control-plane/src/edition-pages.tsx
@@ -16,3 +16,15 @@ export function BlogIndexPage() {
 export function BlogArticlePage() {
   return <Navigate replace to="/agents" />;
 }
+
+export function TeamPage() {
+  return <Navigate replace to="/agents" />;
+}
+
+export function PrivacyPage() {
+  return <Navigate replace to="/agents" />;
+}
+
+export function TermsPage() {
+  return <Navigate replace to="/agents" />;
+}

--- a/apps/control-plane/src/edition-pages.tsx
+++ b/apps/control-plane/src/edition-pages.tsx
@@ -17,6 +17,10 @@ export function BlogArticlePage() {
   return <Navigate replace to="/agents" />;
 }
 
+export function ProductUpdateArticlePage() {
+  return <Navigate replace to="/agents" />;
+}
+
 export function TeamPage() {
   return <Navigate replace to="/agents" />;
 }

--- a/apps/control-plane/src/public-routes.ts
+++ b/apps/control-plane/src/public-routes.ts
@@ -11,6 +11,10 @@ export const publicDocumentRoutes = [
     output: "blog/kill-alert-fatigue-automating-on-call-with-ai/index.html",
     pathname: blogArticlePath,
   },
+  {
+    output: "blog/quieter-incidents-slack-and-connectors/index.html",
+    pathname: "/blog/quieter-incidents-slack-and-connectors",
+  },
 ] as const;
 
 export const publicDocumentPathnames = publicDocumentRoutes.map(

--- a/apps/control-plane/src/public-routes.ts
+++ b/apps/control-plane/src/public-routes.ts
@@ -4,6 +4,9 @@ export const blogArticlePath =
 export const publicDocumentRoutes = [
   { output: "index.html", pathname: "/" },
   { output: "blog/index.html", pathname: "/blog" },
+  { output: "team/index.html", pathname: "/team" },
+  { output: "privacy/index.html", pathname: "/privacy" },
+  { output: "tos/index.html", pathname: "/tos" },
   {
     output: "blog/kill-alert-fatigue-automating-on-call-with-ai/index.html",
     pathname: blogArticlePath,

--- a/apps/control-plane/src/use-document-title.ts
+++ b/apps/control-plane/src/use-document-title.ts
@@ -2,6 +2,6 @@ import { useEffect } from "react";
 
 export function useDocumentTitle(title: string) {
   useEffect(() => {
-    document.title = `${title} · Responder`;
+    document.title = `${title} · Superlog`;
   }, [title]);
 }

--- a/apps/control-plane/src/use-page-metadata.ts
+++ b/apps/control-plane/src/use-page-metadata.ts
@@ -2,7 +2,7 @@ import { useEffect } from "react";
 import type { SeoMetadata } from "./page-metadata";
 
 const ownedSelector = "[data-responder-seo]";
-const shellTitle = "Responder";
+const shellTitle = "Superlog";
 
 function removeOwnedMetadata() {
   document.head.querySelectorAll(ownedSelector).forEach((element) => element.remove());

--- a/drizzle/0033_melodic_frightful_four.sql
+++ b/drizzle/0033_melodic_frightful_four.sql
@@ -1,0 +1,10 @@
+CREATE TABLE "legacy_account_redirect" (
+	"email_normalized" text PRIMARY KEY NOT NULL,
+	"old_user_id" text NOT NULL,
+	"redirect_enabled" boolean DEFAULT true NOT NULL,
+	"source_snapshot" text NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX "legacy_account_redirect_enabled_idx" ON "legacy_account_redirect" USING btree ("redirect_enabled");

--- a/drizzle/meta/0033_snapshot.json
+++ b/drizzle/meta/0033_snapshot.json
@@ -1,0 +1,4094 @@
+{
+  "id": "99b7bbd5-e87d-4a6a-9689-1235963df448",
+  "prevId": "ef0238dc-3acf-4fb1-b2dc-72b0cc14d59a",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "invitation_organizationId_idx": {
+          "name": "invitation_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_email_idx": {
+          "name": "invitation_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.legacy_account_redirect": {
+      "name": "legacy_account_redirect",
+      "schema": "",
+      "columns": {
+        "email_normalized": {
+          "name": "email_normalized",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "old_user_id": {
+          "name": "old_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_enabled": {
+          "name": "redirect_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "source_snapshot": {
+          "name": "source_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "legacy_account_redirect_enabled_idx": {
+          "name": "legacy_account_redirect_enabled_idx",
+          "columns": [
+            {
+              "expression": "redirect_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "member_organizationId_idx": {
+          "name": "member_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_userId_idx": {
+          "name": "member_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'user'"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_organization_id": {
+          "name": "last_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_config_versions": {
+      "name": "agent_config_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "trigger_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_config": {
+          "name": "trigger_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "report_config": {
+          "name": "report_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context_account_ids": {
+          "name": "context_account_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "context_resource_ids": {
+          "name": "context_resource_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "pr_mode": {
+          "name": "pr_mode",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pr_mode_policy": {
+          "name": "pr_mode_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'disabled'"
+        },
+        "create_linear_tickets": {
+          "name": "create_linear_tickets",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "linear_issue_template": {
+          "name": "linear_issue_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'## Responder issue\n[{{issue_id}}]({{issue_url}})\n\n## Description\n{{description}}\n\n## Evidence\n{{evidence}}\n\n## Recommended remediation\n{{remediation}}'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_config_versions_agent_version_idx": {
+          "name": "agent_config_versions_agent_version_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_config_versions_agent_idx": {
+          "name": "agent_config_versions_agent_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_config_versions_agent_id_agents_id_fk": {
+          "name": "agent_config_versions_agent_id_agents_id_fk",
+          "tableFrom": "agent_config_versions",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_config_versions_created_by_user_id_fk": {
+          "name": "agent_config_versions_created_by_user_id_fk",
+          "tableFrom": "agent_config_versions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_version_repositories": {
+      "name": "agent_version_repositories",
+      "schema": "",
+      "columns": {
+        "agent_config_version_id": {
+          "name": "agent_config_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_version_repositories_agent_config_version_id_agent_config_versions_id_fk": {
+          "name": "agent_version_repositories_agent_config_version_id_agent_config_versions_id_fk",
+          "tableFrom": "agent_version_repositories",
+          "tableTo": "agent_config_versions",
+          "columnsFrom": [
+            "agent_config_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_version_repositories_repository_id_repositories_id_fk": {
+          "name": "agent_version_repositories_repository_id_repositories_id_fk",
+          "tableFrom": "agent_version_repositories",
+          "tableTo": "repositories",
+          "columnsFrom": [
+            "repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_version_repositories_agent_config_version_id_repository_id_pk": {
+          "name": "agent_version_repositories_agent_config_version_id_repository_id_pk",
+          "columns": [
+            "agent_config_version_id",
+            "repository_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_version_secrets": {
+      "name": "agent_version_secrets",
+      "schema": "",
+      "columns": {
+        "agent_config_version_id": {
+          "name": "agent_config_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_secret_id": {
+          "name": "workspace_secret_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_version_secrets_agent_config_version_id_agent_config_versions_id_fk": {
+          "name": "agent_version_secrets_agent_config_version_id_agent_config_versions_id_fk",
+          "tableFrom": "agent_version_secrets",
+          "tableTo": "agent_config_versions",
+          "columnsFrom": [
+            "agent_config_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_version_secrets_workspace_secret_id_workspace_secrets_id_fk": {
+          "name": "agent_version_secrets_workspace_secret_id_workspace_secrets_id_fk",
+          "tableFrom": "agent_version_secrets",
+          "tableTo": "workspace_secrets",
+          "columnsFrom": [
+            "workspace_secret_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_version_secrets_agent_config_version_id_workspace_secret_id_pk": {
+          "name": "agent_version_secrets_agent_config_version_id_workspace_secret_id_pk",
+          "columns": [
+            "agent_config_version_id",
+            "workspace_secret_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'standard'"
+        },
+        "active_version_id": {
+          "name": "active_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agents_organization_idx": {
+          "name": "agents_organization_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agents_organization_slack_thread_idx": {
+          "name": "agents_organization_slack_thread_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"agents\".\"purpose\" = 'slack_thread'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agents_organization_id_organization_id_fk": {
+          "name": "agents_organization_id_organization_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.billing_notification_deliveries": {
+      "name": "billing_notification_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integration_account_id": {
+          "name": "integration_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_key": {
+          "name": "period_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination": {
+          "name": "destination",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "billing_notification_delivery_target_idx": {
+          "name": "billing_notification_delivery_target_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "integration_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "destination",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "billing_notification_delivery_status_idx": {
+          "name": "billing_notification_delivery_status_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "billing_notification_deliveries_organization_id_organization_id_fk": {
+          "name": "billing_notification_deliveries_organization_id_organization_id_fk",
+          "tableFrom": "billing_notification_deliveries",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "billing_notification_deliveries_integration_account_id_integration_accounts_id_fk": {
+          "name": "billing_notification_deliveries_integration_account_id_integration_accounts_id_fk",
+          "tableFrom": "billing_notification_deliveries",
+          "tableTo": "integration_accounts",
+          "columnsFrom": [
+            "integration_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.delivery_attempts": {
+      "name": "delivery_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "investigation_id": {
+          "name": "investigation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination": {
+          "name": "destination",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "delivery_attempts_idempotency_idx": {
+          "name": "delivery_attempts_idempotency_idx",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_attempts_investigation_idx": {
+          "name": "delivery_attempts_investigation_idx",
+          "columns": [
+            {
+              "expression": "investigation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "delivery_attempts_investigation_id_investigations_id_fk": {
+          "name": "delivery_attempts_investigation_id_investigations_id_fk",
+          "tableFrom": "delivery_attempts",
+          "tableTo": "investigations",
+          "columnsFrom": [
+            "investigation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instance_configuration": {
+      "name": "instance_configuration",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "active_runtime_profile_id": {
+          "name": "active_runtime_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "instance_configuration_active_runtime_profile_id_runtime_profiles_id_fk": {
+          "name": "instance_configuration_active_runtime_profile_id_runtime_profiles_id_fk",
+          "tableFrom": "instance_configuration",
+          "tableTo": "runtime_profiles",
+          "columnsFrom": [
+            "active_runtime_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_accounts": {
+      "name": "integration_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "integration_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_account_id": {
+          "name": "external_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'connected'"
+        },
+        "encrypted_credentials": {
+          "name": "encrypted_credentials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_key_version": {
+          "name": "credential_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "integration_accounts_organization_provider_external_idx": {
+          "name": "integration_accounts_organization_provider_external_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_accounts_organization_idx": {
+          "name": "integration_accounts_organization_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_accounts_organization_id_organization_id_fk": {
+          "name": "integration_accounts_organization_id_organization_id_fk",
+          "tableFrom": "integration_accounts",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_connection_states": {
+      "name": "integration_connection_states",
+      "schema": "",
+      "columns": {
+        "state_hash": {
+          "name": "state_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "integration_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_verifier": {
+          "name": "code_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "return_to": {
+          "name": "return_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'/settings'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "integration_connection_states_expires_idx": {
+          "name": "integration_connection_states_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_connection_states_organization_idx": {
+          "name": "integration_connection_states_organization_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_connection_states_owner_provider_idx": {
+          "name": "integration_connection_states_owner_provider_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_connection_states_organization_id_organization_id_fk": {
+          "name": "integration_connection_states_organization_id_organization_id_fk",
+          "tableFrom": "integration_connection_states",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "integration_connection_states_user_id_user_id_fk": {
+          "name": "integration_connection_states_user_id_user_id_fk",
+          "tableFrom": "integration_connection_states",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_resources": {
+      "name": "integration_resources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "integration_account_id": {
+          "name": "integration_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "integration_resource_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "available": {
+          "name": "available",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "integration_resources_account_kind_external_idx": {
+          "name": "integration_resources_account_kind_external_idx",
+          "columns": [
+            {
+              "expression": "integration_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_resources_account_idx": {
+          "name": "integration_resources_account_idx",
+          "columns": [
+            {
+              "expression": "integration_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_resources_integration_account_id_integration_accounts_id_fk": {
+          "name": "integration_resources_integration_account_id_integration_accounts_id_fk",
+          "tableFrom": "integration_resources",
+          "tableTo": "integration_accounts",
+          "columnsFrom": [
+            "integration_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.investigation_issues": {
+      "name": "investigation_issues",
+      "schema": "",
+      "columns": {
+        "investigation_id": {
+          "name": "investigation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relationship": {
+          "name": "relationship",
+          "type": "issue_relationship",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "investigation_issues_issue_idx": {
+          "name": "investigation_issues_issue_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "investigation_issues_investigation_id_investigations_id_fk": {
+          "name": "investigation_issues_investigation_id_investigations_id_fk",
+          "tableFrom": "investigation_issues",
+          "tableTo": "investigations",
+          "columnsFrom": [
+            "investigation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "investigation_issues_issue_id_issues_id_fk": {
+          "name": "investigation_issues_issue_id_issues_id_fk",
+          "tableFrom": "investigation_issues",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "investigation_issues_investigation_id_issue_id_pk": {
+          "name": "investigation_issues_investigation_id_issue_id_pk",
+          "columns": [
+            "investigation_id",
+            "issue_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.investigation_replay_requests": {
+      "name": "investigation_replay_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source_investigation_id": {
+          "name": "source_investigation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "replay_investigation_id": {
+          "name": "replay_investigation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_by": {
+          "name": "requested_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "investigation_replay_request_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "processing_started_at": {
+          "name": "processing_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "queued_at": {
+          "name": "queued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "investigation_replay_requests_replay_idx": {
+          "name": "investigation_replay_requests_replay_idx",
+          "columns": [
+            {
+              "expression": "replay_investigation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "investigation_replay_requests_claim_idx": {
+          "name": "investigation_replay_requests_claim_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "investigation_replay_requests_source_idx": {
+          "name": "investigation_replay_requests_source_idx",
+          "columns": [
+            {
+              "expression": "source_investigation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "investigation_replay_requests_source_investigation_id_investigations_id_fk": {
+          "name": "investigation_replay_requests_source_investigation_id_investigations_id_fk",
+          "tableFrom": "investigation_replay_requests",
+          "tableTo": "investigations",
+          "columnsFrom": [
+            "source_investigation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.investigation_trace_events": {
+      "name": "investigation_trace_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "investigation_id": {
+          "name": "investigation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event": {
+          "name": "event",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "investigation_trace_events_investigation_id_idx": {
+          "name": "investigation_trace_events_investigation_id_idx",
+          "columns": [
+            {
+              "expression": "investigation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "investigation_trace_events_investigation_id_investigations_id_fk": {
+          "name": "investigation_trace_events_investigation_id_investigations_id_fk",
+          "tableFrom": "investigation_trace_events",
+          "tableTo": "investigations",
+          "columnsFrom": [
+            "investigation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.investigations": {
+      "name": "investigations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_config_version_id": {
+          "name": "agent_config_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime_profile_id": {
+          "name": "runtime_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_mode": {
+          "name": "execution_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'standard'"
+        },
+        "slack_investigation_session_id": {
+          "name": "slack_investigation_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "investigation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finding": {
+          "name": "finding",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "structured_report": {
+          "name": "structured_report",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replay_report": {
+          "name": "replay_report",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "report_markdown": {
+          "name": "report_markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_replay": {
+          "name": "is_replay",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "replay_of_investigation_id": {
+          "name": "replay_of_investigation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eve_session_id": {
+          "name": "eve_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_message_timestamp": {
+          "name": "slack_message_timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_trace_items": {
+          "name": "slack_trace_items",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "slack_thread_snapshot": {
+          "name": "slack_thread_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "investigations_organization_created_idx": {
+          "name": "investigations_organization_created_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "investigations_agent_created_idx": {
+          "name": "investigations_agent_created_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "investigations_replay_source_idx": {
+          "name": "investigations_replay_source_idx",
+          "columns": [
+            {
+              "expression": "replay_of_investigation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "investigations_organization_id_organization_id_fk": {
+          "name": "investigations_organization_id_organization_id_fk",
+          "tableFrom": "investigations",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "investigations_agent_id_agents_id_fk": {
+          "name": "investigations_agent_id_agents_id_fk",
+          "tableFrom": "investigations",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "investigations_agent_config_version_id_agent_config_versions_id_fk": {
+          "name": "investigations_agent_config_version_id_agent_config_versions_id_fk",
+          "tableFrom": "investigations",
+          "tableTo": "agent_config_versions",
+          "columnsFrom": [
+            "agent_config_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "investigations_runtime_profile_id_runtime_profiles_id_fk": {
+          "name": "investigations_runtime_profile_id_runtime_profiles_id_fk",
+          "tableFrom": "investigations",
+          "tableTo": "runtime_profiles",
+          "columnsFrom": [
+            "runtime_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "investigations_slack_investigation_session_id_slack_investigation_sessions_id_fk": {
+          "name": "investigations_slack_investigation_session_id_slack_investigation_sessions_id_fk",
+          "tableFrom": "investigations",
+          "tableTo": "slack_investigation_sessions",
+          "columnsFrom": [
+            "slack_investigation_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "investigations_replay_source_fk": {
+          "name": "investigations_replay_source_fk",
+          "tableFrom": "investigations",
+          "tableTo": "investigations",
+          "columnsFrom": [
+            "replay_of_investigation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_linear_tickets": {
+      "name": "issue_linear_tickets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "investigation_id": {
+          "name": "investigation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_config_version_id": {
+          "name": "agent_config_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integration_account_id": {
+          "name": "integration_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linear_issue_id": {
+          "name": "linear_issue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linear_identifier": {
+          "name": "linear_identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linear_issue_url": {
+          "name": "linear_issue_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "issue_linear_tickets_issue_idx": {
+          "name": "issue_linear_tickets_issue_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_linear_tickets_investigation_idx": {
+          "name": "issue_linear_tickets_investigation_idx",
+          "columns": [
+            {
+              "expression": "investigation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_linear_tickets_status_created_idx": {
+          "name": "issue_linear_tickets_status_created_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_linear_tickets_issue_id_issues_id_fk": {
+          "name": "issue_linear_tickets_issue_id_issues_id_fk",
+          "tableFrom": "issue_linear_tickets",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_linear_tickets_investigation_id_investigations_id_fk": {
+          "name": "issue_linear_tickets_investigation_id_investigations_id_fk",
+          "tableFrom": "issue_linear_tickets",
+          "tableTo": "investigations",
+          "columnsFrom": [
+            "investigation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_linear_tickets_agent_config_version_id_agent_config_versions_id_fk": {
+          "name": "issue_linear_tickets_agent_config_version_id_agent_config_versions_id_fk",
+          "tableFrom": "issue_linear_tickets",
+          "tableTo": "agent_config_versions",
+          "columnsFrom": [
+            "agent_config_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "issue_linear_tickets_integration_account_id_integration_accounts_id_fk": {
+          "name": "issue_linear_tickets_integration_account_id_integration_accounts_id_fk",
+          "tableFrom": "issue_linear_tickets",
+          "tableTo": "integration_accounts",
+          "columnsFrom": [
+            "integration_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_pull_request_activities": {
+      "name": "issue_pull_request_activities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_key": {
+          "name": "external_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event": {
+          "name": "event",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_pull_request_activities_request_idx": {
+          "name": "issue_pull_request_activities_request_idx",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_pull_request_activities_external_key_idx": {
+          "name": "issue_pull_request_activities_external_key_idx",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"issue_pull_request_activities\".\"external_key\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_pull_request_activities_request_id_issue_pull_requests_id_fk": {
+          "name": "issue_pull_request_activities_request_id_issue_pull_requests_id_fk",
+          "tableFrom": "issue_pull_request_activities",
+          "tableTo": "issue_pull_requests",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_pull_request_slack_messages": {
+      "name": "issue_pull_request_slack_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integration_account_id": {
+          "name": "integration_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_timestamp": {
+          "name": "message_timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_pull_request_slack_messages_message_idx": {
+          "name": "issue_pull_request_slack_messages_message_idx",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "integration_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "message_timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_pull_request_slack_messages_request_idx": {
+          "name": "issue_pull_request_slack_messages_request_idx",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_pull_request_slack_messages_request_id_issue_pull_requests_id_fk": {
+          "name": "issue_pull_request_slack_messages_request_id_issue_pull_requests_id_fk",
+          "tableFrom": "issue_pull_request_slack_messages",
+          "tableTo": "issue_pull_requests",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_pull_request_slack_messages_integration_account_id_integration_accounts_id_fk": {
+          "name": "issue_pull_request_slack_messages_integration_account_id_integration_accounts_id_fk",
+          "tableFrom": "issue_pull_request_slack_messages",
+          "tableTo": "integration_accounts",
+          "columnsFrom": [
+            "integration_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_pull_requests": {
+      "name": "issue_pull_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "investigation_id": {
+          "name": "investigation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_config_version_id": {
+          "name": "agent_config_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "remediation_id": {
+          "name": "remediation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_full_name": {
+          "name": "repository_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pull_request_number": {
+          "name": "pull_request_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pull_request_url": {
+          "name": "pull_request_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eve_session_id": {
+          "name": "eve_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "issue_pull_requests_active_issue_idx": {
+          "name": "issue_pull_requests_active_issue_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"status\" in ('queued', 'creating', 'created')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_pull_requests_issue_created_idx": {
+          "name": "issue_pull_requests_issue_created_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_pull_requests_investigation_idx": {
+          "name": "issue_pull_requests_investigation_idx",
+          "columns": [
+            {
+              "expression": "investigation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_pull_requests_issue_id_issues_id_fk": {
+          "name": "issue_pull_requests_issue_id_issues_id_fk",
+          "tableFrom": "issue_pull_requests",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_pull_requests_investigation_id_investigations_id_fk": {
+          "name": "issue_pull_requests_investigation_id_investigations_id_fk",
+          "tableFrom": "issue_pull_requests",
+          "tableTo": "investigations",
+          "columnsFrom": [
+            "investigation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_pull_requests_agent_config_version_id_agent_config_versions_id_fk": {
+          "name": "issue_pull_requests_agent_config_version_id_agent_config_versions_id_fk",
+          "tableFrom": "issue_pull_requests",
+          "tableTo": "agent_config_versions",
+          "columnsFrom": [
+            "agent_config_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issues": {
+      "name": "issues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root_cause": {
+          "name": "root_cause",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "timeline": {
+          "name": "timeline",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "severity": {
+          "name": "severity",
+          "type": "severity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "remediation": {
+          "name": "remediation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "remediations": {
+          "name": "remediations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_model": {
+          "name": "embedding_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issues_organization_created_idx": {
+          "name": "issues_organization_created_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issues_organization_id_organization_id_fk": {
+          "name": "issues_organization_id_organization_id_fk",
+          "tableFrom": "issues",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.repositories": {
+      "name": "repositories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "integration_account_id": {
+          "name": "integration_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'main'"
+        },
+        "private": {
+          "name": "private",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "available": {
+          "name": "available",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "repositories_installation_external_idx": {
+          "name": "repositories_installation_external_idx",
+          "columns": [
+            {
+              "expression": "integration_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "repositories_integration_account_id_integration_accounts_id_fk": {
+          "name": "repositories_integration_account_id_integration_accounts_id_fk",
+          "tableFrom": "repositories",
+          "tableTo": "integration_accounts",
+          "columnsFrom": [
+            "integration_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runtime_profiles": {
+      "name": "runtime_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "version": {
+          "name": "version",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_options": {
+          "name": "model_options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "runtime_profiles_version_idx": {
+          "name": "runtime_profiles_version_idx",
+          "columns": [
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_investigation_sessions": {
+      "name": "slack_investigation_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_config_version_id": {
+          "name": "agent_config_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime_profile_id": {
+          "name": "runtime_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_timestamp": {
+          "name": "thread_timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandbox_session_state": {
+          "name": "sandbox_session_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_response_id": {
+          "name": "previous_response_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "slack_investigation_sessions_thread_idx": {
+          "name": "slack_investigation_sessions_thread_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "thread_timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_investigation_sessions_organization_id_organization_id_fk": {
+          "name": "slack_investigation_sessions_organization_id_organization_id_fk",
+          "tableFrom": "slack_investigation_sessions",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "slack_investigation_sessions_agent_id_agents_id_fk": {
+          "name": "slack_investigation_sessions_agent_id_agents_id_fk",
+          "tableFrom": "slack_investigation_sessions",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "slack_investigation_sessions_agent_config_version_id_agent_config_versions_id_fk": {
+          "name": "slack_investigation_sessions_agent_config_version_id_agent_config_versions_id_fk",
+          "tableFrom": "slack_investigation_sessions",
+          "tableTo": "agent_config_versions",
+          "columnsFrom": [
+            "agent_config_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "slack_investigation_sessions_runtime_profile_id_runtime_profiles_id_fk": {
+          "name": "slack_investigation_sessions_runtime_profile_id_runtime_profiles_id_fk",
+          "tableFrom": "slack_investigation_sessions",
+          "tableTo": "runtime_profiles",
+          "columnsFrom": [
+            "runtime_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_receipts": {
+      "name": "webhook_receipts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_event_id": {
+          "name": "external_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "investigation_id": {
+          "name": "investigation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_hash": {
+          "name": "payload_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_receipts_provider_event_idx": {
+          "name": "webhook_receipts_provider_event_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_receipts_organization_id_organization_id_fk": {
+          "name": "webhook_receipts_organization_id_organization_id_fk",
+          "tableFrom": "webhook_receipts",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_secrets": {
+      "name": "workspace_secrets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "daytona_secret_id": {
+          "name": "daytona_secret_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "daytona_secret_name": {
+          "name": "daytona_secret_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allowed_hosts": {
+          "name": "allowed_hosts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workspace_secrets_organization_name_idx": {
+          "name": "workspace_secrets_organization_name_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_secrets_daytona_id_idx": {
+          "name": "workspace_secrets_daytona_id_idx",
+          "columns": [
+            {
+              "expression": "daytona_secret_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_secrets_daytona_name_idx": {
+          "name": "workspace_secrets_daytona_name_idx",
+          "columns": [
+            {
+              "expression": "daytona_secret_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_secrets_organization_id_organization_id_fk": {
+          "name": "workspace_secrets_organization_id_organization_id_fk",
+          "tableFrom": "workspace_secrets",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "workspace_secrets_created_by_user_id_fk": {
+          "name": "workspace_secrets_created_by_user_id_fk",
+          "tableFrom": "workspace_secrets",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.integration_provider": {
+      "name": "integration_provider",
+      "schema": "public",
+      "values": [
+        "aws",
+        "github",
+        "slack",
+        "sentry",
+        "datadog",
+        "axiom",
+        "clickstack",
+        "upstash",
+        "langfuse",
+        "vercel",
+        "custom_mcp",
+        "linear"
+      ]
+    },
+    "public.integration_resource_kind": {
+      "name": "integration_resource_kind",
+      "schema": "public",
+      "values": [
+        "slack_channel",
+        "sentry_project",
+        "datadog_monitor",
+        "vercel_project"
+      ]
+    },
+    "public.investigation_replay_request_status": {
+      "name": "investigation_replay_request_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "queued",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.investigation_status": {
+      "name": "investigation_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "investigating",
+        "resolved",
+        "failed"
+      ]
+    },
+    "public.issue_relationship": {
+      "name": "issue_relationship",
+      "schema": "public",
+      "values": [
+        "new",
+        "recurrence"
+      ]
+    },
+    "public.severity": {
+      "name": "severity",
+      "schema": "public",
+      "values": [
+        "SEV-1",
+        "SEV-2",
+        "SEV-3"
+      ]
+    },
+    "public.trigger_kind": {
+      "name": "trigger_kind",
+      "schema": "public",
+      "values": [
+        "sentry_issue",
+        "datadog_monitor",
+        "slack_channel",
+        "slack_mention"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -232,6 +232,13 @@
       "when": 1787849835131,
       "tag": "0032_flippant_stryfe",
       "breakpoints": true
+    },
+    {
+      "idx": 33,
+      "version": "7",
+      "when": 1788183472547,
+      "tag": "0033_melodic_frightful_four",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "callbacks:use": "bash scripts/local-tunnel.sh claim",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
+    "legacy-redirect:import": "tsx scripts/import-legacy-account-redirects.ts",
     "dev": "pnpm --filter @responder/control-plane dev",
     "dev:worker": "bash scripts/local-worker.sh",
     "dev:callback-bridge": "node scripts/local-callback-bridge.mjs",

--- a/packages/core/src/db/legacy-account-redirect.test.ts
+++ b/packages/core/src/db/legacy-account-redirect.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { legacyProductUrl, normalizeLegacyEmail } from "./legacy-account-redirect.js";
+
+describe("legacy account redirect", () => {
+  it("normalizes lookup email without changing its identity", () => {
+    expect(normalizeLegacyEmail("  ALI@Example.COM ")).toBe("ali@example.com");
+  });
+
+  it("uses the fixed telemetry origin by default", () => {
+    expect(legacyProductUrl({})).toBe("https://telemetry.superlog.sh/");
+  });
+
+  it("rejects non-HTTPS production redirect origins", () => {
+    expect(() => legacyProductUrl({ LEGACY_PRODUCT_URL: "http://evil.example" })).toThrow(
+      "LEGACY_PRODUCT_URL must be telemetry.superlog.sh over HTTPS",
+    );
+  });
+
+  it("allows localhost for local integration tests", () => {
+    expect(legacyProductUrl({ LEGACY_PRODUCT_URL: "http://localhost:4173/path" })).toBe(
+      "http://localhost:4173/",
+    );
+  });
+});

--- a/packages/core/src/db/legacy-account-redirect.ts
+++ b/packages/core/src/db/legacy-account-redirect.ts
@@ -1,0 +1,56 @@
+import { eq } from "drizzle-orm";
+import { getDatabase } from "./client.js";
+import { legacyAccountRedirect } from "./schema.js";
+
+const DEFAULT_LEGACY_PRODUCT_URL = "https://telemetry.superlog.sh";
+
+/** Normalize only the value used for an exact account lookup. */
+export function normalizeLegacyEmail(email: string): string {
+  return email.trim().toLowerCase();
+}
+
+/**
+ * Return the configured legacy product origin. This is deliberately not an
+ * arbitrary URL from a request, so the redirect endpoint cannot become an
+ * open redirector.
+ */
+export function legacyProductUrl(
+  environment: NodeJS.ProcessEnv = process.env,
+): string {
+  const configured = environment.LEGACY_PRODUCT_URL ?? DEFAULT_LEGACY_PRODUCT_URL;
+  const url = new URL(configured);
+  if (
+    (url.protocol !== "https:" && url.hostname !== "localhost") ||
+    (url.hostname !== "telemetry.superlog.sh" && url.hostname !== "localhost")
+  ) {
+    throw new Error("LEGACY_PRODUCT_URL must be telemetry.superlog.sh over HTTPS");
+  }
+  url.pathname = "/";
+  url.search = "";
+  url.hash = "";
+  return url.toString();
+}
+
+export async function shouldRedirectLegacyAccount(email: string): Promise<boolean> {
+  const marker = await getDatabase().query.legacyAccountRedirect.findFirst({
+    where: eq(
+      legacyAccountRedirect.emailNormalized,
+      normalizeLegacyEmail(email),
+    ),
+    columns: { redirectEnabled: true },
+  });
+  return marker?.redirectEnabled === true;
+}
+
+/** Keep the row for auditability and to make an explicit migration sticky. */
+export async function clearLegacyAccountRedirect(email: string): Promise<void> {
+  await getDatabase()
+    .update(legacyAccountRedirect)
+    .set({ redirectEnabled: false })
+    .where(
+      eq(
+        legacyAccountRedirect.emailNormalized,
+        normalizeLegacyEmail(email),
+      ),
+    );
+}

--- a/packages/core/src/db/schema.ts
+++ b/packages/core/src/db/schema.ts
@@ -23,6 +23,30 @@ import type {
 } from "../investigations/report.js";
 import { organization, user } from "./auth-schema.js";
 
+/**
+ * Email-keyed handoff markers for accounts that originated in the legacy
+ * Superlog product. This lives in the application schema (rather than the
+ * generated Better Auth schema) so auth-schema regeneration cannot erase it.
+ * The marker is intentionally not tied to a Responder user: an old user may
+ * authenticate through OAuth for the first time after the import, at which
+ * point Better Auth creates the local user row.
+ */
+export const legacyAccountRedirect = pgTable(
+  "legacy_account_redirect",
+  {
+    emailNormalized: text("email_normalized").primaryKey(),
+    oldUserId: text("old_user_id").notNull(),
+    redirectEnabled: boolean("redirect_enabled").default(true).notNull(),
+    sourceSnapshot: text("source_snapshot").notNull(),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+    updatedAt: timestamp("updated_at")
+      .defaultNow()
+      .$onUpdate(() => /* @__PURE__ */ new Date())
+      .notNull(),
+  },
+  (table) => [index("legacy_account_redirect_enabled_idx").on(table.redirectEnabled)],
+);
+
 export const integrationProvider = pgEnum("integration_provider", [
   "aws",
   "github",

--- a/scripts/import-legacy-account-redirects.ts
+++ b/scripts/import-legacy-account-redirects.ts
@@ -1,0 +1,124 @@
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { basename, resolve } from "node:path";
+import { closeDatabase, getDatabase } from "../packages/core/src/db/client.js";
+import { normalizeLegacyEmail } from "../packages/core/src/db/legacy-account-redirect.js";
+import { legacyAccountRedirect } from "../packages/core/src/db/schema.js";
+
+const requiredColumns = ["old_user_id", "email", "redirect_flag"] as const;
+
+function parseCsvLine(line: string): string[] {
+  const values: string[] = [];
+  let value = "";
+  let quoted = false;
+  for (let index = 0; index < line.length; index += 1) {
+    const character = line[index];
+    if (character === '"') {
+      if (quoted && line[index + 1] === '"') {
+        value += '"';
+        index += 1;
+      } else {
+        quoted = !quoted;
+      }
+    } else if (character === "," && !quoted) {
+      values.push(value);
+      value = "";
+    } else {
+      value += character;
+    }
+  }
+  values.push(value);
+  if (quoted) throw new Error("CSV contains an unterminated quoted field");
+  return values;
+}
+
+function parseManifest(contents: string) {
+  const lines = contents.split(/\r?\n/).filter((line) => line.length > 0);
+  if (lines.length < 2) throw new Error("Redirect manifest must contain a header and rows");
+  const header = parseCsvLine(lines[0]);
+  for (const column of requiredColumns) {
+    if (!header.includes(column)) throw new Error(`Redirect manifest is missing ${column}`);
+  }
+  const indexes = Object.fromEntries(header.map((column, index) => [column, index]));
+  const seen = new Set<string>();
+  return lines.slice(1).map((line, rowIndex) => {
+    const values = parseCsvLine(line);
+    const email = normalizeLegacyEmail(values[indexes.email] ?? "");
+    const oldUserId = values[indexes.old_user_id]?.trim() ?? "";
+    const redirectFlag = values[indexes.redirect_flag]?.trim().toLowerCase();
+    if (!oldUserId || !email) throw new Error(`Row ${rowIndex + 2} is missing an id or email`);
+    if (redirectFlag !== "true") {
+      throw new Error(`Row ${rowIndex + 2} is not a TRUE redirect row`);
+    }
+    if (seen.has(email)) throw new Error(`Duplicate normalized email at row ${rowIndex + 2}`);
+    seen.add(email);
+    return { emailNormalized: email, oldUserId };
+  });
+}
+
+const input = process.argv.slice(2).find((argument) => !argument.startsWith("--"));
+const apply = process.argv.includes("--apply");
+if (!input) {
+  console.error("Usage: pnpm legacy-redirect:import <manifest.csv> [--apply]");
+  process.exit(2);
+}
+
+const path = resolve(input);
+const contents = await readFile(path, "utf8");
+const rows = parseManifest(contents);
+const sourceSnapshot = createHash("sha256").update(contents).digest("hex");
+
+console.info(
+  JSON.stringify({
+    apply,
+    event: "legacy_account_redirect_manifest_validated",
+    rows: rows.length,
+    sourceFile: basename(path),
+    sourceSnapshot,
+  }),
+);
+await closeDatabase();
+
+if (!apply) {
+  console.info("Dry run only. Re-run with --apply to update the marker table.");
+  process.exit(0);
+}
+
+const database = getDatabase();
+await database.transaction(async (transaction) => {
+  const now = new Date();
+  await transaction
+    .update(legacyAccountRedirect)
+    .set({ redirectEnabled: false, sourceSnapshot, updatedAt: now });
+  for (let index = 0; index < rows.length; index += 100) {
+    const batch = rows.slice(index, index + 100).map((row) => ({
+      ...row,
+      redirectEnabled: true,
+      sourceSnapshot,
+      createdAt: now,
+      updatedAt: now,
+    }));
+    await transaction
+      .insert(legacyAccountRedirect)
+      .values(batch)
+      .onConflictDoUpdate({
+        target: legacyAccountRedirect.emailNormalized,
+        set: {
+          // The old user id is stable for a normalized email. Keep the
+          // previously imported id on conflict and refresh routing metadata.
+          oldUserId: legacyAccountRedirect.oldUserId,
+          redirectEnabled: true,
+          sourceSnapshot,
+          updatedAt: now,
+        },
+      });
+  }
+});
+
+console.info(
+  JSON.stringify({
+    event: "legacy_account_redirect_manifest_applied",
+    rows: rows.length,
+    sourceSnapshot,
+  }),
+);


### PR DESCRIPTION
## Summary
- add the legacy-account redirect marker table and dry-run-first importer
- redirect marked Responder sign-ins to telemetry.superlog.sh while clearing the marker for explicit Responder signups
- add public /team, /privacy, /tos, and the merged legacy blog route
- brand the customer-facing app and invitation copy as Superlog

## Validation
- pnpm test (118 files, 875 tests)
- pnpm typecheck
- pnpm lint
- Drizzle generation and 730-row importer dry run

The private hosted overlay will update its open-core gitlink only after this PR is merged.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redirects Responder sign-ins for accounts imported from the legacy Superlog product to `telemetry.superlog.sh` unless the user explicitly signs up, and rebrands customer-facing copy as Superlog.

- Adds a dry-run-first importer (`pnpm legacy-redirect:import`) and a `legacy_account_redirect` marker table keyed by normalized email.
- Adds `/api/legacy-account-redirect` lookup and `/clear` endpoints; the clear marker fires after explicit email or social signup.
- Pins the redirect target to `telemetry.superlog.sh` over HTTPS so the endpoint cannot become an open redirector.
- Serves `/team`, `/privacy`, `/tos`, and the merged legacy blog post, all redirecting to `/agents`.

**Migration**
- Apply migration `0033_melodic_frightful_four`, then run `pnpm legacy-redirect:import <manifest.csv> --apply` to populate the marker table; the import is a single transaction and keeps the previous `old_user_id` on conflict.

<sup>Written for commit b43738aa728cb3ec9cfc1c6c1af4be77c33623c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/responder-oss/pull/92?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

