### PR TITLE
Open agent rows on click and add a row actions menu

### DIFF
--- a/apps/control-plane/src/components/icons.tsx
+++ b/apps/control-plane/src/components/icons.tsx
@@ -310,6 +310,23 @@ export function PlusIcon(props: IconProps) {
   );
 }
 
+export function EllipsisIcon(props: IconProps) {
+  return (
+    <svg
+      aria-hidden="true"
+      fill="none"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      {...props}
+    >
+      <circle cx="3.5" cy="8" fill="currentColor" r="1.1" />
+      <circle cx="8" cy="8" fill="currentColor" r="1.1" />
+      <circle cx="12.5" cy="8" fill="currentColor" r="1.1" />
+    </svg>
+  );
+}
+
 export function SearchIcon(props: IconProps) {
   return (
     <svg

--- a/apps/control-plane/src/design-system/design-system.css
+++ b/apps/control-plane/src/design-system/design-system.css
@@ -1182,6 +1182,10 @@
   background: var(--ds-surface-hover);
 }
 
+.dsDataTable__row--interactive {
+  cursor: pointer;
+}
+
 .dsDataTable__cell--left {
   text-align: left;
 }

--- a/apps/control-plane/src/design-system/design-system.test.ts
+++ b/apps/control-plane/src/design-system/design-system.test.ts
@@ -41,4 +41,36 @@ describe("DataTable", () => {
     expect(markup).toContain("First issue");
     expect(markup).toContain("Third issue");
   });
+
+  it("marks rows as interactive only when a row click handler is provided", () => {
+    const columns: Array<DataTableColumn<TestRow>> = [
+      {
+        header: "Issue",
+        key: "title",
+        render: (row) => row.title,
+      },
+    ];
+    const rows: Array<TestRow> = [
+      { date: "Today", id: "issue-1", title: "First issue" },
+    ];
+    const baseProps = {
+      "aria-label": "Issues",
+      columns,
+      getRowKey: (row: TestRow) => row.id,
+      rows,
+    };
+
+    const withoutRowClick = renderToStaticMarkup(
+      createElement(DataTable<TestRow>, baseProps),
+    );
+    const withRowClick = renderToStaticMarkup(
+      createElement(DataTable<TestRow>, {
+        ...baseProps,
+        onRowClick: () => undefined,
+      }),
+    );
+
+    expect(withoutRowClick).not.toContain("dsDataTable__row--interactive");
+    expect(withRowClick).toContain("dsDataTable__row--interactive");
+  });
 });

--- a/apps/control-plane/src/design-system/design-system.tsx
+++ b/apps/control-plane/src/design-system/design-system.tsx
@@ -735,6 +735,7 @@ export interface DataTableProps<Row, Filter extends string = string> {
   getRowGroup?: (row: Row) => string;
   getRowKey: (row: Row) => string | number;
   onFilterChange?: (value: Filter) => void;
+  onRowClick?: (row: Row) => void;
   rows: Array<Row>;
 }
 
@@ -768,6 +769,7 @@ export function DataTable<Row, Filter extends string = string>({
   getRowGroup,
   getRowKey,
   onFilterChange,
+  onRowClick,
   rows,
 }: DataTableProps<Row, Filter>) {
   const rowGroups = getRowGroup ? groupDataTableRows(rows, getRowGroup) : [];
@@ -797,7 +799,26 @@ export function DataTable<Row, Filter extends string = string>({
 
   function renderedRows(groupRows: Array<Row>) {
     return groupRows.map((row) => (
-      <tr key={getRowKey(row)}>
+      <tr
+        className={onRowClick ? "dsDataTable__row--interactive" : undefined}
+        key={getRowKey(row)}
+        onClick={
+          onRowClick
+            ? (event) => {
+                // Clicks on links, buttons, and inputs inside the row keep
+                // their own behavior; selecting text must not navigate.
+                if (
+                  event.target instanceof Element &&
+                  event.target.closest("a, button, input, textarea, select, label")
+                ) {
+                  return;
+                }
+                if (window.getSelection()?.toString()) return;
+                onRowClick(row);
+              }
+            : undefined
+        }
+      >
         {columns.map((column) => (
           <td
             className={`dsDataTable__cell--${column.align ?? "left"}`}

--- a/apps/control-plane/src/pages/agents.tsx
+++ b/apps/control-plane/src/pages/agents.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState } from "react";
-import { Link } from "react-router-dom";
+import { useEffect, useRef, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
 import {
   type AgentListItem,
   fetchAgents,
@@ -13,16 +13,105 @@ import {
   integrationsForAgent,
 } from "../agent-list-presentation";
 import { AppShell } from "../components/app-shell";
-import { ArrowIcon, PlusIcon } from "../components/icons";
+import { EllipsisIcon, PlusIcon } from "../components/icons";
 import { AgentListSkeleton } from "../components/screen-skeletons";
-import { Badge, DataTable } from "../design-system";
+import { Badge, DataTable, IconButton } from "../design-system";
 import { useDocumentTitle } from "../use-document-title";
+
+function AgentRowMenu({ agent }: { agent: AgentListItem }) {
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const closeTimer = useRef<number | null>(null);
+
+  function cancelScheduledClose() {
+    if (closeTimer.current !== null) {
+      window.clearTimeout(closeTimer.current);
+      closeTimer.current = null;
+    }
+  }
+
+  // The short delay lets the pointer cross the gap between the trigger and
+  // the popover without the menu closing underneath it.
+  function scheduleClose() {
+    cancelScheduledClose();
+    closeTimer.current = window.setTimeout(() => setOpen(false), 140);
+  }
+
+  useEffect(() => cancelScheduledClose, []);
+
+  useEffect(() => {
+    if (!open) return;
+
+    function closeOnOutsideClick(event: MouseEvent) {
+      if (
+        event.target instanceof Node &&
+        !rootRef.current?.contains(event.target)
+      ) {
+        setOpen(false);
+      }
+    }
+
+    function closeOnEscape(event: KeyboardEvent) {
+      if (event.key === "Escape") setOpen(false);
+    }
+
+    document.addEventListener("mousedown", closeOnOutsideClick);
+    document.addEventListener("keydown", closeOnEscape);
+    return () => {
+      document.removeEventListener("mousedown", closeOnOutsideClick);
+      document.removeEventListener("keydown", closeOnEscape);
+    };
+  }, [open]);
+
+  return (
+    <div
+      className="agentRowMenu"
+      onMouseEnter={cancelScheduledClose}
+      onMouseLeave={scheduleClose}
+      ref={rootRef}
+    >
+      <IconButton
+        aria-expanded={open}
+        aria-haspopup="menu"
+        aria-label={`Actions for ${agent.name}`}
+        onClick={() => setOpen((value) => !value)}
+        onMouseEnter={() => {
+          cancelScheduledClose();
+          setOpen(true);
+        }}
+        size="small"
+        variant="ghost"
+      >
+        <EllipsisIcon />
+      </IconButton>
+      {open ? (
+        <div className="agentRowMenu__popover" role="menu">
+          <Link
+            className="agentRowMenu__item"
+            role="menuitem"
+            to={`/agents/${agent.id}`}
+          >
+            View details
+          </Link>
+          <Link
+            className="agentRowMenu__item"
+            role="menuitem"
+            to={`/agents/${agent.id}/edit`}
+          >
+            Edit agent
+          </Link>
+        </div>
+      ) : null}
+    </div>
+  );
+}
 
 export function AgentsPage() {
   const [agents, setAgents] = useState<AgentListItem[]>([]);
   const [agentFilter, setAgentFilter] = useState<AgentFilter>("all");
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const navigate = useNavigate();
   useDocumentTitle("Agents");
 
   useEffect(() => {
@@ -162,16 +251,8 @@ export function AgentsPage() {
               {
                 align: "right",
                 header: "",
-                key: "open",
-                render: (agent) => (
-                  <Link
-                    aria-label={`Open ${agent.name}`}
-                    className="agentTableArrow"
-                    to={`/agents/${agent.id}`}
-                  >
-                    <ArrowIcon />
-                  </Link>
-                ),
+                key: "actions",
+                render: (agent) => <AgentRowMenu agent={agent} />,
                 width: "5%",
               },
             ]}
@@ -192,6 +273,7 @@ export function AgentsPage() {
             ]}
             getRowKey={(agent) => agent.id}
             onFilterChange={setAgentFilter}
+            onRowClick={(agent) => navigate(`/agents/${agent.id}`)}
             rows={filteredAgents}
           />
         </section>

--- a/apps/control-plane/src/styles.css
+++ b/apps/control-plane/src/styles.css
@@ -2624,23 +2624,74 @@ button:disabled {
   color: var(--ds-positive);
 }
 
-.agentTableArrow,
 .investigationRow__arrow {
   display: flex;
   justify-content: flex-end;
   color: var(--ds-text-muted);
 }
 
-.agentTableTitle:focus-visible,
-.agentTableArrow:focus-visible {
+.agentTableTitle:focus-visible {
   border-radius: 4px;
   outline: 2px solid var(--ds-text-primary);
   outline-offset: 2px;
 }
 
 .agentTableTitle:hover strong,
-.agentTableArrow:hover {
+.dsDataTable__row--interactive:hover .agentTableTitle strong {
   color: var(--ds-text-primary);
+}
+
+.agentRowMenu {
+  position: relative;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.agentRowMenu__popover {
+  position: absolute;
+  z-index: 20;
+  top: calc(100% + 4px);
+  right: 0;
+  min-width: 148px;
+  padding: 6px;
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--border-strong);
+  border-radius: 8px;
+  background: var(--surface);
+  box-shadow: 0 18px 50px rgb(0 0 0 / 45%);
+}
+
+/* The table container scrolls, so the last row opens its menu upward and a
+   lone row opens sideways to stay inside the visible area. */
+.agentListTable .dsDataTable tbody tr:last-child:not(:first-child) .agentRowMenu__popover {
+  top: auto;
+  bottom: calc(100% + 4px);
+}
+
+.agentListTable .dsDataTable tbody tr:first-child:last-child .agentRowMenu__popover {
+  top: auto;
+  right: calc(100% + 6px);
+  bottom: 0;
+}
+
+.agentRowMenu__item {
+  width: 100%;
+  min-height: 32px;
+  padding: 6px 9px;
+  display: flex;
+  align-items: center;
+  border-radius: 5px;
+  color: var(--secondary);
+  font-size: 12px;
+  text-align: left;
+}
+
+.agentRowMenu__item:hover,
+.agentRowMenu__item:focus-visible {
+  background: var(--ds-surface-hover);
+  color: var(--foreground);
+  outline: none;
 }
 
 .detailHeading {


### PR DESCRIPTION
## Summary
- make agent list rows fully clickable, navigating to the agent detail page; clicks on inline links, buttons, and text selections keep their own behavior
- replace the trailing chevron with a row actions menu that opens on hover or click, with View details and Edit agent entries
- flip the menu upward on the last row and sideways on a single-row table so the scrolling table container never clips it
- add an optional onRowClick to the DataTable design-system component with a pointer cursor on interactive rows, plus regression coverage

## Validation
- pnpm typecheck
- pnpm lint
- pnpm test
- pnpm build