### PR TITLE
Edit agents section by section

### DIFF
--- a/apps/control-plane/src/pages/agent-create.tsx
+++ b/apps/control-plane/src/pages/agent-create.tsx
@@ -508,7 +508,6 @@ export function AgentCreatePage() {
   const [connectionSettingsOpen, setConnectionSettingsOpen] = useState<
     AgentOptions["accounts"][number] | null
   >(null);
-  const [promptStepReady, setPromptStepReady] = useState(false);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [connectingProvider, setConnectingProvider] =
@@ -613,12 +612,6 @@ export function AgentCreatePage() {
     secretDialogOpen,
     vercelDialogOpen,
   ]);
-
-  useEffect(() => {
-    if (activeStep !== 4 || promptStepReady) return;
-    const timeout = window.setTimeout(() => setPromptStepReady(true), 500);
-    return () => window.clearTimeout(timeout);
-  }, [activeStep, promptStepReady]);
 
   useEffect(() => {
     let cancelled = false;
@@ -1285,7 +1278,6 @@ export function AgentCreatePage() {
 
   function showStep(step: CreateStep) {
     if (step > furthestStep) return;
-    if (step === 4) setPromptStepReady(false);
     setActiveStep(step);
     setError(null);
     window.scrollTo({ top: 0, behavior: "smooth" });
@@ -1298,7 +1290,6 @@ export function AgentCreatePage() {
     }
     if (activeStep === finalStep) return;
     const nextStep = (activeStep + 1) as CreateStep;
-    if (nextStep === 4) setPromptStepReady(false);
     setActiveStep(nextStep);
     setFurthestStep((current) =>
       Math.max(current, nextStep) as CreateStep
@@ -1315,13 +1306,8 @@ export function AgentCreatePage() {
   }
 
   async function saveConfiguration() {
-    // Editing saves the whole configuration from any section. The prompt
-    // guard still absorbs the double-click that lands where Continue was.
-    if (isEditing) {
-      if (activeStep === 4 && !promptStepReady) return;
-    } else if (activeStep !== finalStep) {
-      return;
-    }
+    // Editing saves the whole configuration from any section.
+    if (!isEditing && activeStep !== finalStep) return;
     if (missingRequirement) {
       setError(missingRequirement);
       const blockedStep: CreateStep = slackConnectionRequirement
@@ -1561,8 +1547,11 @@ export function AgentCreatePage() {
         >
           {steps.map((step) => {
             const current = activeStep === step.id;
-            const complete =
-              step.id < furthestStep && !stepRequirements[step.id];
+            // Editing has no step order: each marker reflects whether its
+            // section is complete right now.
+            const complete = isEditing
+              ? !stepRequirements[step.id]
+              : step.id < furthestStep && !stepRequirements[step.id];
             return (
               <button
                 aria-current={current ? "step" : undefined}
@@ -1579,7 +1568,7 @@ export function AgentCreatePage() {
                 type="button"
               >
                 <span className="createStepperStep__marker">
-                  {complete ? "✓" : step.id}
+                  {complete ? "✓" : isEditing ? "" : step.id}
                 </span>
                 <span className="createStepperStep__copy">
                   <strong>{step.title}</strong>
@@ -2922,26 +2911,20 @@ export function AgentCreatePage() {
                 Back
               </Button>
             )}
-            {activeStep < finalStep ? (
+            {!isEditing && activeStep < finalStep ? (
               <Button
                 disabled={Boolean(currentRequirement)}
                 onClick={continueToNextStep}
                 type="button"
-                variant={isEditing ? "secondary" : "primary"}
+                variant="primary"
               >
-                {!isEditing && activeStep === 2
-                  ? "Continue to context"
-                  : "Continue"}
+                {activeStep === 2 ? "Continue to context" : "Continue"}
               </Button>
             ) : null}
             {isEditing || activeStep === finalStep ? (
               <Button
                 data-submit-agent="true"
-                disabled={
-                  Boolean(missingRequirement) ||
-                  (isEditing && activeStep === 4 && !promptStepReady) ||
-                  saving
-                }
+                disabled={Boolean(missingRequirement) || saving}
                 loading={saving}
                 onClick={!isEditing ? () => void saveConfiguration() : undefined}
                 type={isEditing ? "submit" : "button"}

--- a/apps/control-plane/src/pages/agent-create.tsx
+++ b/apps/control-plane/src/pages/agent-create.tsx
@@ -1315,10 +1315,11 @@ export function AgentCreatePage() {
   }
 
   async function saveConfiguration() {
-    if (
-      activeStep !== finalStep ||
-      (isEditing && !promptStepReady)
-    ) {
+    // Editing saves the whole configuration from any section. The prompt
+    // guard still absorbs the double-click that lands where Continue was.
+    if (isEditing) {
+      if (activeStep === 4 && !promptStepReady) return;
+    } else if (activeStep !== finalStep) {
       return;
     }
     if (missingRequirement) {
@@ -2926,18 +2927,19 @@ export function AgentCreatePage() {
                 disabled={Boolean(currentRequirement)}
                 onClick={continueToNextStep}
                 type="button"
-                variant="primary"
+                variant={isEditing ? "secondary" : "primary"}
               >
                 {!isEditing && activeStep === 2
                   ? "Continue to context"
                   : "Continue"}
               </Button>
-            ) : (
+            ) : null}
+            {isEditing || activeStep === finalStep ? (
               <Button
                 data-submit-agent="true"
                 disabled={
                   Boolean(missingRequirement) ||
-                  (isEditing && !promptStepReady) ||
+                  (isEditing && activeStep === 4 && !promptStepReady) ||
                   saving
                 }
                 loading={saving}
@@ -2947,7 +2949,7 @@ export function AgentCreatePage() {
               >
                 {isEditing ? "Save changes" : "Create agent"}
               </Button>
-            )}
+            ) : null}
           </footer>
           )}
         </div>

--- a/apps/control-plane/src/pages/agent-create.tsx
+++ b/apps/control-plane/src/pages/agent-create.tsx
@@ -488,8 +488,11 @@ export function AgentCreatePage() {
     : initialStep;
   const [activeStep, setActiveStep] =
     useState<CreateStep>(normalizedInitialStep);
-  const [furthestStep, setFurthestStep] =
-    useState<CreateStep>(normalizedInitialStep);
+  // Editing an existing agent unlocks every section immediately; only the
+  // create flow walks steps sequentially.
+  const [furthestStep, setFurthestStep] = useState<CreateStep>(
+    isEditing ? 4 : normalizedInitialStep,
+  );
   const [githubDialogOpen, setGithubDialogOpen] = useState(githubJustConnected);
   const [vercelDialogOpen, setVercelDialogOpen] = useState(vercelJustConnected);
   const [vercelAccountId, setVercelAccountId] = useState(


### PR DESCRIPTION
## Summary
- Unlock all four sections of the agent edit page immediately, so any section can be opened directly from the sidebar instead of walking Continue → Continue → Continue.
- Save the full configuration from any section: Save changes replaces Continue in the edit footer, with the existing validation still routing to a blocked section when something is incomplete.
- Turn the edit sidebar markers into status indicators (green check when a section is complete, empty when not) and drop the step numbers; the create flow keeps its sequential numbered wizard unchanged.
- Remove the 500ms prompt-step save guard, which only existed to absorb double-clicks on the now-removed Continue button.

## Test plan
- pnpm typecheck, pnpm lint, pnpm test (873 passing), pnpm build
- Verified in the dev server against a configured agent: direct navigation between all sections on fresh load, saving from the Input section, marker/save-button reaction to clearing a required field, and the unchanged create flow at /agents/new