### PR TITLE
Add DPA, security, and subprocessors page routes

### DIFF
--- a/apps/control-plane/src/app.tsx
+++ b/apps/control-plane/src/app.tsx
@@ -13,10 +13,13 @@ import { editionSeoMetadataForPath } from "./edition-metadata";
 import {
   BlogArticlePage,
   BlogIndexPage,
+  DpaPage,
   HomePage,
   PrivacyPage,
   PricingPage,
   ProductUpdateArticlePage,
+  SecurityPage,
+  SubprocessorsPage,
   TeamPage,
   TermsPage,
 } from "./edition-pages";
@@ -52,6 +55,9 @@ export function App() {
       <Route element={<TeamPage />} path="/team" />
       <Route element={<PrivacyPage />} path="/privacy" />
       <Route element={<TermsPage />} path="/tos" />
+      <Route element={<DpaPage />} path="/dpa" />
+      <Route element={<SecurityPage />} path="/security" />
+      <Route element={<SubprocessorsPage />} path="/subprocessors" />
       <Route
         element={<BlogArticlePage />}
         path={blogArticlePath}

--- a/apps/control-plane/src/edition-pages.tsx
+++ b/apps/control-plane/src/edition-pages.tsx
@@ -32,3 +32,15 @@ export function PrivacyPage() {
 export function TermsPage() {
   return <Navigate replace to="/agents" />;
 }
+
+export function DpaPage() {
+  return <Navigate replace to="/agents" />;
+}
+
+export function SecurityPage() {
+  return <Navigate replace to="/agents" />;
+}
+
+export function SubprocessorsPage() {
+  return <Navigate replace to="/agents" />;
+}


### PR DESCRIPTION
Adds /dpa, /security, and /subprocessors routes backed by edition pages, so hosted editions can publish the legal pages that the terms of service references. The default edition redirects all three to /agents, matching the existing public-page pattern.

Pairs with the hosted overlay PR in superloglabs/responder that implements the pages; merge this one first, then the overlay's gitlink bump.