### PR TITLE
Use a shared Daytona sandbox snapshot

### DIFF
--- a/apps/worker/src/investigate.ts
+++ b/apps/worker/src/investigate.ts
@@ -66,8 +66,8 @@ import {
   closeDaytonaSandbox,
   configureDaytonaSandboxLifecycle,
   createDaytonaSandboxSession,
-  pauseDaytonaSandbox,
   prepareDaytonaSandbox,
+  pauseDaytonaSandbox,
 } from "./sandbox.js";
 import {
   investigationTraceEventFromStream,
@@ -633,7 +633,7 @@ export async function runInvestigationAgent(
         workspaceSecrets,
         threadMode ? -1 : 0,
       );
-      await prepareDaytonaSandbox(session);
+      if (!config.sandboxSnapshotName) await prepareDaytonaSandbox(session);
     }
     const repositories = sessionReady
       ? threadMode && job.refreshWorkspace

--- a/apps/worker/src/remediate.ts
+++ b/apps/worker/src/remediate.ts
@@ -196,7 +196,7 @@ export async function runRemediationAgent(
   try {
     session = await createDaytonaSandboxSession(client, config, sandboxName);
     await configureDaytonaSandboxLifecycle(session, config, workspaceSecrets);
-    await prepareDaytonaSandbox(session);
+    if (!config.sandboxSnapshotName) await prepareDaytonaSandbox(session);
     const repositories = await checkoutRuntimeRepositories(
       session,
       job.config.id,

--- a/apps/worker/src/review-pull-request.ts
+++ b/apps/worker/src/review-pull-request.ts
@@ -97,7 +97,7 @@ export async function runPullRequestReviewAgent(
   try {
     session = await createDaytonaSandboxSession(client, config, sandboxName);
     await configureDaytonaSandboxLifecycle(session, config, workspaceSecrets);
-    await prepareDaytonaSandbox(session);
+    if (!config.sandboxSnapshotName) await prepareDaytonaSandbox(session);
     const repositories = await checkoutRuntimeRepositoriesAtRefs(
       session,
       job.config.id,

--- a/apps/worker/src/sandbox.ts
+++ b/apps/worker/src/sandbox.ts
@@ -268,6 +268,10 @@ function execSucceeded(output: string): boolean {
   return /(?:^|\n)Process exited with code 0(?:\n|$)/u.test(output);
 }
 
+/**
+ * Install the small set of tools needed by agents when no prebuilt snapshot
+ * is configured. Named snapshots already contain these tools and skip this.
+ */
 export async function prepareDaytonaSandbox(
   session: DaytonaSandboxSession,
 ): Promise<void> {

--- a/packages/core/src/daytona-config.test.ts
+++ b/packages/core/src/daytona-config.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  daytonaClientOptions,
   isDaytonaNotFound,
   requireDaytonaClientConfig,
 } from "./daytona-config.js";
@@ -9,6 +10,7 @@ describe("Daytona client configuration", () => {
     expect(
       requireDaytonaClientConfig({
         DAYTONA_API_KEY: "api-key",
+        DAYTONA_SANDBOX_SNAPSHOT_NAME: "snapshot-name",
         DAYTONA_API_URL: " ",
         DAYTONA_TARGET: "",
       }),
@@ -16,6 +18,7 @@ describe("Daytona client configuration", () => {
       daytonaApiKey: "api-key",
       daytonaApiUrl: undefined,
       daytonaTarget: undefined,
+      sandboxSnapshotName: "snapshot-name",
     });
   });
 
@@ -23,9 +26,24 @@ describe("Daytona client configuration", () => {
     expect(
       requireDaytonaClientConfig({
         DAYTONA_API_KEY: "api-key",
+        DAYTONA_SANDBOX_SNAPSHOT_NAME: "snapshot-name",
         DAYTONA_API_URL: " https://daytona.example.test:8443/api ",
       }).daytonaApiUrl,
     ).toBe("https://daytona.example.test:8443/api");
+  });
+
+  it("passes the configured snapshot to Daytona clients", () => {
+    expect(
+      daytonaClientOptions({
+        daytonaApiKey: "api-key",
+        sandboxSnapshotName: "snapshot-name",
+      }),
+    ).toEqual({
+      apiKey: "api-key",
+      apiUrl: undefined,
+      sandboxSnapshotName: "snapshot-name",
+      target: undefined,
+    });
   });
 
   it.each([
@@ -36,6 +54,7 @@ describe("Daytona client configuration", () => {
     expect(() =>
       requireDaytonaClientConfig({
         DAYTONA_API_KEY: "api-key",
+        DAYTONA_SANDBOX_SNAPSHOT_NAME: "snapshot-name",
         DAYTONA_API_URL: daytonaApiUrl,
       }),
     ).toThrow("DAYTONA_API_URL must be an absolute HTTPS URL");
@@ -45,18 +64,21 @@ describe("Daytona client configuration", () => {
     expect(() =>
       requireDaytonaClientConfig({
         DAYTONA_API_KEY: "api-key",
+        DAYTONA_SANDBOX_SNAPSHOT_NAME: "snapshot-name",
         DAYTONA_API_URL: "https://user:password@daytona.example.test/api",
       }),
     ).toThrow("DAYTONA_API_URL cannot contain credentials");
     expect(() =>
       requireDaytonaClientConfig({
         DAYTONA_API_KEY: "api-key",
+        DAYTONA_SANDBOX_SNAPSHOT_NAME: "snapshot-name",
         DAYTONA_API_URL: "https://daytona.example.test/api#ignored",
       }),
     ).toThrow("DAYTONA_API_URL cannot contain a fragment");
     expect(() =>
       requireDaytonaClientConfig({
         DAYTONA_API_KEY: "api-key",
+        DAYTONA_SANDBOX_SNAPSHOT_NAME: "snapshot-name",
         DAYTONA_API_URL:
           "https://daytona.example.test/api?access_token=secret",
       }),

--- a/packages/core/src/daytona-config.ts
+++ b/packages/core/src/daytona-config.ts
@@ -2,6 +2,7 @@ export interface DaytonaClientConfig {
   daytonaApiKey: string;
   daytonaApiUrl?: string;
   daytonaTarget?: string;
+  sandboxSnapshotName?: string;
 }
 
 function optionalDaytonaApiUrl(value: string | undefined): string | undefined {
@@ -34,10 +35,12 @@ export function requireDaytonaClientConfig(
 ): DaytonaClientConfig {
   const daytonaApiKey = environment.DAYTONA_API_KEY;
   if (!daytonaApiKey) throw new Error("DAYTONA_API_KEY is required");
+  const sandboxSnapshotName = environment.DAYTONA_SANDBOX_SNAPSHOT_NAME?.trim();
   return {
     daytonaApiKey,
     daytonaApiUrl: optionalDaytonaApiUrl(environment.DAYTONA_API_URL),
     daytonaTarget: environment.DAYTONA_TARGET?.trim() || undefined,
+    sandboxSnapshotName,
   };
 }
 
@@ -55,10 +58,12 @@ export function daytonaClientOptions(config: DaytonaClientConfig): {
   apiKey: string;
   apiUrl?: string;
   target?: string;
+  sandboxSnapshotName?: string;
 } {
   return {
     apiKey: config.daytonaApiKey,
     apiUrl: config.daytonaApiUrl,
     target: config.daytonaTarget,
+    sandboxSnapshotName: config.sandboxSnapshotName,
   };
 }


### PR DESCRIPTION
Create and verify the shared `responder-base-2026-08-31` Daytona snapshot with Bun, Node.js, Python, ripgrep, and Git.

Pass `DAYTONA_SANDBOX_SNAPSHOT_NAME` through every agent sandbox client and skip runtime package installation when configured. Repository dependencies remain the agent's responsibility.

Verification: pnpm typecheck, pnpm lint, pnpm test.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables agent sandboxes to start from a shared Daytona snapshot, skipping runtime tool installation when the snapshot is configured.

- Adds `DAYTONA_SANDBOX_SNAPSHOT_NAME` to `DaytonaClientConfig` and passes it to client options.
- Skips `prepareDaytonaSandbox` when the snapshot is set, since it already includes Bun, Node.js, Python, ripgrep, and Git.
- Repository dependencies remain the agent's responsibility.

<sup>Written for commit a4332c51f3b79d65a6e1912cadc2cde3f5b1e632. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/responder-oss/pull/96?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

