### PR TITLE
Increase investigation turn limit to 40

### DIFF
--- a/apps/worker/src/investigate.test.ts
+++ b/apps/worker/src/investigate.test.ts
@@ -4,6 +4,7 @@ import {
   contextServerConnectFailureEvent,
   initialInvestigationMessage,
   investigationCapabilities,
+  investigationMaxTurns,
   investigationInstructions,
   investigationInstructionsTraceEvent,
   investigationTraceWriteFailure,
@@ -13,6 +14,10 @@ import {
 } from "./investigate.js";
 
 describe("sandbox agent configuration", () => {
+  it("allows forty model turns for investigations", () => {
+    expect(investigationMaxTurns).toBe(40);
+  });
+
   it("identifies the custom MCP account when its server cannot connect", () => {
     expect(
       contextServerConnectFailureEvent({

--- a/apps/worker/src/investigate.ts
+++ b/apps/worker/src/investigate.ts
@@ -263,6 +263,8 @@ export function investigationCapabilities(replay: boolean) {
   return Capabilities.default();
 }
 
+export const investigationMaxTurns = 40;
+
 export function investigationInstructions(input: {
   agentPrompt: string;
   awsAlarmTriggered?: boolean;
@@ -732,7 +734,7 @@ export async function runInvestigationAgent(
       agent,
       initialMessage.message,
       {
-        maxTurns: 20,
+        maxTurns: investigationMaxTurns,
         sandbox: { session },
         stream: true,
         ...(sessionRuntime?.previousResponseId


### PR DESCRIPTION
Raises the investigation run turn limit from 20 to 40.

The limit is exposed as a named constant and covered by a focused worker test.

Validation:
- pnpm --dir open-core exec vitest run apps/worker/src/investigate.test.ts
- pnpm --dir open-core typecheck
- pnpm --dir open-core lint

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raises the investigation run turn limit from 20 to 40 so agents have more room to complete them.

- Exposes the limit as `investigationMaxTurns` and adds a worker test asserting the value.

<sup>Written for commit 4533fd4e77fbb4a989644d91398480afc9360f29. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/responder-oss/pull/103?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

