### PR TITLE
Fix duplicate sign-in branding

### DIFF
--- a/apps/control-plane/src/components/auth-gate.tsx
+++ b/apps/control-plane/src/components/auth-gate.tsx
@@ -23,7 +23,6 @@ function AuthFrame({ children }: AuthGateProps) {
       <section className="authCard">
         <div className="authBrand">
           <img alt="Superlog" draggable={false} src="/superlog-wordmark.svg" />
-          <span>Superlog</span>
         </div>
         {children}
       </section>

--- a/apps/control-plane/src/styles.css
+++ b/apps/control-plane/src/styles.css
@@ -1696,13 +1696,6 @@ button:disabled {
 
 .authBrand {
   margin-bottom: 56px;
-  display: flex;
-  align-items: center;
-  gap: 9px;
-  color: var(--foreground);
-  font-size: 16px;
-  font-weight: 600;
-  letter-spacing: -0.018em;
 }
 
 .authBrand img {


### PR DESCRIPTION
## Summary
- remove the duplicate visible Superlog label from the sign-in wordmark
- remove the auth-brand text styling that is no longer needed

## Validation
- pnpm --dir open-core --filter @responder/control-plane typecheck

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the duplicate "Superlog" text label from the sign-in page so the branding shows only the wordmark image, and cleans up the now-unused label styling.

<sup>Written for commit d8ea0cd6d94a98c4260a624f8a43017cf246a5d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/responder-oss/pull/100?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

