### PR TITLE
Track Slack tag mode usage

### DIFF
--- a/apps/control-plane/server/index.test.ts
+++ b/apps/control-plane/server/index.test.ts
@@ -808,6 +808,7 @@ describe("control-plane API", () => {
         ts: "1700000006.000002",
         thread_ts: "1700000006.000001",
         user: "U123",
+        username: "Ada Lovelace",
         text: "<@U-RESPONDER> investigate checkout latency",
       },
     });
@@ -837,6 +838,7 @@ describe("control-plane API", () => {
           channelId: "C123",
           integrationAccountId: "04040404-0404-4404-8404-040404040404",
           slackUserId: "U123",
+          slackUserName: "Ada Lovelace",
           teamId: "T123",
           threadTimestamp: "1700000006.000001",
         }),

--- a/apps/control-plane/server/investigations/queue.test.ts
+++ b/apps/control-plane/server/investigations/queue.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   beginInvestigation: vi.fn(),
+  beginSlackThreadInvestigation: vi.fn(),
   bossSend: vi.fn(),
   bossStart: vi.fn(),
   bossStop: vi.fn(),
@@ -37,6 +38,7 @@ vi.mock("../../../../packages/core/src/billing/notifications.js", () => ({
 
 vi.mock("../../../../packages/core/src/db/investigations.js", () => ({
   beginInvestigation: mocks.beginInvestigation,
+  beginSlackThreadInvestigation: mocks.beginSlackThreadInvestigation,
   discardPendingInvestigation: mocks.discardPendingInvestigation,
   failInvestigation: mocks.failInvestigation,
   getRuntimeAgentConfig: mocks.getRuntimeAgentConfig,
@@ -71,6 +73,7 @@ vi.mock("../../../../packages/core/src/jobs.js", async (importOriginal) => {
 import {
   closeInvestigationQueue,
   queueInvestigation,
+  queueSlackThreadInvestigation,
   queueInvestigationRetry,
   queueIssueRemediation,
 } from "./queue.js";
@@ -117,6 +120,11 @@ describe("investigation queue", () => {
     await closeInvestigationQueue();
     vi.clearAllMocks();
     mocks.beginInvestigation.mockResolvedValue(created);
+    mocks.beginSlackThreadInvestigation.mockResolvedValue({
+      ...created,
+      configurationChanged: false,
+      slackInvestigationSessionId: "22222222-2222-4222-8222-222222222222",
+    });
     mocks.consumeInvestigation.mockResolvedValue({
       allowed: true,
       configured: false,
@@ -210,6 +218,50 @@ describe("investigation queue", () => {
     );
     expect(mocks.bossSend).not.toHaveBeenCalled();
     expect(mocks.captureAnalyticsEvent).not.toHaveBeenCalled();
+  });
+
+  it("captures Tag mode usage for a newly queued Slack turn", async () => {
+    const tagRequest = {
+      agentId: created.config.agentId,
+      attributes: {
+        channelId: "C123",
+        slackUserId: "U123",
+        slackUserName: "Ada Lovelace",
+        teamId: "T123",
+      },
+      body: "Investigate checkout latency",
+      externalEventId: "EvMention:agent-1",
+      provider: "slack" as const,
+      title: "Investigate checkout latency",
+    };
+    const thread = {
+      channelId: "C123",
+      teamId: "T123",
+      threadTimestamp: "1785500001.000200",
+    };
+
+    await expect(queueSlackThreadInvestigation(tagRequest, thread)).resolves.toEqual({
+      investigationId: created.investigationId,
+      jobId: "21212121-2121-4121-8121-212121212121",
+      kind: "queued",
+    });
+
+    expect(mocks.captureAnalyticsEvent).toHaveBeenCalledWith({
+      distinctId: "slack:T123:U123",
+      event: "tag mode used",
+      organizationId: created.config.organizationId,
+      properties: {
+        $process_person_profile: false,
+        agent_id: created.config.agentId,
+        channel_id: "C123",
+        investigation_id: created.investigationId,
+        slack_user_id: "U123",
+        user_name: "Ada Lovelace",
+        surface: "slack",
+        team_id: "T123",
+        thread_timestamp: "1785500001.000200",
+      },
+    });
   });
 
   it("charges and enqueues a rerun with its refreshed configuration", async () => {

--- a/apps/control-plane/server/investigations/queue.ts
+++ b/apps/control-plane/server/investigations/queue.ts
@@ -205,6 +205,30 @@ export async function queueSlackThreadInvestigation(
       { singletonKey: result.slackInvestigationSessionId },
     );
     if (!jobId) throw new Error("The Slack investigation turn was not created");
+    const slackUserId = typeof request.attributes?.slackUserId === "string"
+      ? request.attributes.slackUserId
+      : undefined;
+    const slackUserName = typeof request.attributes?.slackUserName === "string"
+      ? request.attributes.slackUserName
+      : undefined;
+    await captureAnalyticsEvent({
+      distinctId: slackUserId
+        ? `slack:${thread.teamId}:${slackUserId}`
+        : `investigation:${result.investigationId}`,
+      event: "tag mode used",
+      organizationId: result.config.organizationId,
+      properties: {
+        $process_person_profile: false,
+        agent_id: result.config.agentId,
+        channel_id: thread.channelId,
+        investigation_id: result.investigationId,
+        slack_user_id: slackUserId,
+        user_name: slackUserName,
+        surface: "slack",
+        team_id: thread.teamId,
+        thread_timestamp: thread.threadTimestamp,
+      },
+    });
     return { investigationId: result.investigationId, jobId, kind: "queued" };
   } catch (error) {
     await failInvestigation(

--- a/apps/control-plane/server/webhooks/slack.ts
+++ b/apps/control-plane/server/webhooks/slack.ts
@@ -431,6 +431,7 @@ async function forwardSlackEvent(input: {
   timestamp: string;
   threadMode?: boolean;
   userId?: string;
+  userName?: string;
 }) {
   const request = {
     agentId: input.agentId,
@@ -458,6 +459,7 @@ async function forwardSlackEvent(input: {
         ? {
             integrationAccountId: input.integrationAccountId,
             ...(input.userId ? { slackUserId: input.userId } : {}),
+            ...(input.userName ? { slackUserName: input.userName } : {}),
           }
         : {}),
       slackEventId: input.eventId,
@@ -919,6 +921,7 @@ export const slackWebhookRoutes = new Hono().post("/", async (context) => {
         timestamp: event.ts,
         threadMode: match.trigger === "slack_thread",
         userId: event.user,
+        userName: event.username?.trim() || undefined,
       });
       await recordInvestigationSlackSource(result.investigationId, {
         attachments: event.attachments ?? [],

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -18,6 +18,7 @@ activity can be separated from other products sharing the PostHog project.
 | `investigation created` | A new investigation or replay is persisted and accepted for processing | `investigation_id`, `agent_id`, `provider`, `is_replay`, `source_investigation_id` |
 | `investigation feedback submitted` | A Slack user rates a completed investigation response | `investigation_id`, `agent_id`, `feedback`, `organization_id`, `organization_name`, `slack_user_id`, `user_name`, `team_id`, `channel_id`, `surface` |
 | `investigation rerun` | A finished investigation is accepted for another run with the active Agent configuration | `investigation_id`, `agent_id`, `agent_config_version_id`, `provider` |
+| `tag mode used` | A new `@Responder` mention is accepted as a Tag mode investigation turn | `investigation_id`, `agent_id`, `slack_user_id`, `user_name`, `team_id`, `channel_id`, `thread_timestamp`, `surface`, `organization_name` |
 
 Events associated with a workspace include `organization_id` and the PostHog
 `organization` group. Authenticated events use the Better Auth user ID as their

--- a/packages/core/src/analytics.ts
+++ b/packages/core/src/analytics.ts
@@ -18,6 +18,7 @@ export interface AnalyticsEvent {
     | "pr opened"
     | "pr review addressed"
     | "prompt copied"
+    | "tag mode used"
     | "user signed up";
   organizationId?: string;
   properties?: Record<string, AnalyticsProperty>;


### PR DESCRIPTION
## What changed

Adds a dedicated `tag mode used` PostHog event for newly queued Slack Tag mode turns. The event includes workspace/organization context, agent and investigation IDs, Slack user and thread metadata, and avoids capturing message content. Slack retry duplicates are not counted.

## Validation

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test`
- [ ] `pnpm build` (not run; analytics-only change)
- [x] Added or updated focused tests
- [x] Checked migrations when the schema changed (no schema change)

## Risk and rollout

Analytics delivery remains non-blocking. Events are disabled when PostHog is not configured, and Slack user names are included only when Slack provides one.

## Assistance disclosure

Reviewed and validated with the repository test, typecheck, and lint suites.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `tag mode used` PostHog event whenever a new Slack Tag mode turn is queued, so Tag mode usage can be measured without affecting investigation delivery.

**Details**
- Captures org, agent, and investigation IDs plus Slack user, team, channel, and thread metadata; message content is not recorded.
- Slack retry duplicates do not trigger the event since it fires only for first-time queued turns.
- The event is skipped when PostHog is disabled, and the Slack username is included only when Slack provides one.

<sup>Written for commit ac3979416c0069bbd330c764f9dd66a1eea0c1be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/responder-oss/pull/101?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

