### PR TITLE
Fix repository skill loading for large files

### DIFF
--- a/apps/worker/src/repositories.ts
+++ b/apps/worker/src/repositories.ts
@@ -20,6 +20,7 @@ import {
 const defaultMaxArchiveBytes = 5 * 1024 * 1024 * 1024;
 const repositoryDownloadTimeoutMs = 10 * 60_000;
 const repositoryUploadTimeoutSeconds = 30 * 60;
+const repositoryFileDownloadTimeoutSeconds = 30 * 60;
 const workspaceRoot = "/home/daytona/workspace";
 const execFileAsync = promisify(execFile);
 
@@ -323,6 +324,32 @@ async function uploadRepositoryArchive(
     await sandbox.fs.uploadFileStream(localPath, remotePath, {
       timeout: repositoryUploadTimeoutSeconds,
     });
+  } finally {
+    await client[Symbol.asyncDispose]().catch(() => undefined);
+  }
+}
+
+/**
+ * Download repository content through Daytona's filesystem API. The sandbox
+ * editor's readFile implementation streams a file through a command output
+ * buffer, which is unsuitable for arbitrarily-sized repository files.
+ */
+export async function downloadRepositoryFile(
+  session: DaytonaSandboxSession,
+  remotePath: string,
+): Promise<Uint8Array> {
+  const { apiKey, apiUrl, sandboxId, target } = session.state;
+  if (!apiKey) throw new Error("Daytona API key is unavailable for file download");
+
+  const client = new Daytona({ apiKey, apiUrl, target });
+  try {
+    const sandbox = await client.get(sandboxId);
+    return Uint8Array.from(
+      await sandbox.fs.downloadFile(
+        remotePath,
+        repositoryFileDownloadTimeoutSeconds,
+      ),
+    );
   } finally {
     await client[Symbol.asyncDispose]().catch(() => undefined);
   }

--- a/apps/worker/src/repository-skills.test.ts
+++ b/apps/worker/src/repository-skills.test.ts
@@ -1,0 +1,66 @@
+import type { DaytonaSandboxSession } from "@openai/agents-extensions/sandbox/daytona";
+import { describe, expect, it, vi } from "vitest";
+import { loadRepositorySkills } from "./repository-skills.js";
+
+const repository = {
+  branch: "main",
+  path: "/home/daytona/workspace/repositories/example/repo",
+  repository: "example/repo",
+  sha: "a".repeat(40),
+  workspaceBaseSha: "a".repeat(40),
+};
+
+function commandResponse(output: string, exitCode = 0): string {
+  return `Process exited with ${exitCode}\nOutput:\n${output}`;
+}
+
+function sessionForSkillFile(options?: { readError?: Error }) {
+  const execCommand = vi.fn().mockResolvedValue(
+    commandResponse(
+      `${repository.path}/.agents/skills/example/SKILL.md\n${repository.path}/.agents/skills/example/references/guide.md`,
+    ),
+  );
+  const downloadFile = options?.readError
+    ? vi.fn().mockRejectedValue(options.readError)
+    : vi.fn().mockResolvedValue(new TextEncoder().encode("skill instructions"));
+  const session = {
+    execCommand,
+    pathExists: vi.fn((path: string) =>
+      Promise.resolve(path.endsWith("/.agents/skills")),
+    ),
+  } as unknown as DaytonaSandboxSession;
+  return { downloadFile, session };
+}
+
+describe("repository skill loading", () => {
+  it("downloads every skill file without going through the editor", async () => {
+    const { downloadFile, session } = sessionForSkillFile();
+
+    await expect(
+      loadRepositorySkills(session, [repository], { downloadFile }),
+    ).resolves.toBeDefined();
+
+    expect(downloadFile).toHaveBeenCalledTimes(2);
+    expect(downloadFile).toHaveBeenNthCalledWith(
+      1,
+      session,
+      `${repository.path}/.agents/skills/example/SKILL.md`,
+    );
+    expect(downloadFile).toHaveBeenNthCalledWith(
+      2,
+      session,
+      `${repository.path}/.agents/skills/example/references/guide.md`,
+    );
+  });
+
+  it("reports the original skill path when a bounded read fails", async () => {
+    const readError = new Error("permission denied");
+    const { downloadFile, session } = sessionForSkillFile({ readError });
+
+    await expect(
+      loadRepositorySkills(session, [repository], { downloadFile }),
+    ).rejects.toThrow(
+        `Unable to read repository skill file ${repository.path}/.agents/skills/example/SKILL.md: permission denied`,
+      );
+  });
+});

--- a/apps/worker/src/repository-skills.ts
+++ b/apps/worker/src/repository-skills.ts
@@ -1,13 +1,38 @@
 import { dir, file, type Dir, type Entry } from "@openai/agents/sandbox";
 import type { DaytonaSandboxSession } from "@openai/agents-extensions/sandbox/daytona";
 import { dirname, relative } from "node:path";
-import type { CheckedOutRepository } from "./repositories.js";
+import {
+  downloadRepositoryFile,
+  type CheckedOutRepository,
+} from "./repositories.js";
 
 const skillRoots = [".agents/skills", ".claude/skills"] as const;
-const maxSkillFileBytes = 512_000;
+
+export interface RepositorySkillsDependencies {
+  downloadFile: typeof downloadRepositoryFile;
+}
+
+const defaultDependencies: RepositorySkillsDependencies = {
+  downloadFile: downloadRepositoryFile,
+};
 
 function commandSucceeded(output: string): boolean {
-  return /(?:^|\n)Process exited with code 0(?:\n|$)/u.test(output);
+  return output.includes("Process exited with 0");
+}
+
+async function readSkillFile(
+  session: DaytonaSandboxSession,
+  path: string,
+  dependencies: RepositorySkillsDependencies,
+): Promise<Uint8Array> {
+  try {
+    return await dependencies.downloadFile(session, path);
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(`Unable to read repository skill file ${path}: ${detail}`, {
+      cause: error,
+    });
+  }
 }
 
 async function findFiles(
@@ -28,6 +53,7 @@ async function readDirectoryEntry(
   session: DaytonaSandboxSession,
   path: string,
   files: string[],
+  dependencies: RepositorySkillsDependencies,
 ): Promise<Dir> {
   const children: Record<string, Entry> = {};
   const directFiles = new Map<string, string>();
@@ -44,10 +70,7 @@ async function readDirectoryEntry(
   }
   for (const [name, childPath] of directFiles) {
     children[name] = file({
-      content: await session.readFile({
-        path: childPath,
-        maxBytes: maxSkillFileBytes,
-      }),
+      content: await readSkillFile(session, childPath, dependencies),
     });
   }
   for (const name of directDirectories) {
@@ -55,7 +78,12 @@ async function readDirectoryEntry(
     const nestedFiles = files.filter((candidate) =>
       candidate.startsWith(`${nestedPath}/`),
     );
-    children[name] = await readDirectoryEntry(session, nestedPath, nestedFiles);
+    children[name] = await readDirectoryEntry(
+      session,
+      nestedPath,
+      nestedFiles,
+      dependencies,
+    );
   }
   return dir({ children });
 }
@@ -63,6 +91,7 @@ async function readDirectoryEntry(
 export async function loadRepositorySkills(
   session: DaytonaSandboxSession,
   repositories: CheckedOutRepository[],
+  dependencies: RepositorySkillsDependencies = defaultDependencies,
 ): Promise<Dir | undefined> {
   const skills: Record<string, Entry> = {};
   const usedNames = new Set<string>();
@@ -88,6 +117,7 @@ export async function loadRepositorySkills(
           session,
           skillDirectory,
           files.filter((path) => path.startsWith(`${skillDirectory}/`)),
+          dependencies,
         );
       }
     }


### PR DESCRIPTION
Repository skills are already checked out in Daytona, but loading them through the remote editor can fail when the editor command buffers a large file. Download skill files through Daytona's filesystem API instead, preserving full content and retaining the original path in errors.

Adds regression coverage for nested skill files and read failures.

Fixes RESPONDER-PROD-Y

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes repository skill loading for large files. Previously, skill files were read through the editor's command buffer, which could truncate large files. Now they are downloaded via Daytona's filesystem API, and errors preserve the original skill path. Adds regression coverage for nested skill files and read failures. Fixes RESPONDER-PROD-Y.

<sup>Written for commit 086be63a7c12f12e11bd866218a581eea8492220. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/responder-oss/pull/102?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

