### PR TITLE
Recover existing integration credentials

### DIFF
--- a/apps/control-plane/server/integrations/providers.test.ts
+++ b/apps/control-plane/server/integrations/providers.test.ts
@@ -1,3 +1,4 @@
+import { createHmac } from "node:crypto";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const dnsMocks = vi.hoisted(() => ({
@@ -27,7 +28,11 @@ import {
   githubAuthorizeUrl,
   githubInstallUrl,
 } from "./github.js";
-import { listSentryProjects, sentryInstallUrl } from "./sentry.js";
+import {
+  listSentryProjects,
+  refreshSentryGrant,
+  sentryInstallUrl,
+} from "./sentry.js";
 import {
   exchangeSlackCode,
   joinSlackChannel,
@@ -501,6 +506,59 @@ describe("integration providers", () => {
       "https://sentry.io/sentry-apps/responder-test/external-install/",
     );
     expect(url.searchParams.get("state")).toBe("state-token");
+  });
+
+  it("recovers an existing Sentry installation with a client-secret JWT", async () => {
+    vi.stubEnv("SENTRY_APP_SLUG", "responder-test");
+    vi.stubEnv("SENTRY_CLIENT_ID", "sentry-client");
+    vi.stubEnv("SENTRY_CLIENT_SECRET", "sentry-secret");
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(null, { status: 401 }))
+      .mockResolvedValueOnce(
+        Response.json({
+          id: "1",
+          token: "fresh-token",
+          refreshToken: "fresh-refresh-token",
+          expiresAt: "2026-09-01T12:00:00Z",
+        }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      refreshSentryGrant({
+        installationId: "40000000-0000-4000-8000-000000000000",
+        refreshToken: "revoked-refresh-token",
+      }),
+    ).resolves.toMatchObject({ token: "fresh-token" });
+
+    const [, manualRequest] = fetchMock.mock.calls;
+    const jwt = (manualRequest[1].headers.authorization as string).slice(7);
+    const [encodedHeader, encodedPayload, encodedSignature] = jwt.split(".");
+    expect(JSON.parse(Buffer.from(encodedHeader, "base64url").toString())).toEqual({
+      alg: "HS256",
+      typ: "JWT",
+    });
+    const jwtPayload = JSON.parse(
+      Buffer.from(encodedPayload, "base64url").toString(),
+    );
+    expect(jwtPayload).toEqual(
+      expect.objectContaining({
+        exp: expect.any(Number),
+        iat: expect.any(Number),
+        iss: "sentry-client",
+        jti: expect.any(String),
+      }),
+    );
+    expect(jwtPayload.exp - jwtPayload.iat).toBe(60);
+    expect(encodedSignature).toBe(
+      createHmac("sha256", "sentry-secret")
+        .update(`${encodedHeader}.${encodedPayload}`)
+        .digest("base64url"),
+    );
+    expect(JSON.parse(manualRequest[1].body as string)).toEqual({
+      grant_type: "client_secret_jwt",
+    });
   });
 
   it("follows trusted regional Sentry project pagination", async () => {

--- a/apps/control-plane/server/integrations/routes.test.ts
+++ b/apps/control-plane/server/integrations/routes.test.ts
@@ -189,7 +189,7 @@ describe("integration callback routing", () => {
     });
   });
 
-  it("starts a fresh Sentry authorization when reconnecting", async () => {
+  it("tries automatic Sentry recovery before fresh authorization", async () => {
     vi.stubEnv("BETTER_AUTH_URL", "https://responder.example");
     vi.stubEnv("SENTRY_APP_SLUG", "responder-test");
     vi.stubEnv("SENTRY_CLIENT_ID", "sentry-client");
@@ -203,7 +203,9 @@ describe("integration callback routing", () => {
     expect(response.status).toBe(302);
     expect(new URL(response.headers.get("location")!).searchParams.get("state"))
       .toBe("fresh-state");
-    expect(getRecoverableSentryIntegrationAccount).not.toHaveBeenCalled();
+    expect(getRecoverableSentryIntegrationAccount).toHaveBeenCalledWith(
+      tenant.organizationId,
+    );
   });
 
   it("falls back to fresh Sentry authorization when an old retry fails", async () => {
@@ -294,6 +296,68 @@ describe("integration callback routing", () => {
     });
   });
 
+  it("recovers a revoked Sentry token during a connection check", async () => {
+    vi.stubEnv("SENTRY_APP_SLUG", "responder-test");
+    vi.stubEnv("SENTRY_CLIENT_ID", "sentry-client");
+    vi.stubEnv("SENTRY_CLIENT_SECRET", "sentry-secret");
+    vi.mocked(listConnectedSentryIntegrationAccounts).mockResolvedValue([
+      {
+        id: "30000000-0000-4000-8000-000000000000",
+        encryptedCredentials: "encrypted-credentials",
+        metadata: { organizationSlug: "example" },
+      },
+    ]);
+    vi.mocked(decryptCredentials).mockReturnValue({
+      accessToken: "revoked-token",
+      expiresAt: "2099-01-01T00:00:00.000Z",
+      installationId: "40000000-0000-4000-8000-000000000000",
+      refreshToken: "revoked-refresh-token",
+    });
+    vi.mocked(encryptCredentials).mockReturnValue("recovered-credentials");
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(null, { status: 401 }))
+      .mockResolvedValueOnce(new Response(null, { status: 401 }))
+      .mockResolvedValueOnce(
+        Response.json({
+          id: "1",
+          token: "recovered-token",
+          refreshToken: "recovered-refresh-token",
+          expiresAt: "2099-01-01T01:00:00.000Z",
+        }),
+      )
+      .mockResolvedValueOnce(
+        Response.json([
+          { id: "1", name: "Backend", platform: "node", slug: "backend" },
+        ]),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await app.request("/api/integrations/sentry/check", {
+      method: "POST",
+    });
+
+    expect(await response.json()).toEqual({
+      accounts: [
+        {
+          id: "30000000-0000-4000-8000-000000000000",
+          resourceCount: 1,
+          status: "working",
+        },
+      ],
+    });
+    expect(fetchMock.mock.calls[2]?.[1]?.headers.authorization).toMatch(
+      /^Bearer /,
+    );
+    expect(replaceIntegrationResourcesIfCredentialsMatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        encryptedCredentials: "recovered-credentials",
+        integrationAccountId: "30000000-0000-4000-8000-000000000000",
+      }),
+    );
+    expect(setIntegrationAccountStatusIfCredentialsMatch).not.toHaveBeenCalled();
+  });
+
   it("discards a Sentry check superseded by reconnect", async () => {
     vi.mocked(listConnectedSentryIntegrationAccounts).mockResolvedValue([
       {
@@ -336,6 +400,9 @@ describe("integration callback routing", () => {
   });
 
   it("marks a Sentry account for reconnect after a live authorization failure", async () => {
+    vi.stubEnv("SENTRY_APP_SLUG", "responder-test");
+    vi.stubEnv("SENTRY_CLIENT_ID", "sentry-client");
+    vi.stubEnv("SENTRY_CLIENT_SECRET", "sentry-secret");
     vi.mocked(listConnectedSentryIntegrationAccounts).mockResolvedValue([
       {
         id: "30000000-0000-4000-8000-000000000000",
@@ -902,7 +969,7 @@ describe("integration callback routing", () => {
     );
   });
 
-  it("offers a fresh Sentry reconnect when an account already exists", async () => {
+  it("offers automatic Sentry recovery when an account already exists", async () => {
     vi.stubEnv("SENTRY_APP_SLUG", "responder-test");
     vi.stubEnv("SENTRY_CLIENT_ID", "sentry-client");
     vi.stubEnv("SENTRY_CLIENT_SECRET", "sentry-secret");
@@ -926,7 +993,7 @@ describe("integration callback routing", () => {
     expect(body.integrations).toContainEqual(
       expect.objectContaining({
         id: "sentry",
-        connectUrl: "/api/integrations/sentry/start?mode=reconnect",
+        connectUrl: "/api/integrations/sentry/start",
       }),
     );
   });

--- a/apps/control-plane/server/integrations/routes.ts
+++ b/apps/control-plane/server/integrations/routes.ts
@@ -437,6 +437,7 @@ async function retrySentrySetup(organizationId: string): Promise<{
     const fresh = await getFreshSentryCredentials({
       accountId: account.id,
       allowedStatuses: ["connected", "error", "pending"],
+      forceRefresh: true,
       organizationId,
     });
     expectedEncryptedCredentials = fresh.encryptedCredentials;
@@ -470,6 +471,7 @@ async function retrySentrySetup(organizationId: string): Promise<{
 async function getFreshSentryCredentials(input: {
   accountId: string;
   allowedStatuses?: Array<"connected" | "error" | "pending">;
+  forceRefresh?: boolean;
   organizationId: string;
 }) {
   const fresh = await withIntegrationAccountCredentialLease({
@@ -488,7 +490,11 @@ async function getFreshSentryCredentials(input: {
       const expiresAt = current.expiresAt
         ? Date.parse(current.expiresAt)
         : Number.POSITIVE_INFINITY;
-      if (Number.isFinite(expiresAt) && expiresAt > Date.now() + 60_000) {
+      if (
+        !input.forceRefresh &&
+        Number.isFinite(expiresAt) &&
+        expiresAt > Date.now() + 60_000
+      ) {
         return {
           value: { credentials: current, encryptedCredentials },
         };
@@ -590,7 +596,7 @@ export const integrationRoutes = new Hono()
                 : definition.id === "github" && providerAccounts.length === 0
                   ? "/api/integrations/github/start?mode=install"
                 : definition.id === "sentry" && providerAccounts.length > 0
-                  ? "/api/integrations/sentry/start?mode=reconnect"
+                  ? "/api/integrations/sentry/start"
                   : `/api/integrations/${definition.id}/start`
               : null,
           configurationUrl:
@@ -630,10 +636,25 @@ export const integrationRoutes = new Hono()
           });
           expectedEncryptedCredentials = fresh.encryptedCredentials;
           const organizationSlug = getSentryOrganizationSlug(account.metadata);
-          const projects = await listSentryProjects(
-            fresh.credentials.accessToken,
-            organizationSlug,
-          );
+          let projects;
+          try {
+            projects = await listSentryProjects(
+              fresh.credentials.accessToken,
+              organizationSlug,
+            );
+          } catch (error) {
+            if (!sentryErrorNeedsReconnect(error)) throw error;
+            const recovered = await getFreshSentryCredentials({
+              accountId: account.id,
+              forceRefresh: true,
+              organizationId: tenant.organizationId,
+            });
+            expectedEncryptedCredentials = recovered.encryptedCredentials;
+            projects = await listSentryProjects(
+              recovered.credentials.accessToken,
+              organizationSlug,
+            );
+          }
           const updated = await replaceIntegrationResourcesIfCredentialsMatch({
             encryptedCredentials: expectedEncryptedCredentials,
             integrationAccountId: account.id,
@@ -723,10 +744,7 @@ export const integrationRoutes = new Hono()
         405,
       );
     }
-    if (
-      parsedProvider.data === "sentry" &&
-      context.req.query("mode") !== "reconnect"
-    ) {
+    if (parsedProvider.data === "sentry") {
       try {
         const retriedAccount = await retrySentrySetup(tenant.organizationId);
         if (retriedAccount) {

--- a/apps/control-plane/server/integrations/sentry.ts
+++ b/apps/control-plane/server/integrations/sentry.ts
@@ -1,3 +1,4 @@
+import { createHmac, randomUUID } from "node:crypto";
 import { z } from "zod";
 
 const SENTRY_REQUEST_TIMEOUT_MS = 10_000;
@@ -54,6 +55,32 @@ export function sentryInstallUrl(state: string): string {
   return url.toString();
 }
 
+function base64Url(value: string | Uint8Array): string {
+  return Buffer.from(value)
+    .toString("base64")
+    .replaceAll("+", "-")
+    .replaceAll("/", "_")
+    .replaceAll("=", "");
+}
+
+function sentryClientSecretJwt(clientId: string, clientSecret: string): string {
+  const issuedAt = Math.floor(Date.now() / 1_000);
+  const encodedHeader = base64Url(JSON.stringify({ alg: "HS256", typ: "JWT" }));
+  const encodedPayload = base64Url(
+    JSON.stringify({
+      exp: issuedAt + 60,
+      iat: issuedAt,
+      iss: clientId,
+      jti: randomUUID(),
+    }),
+  );
+  const signingInput = `${encodedHeader}.${encodedPayload}`;
+  const signature = createHmac("sha256", clientSecret)
+    .update(signingInput)
+    .digest();
+  return `${signingInput}.${base64Url(signature)}`;
+}
+
 export async function exchangeSentryGrant(input: {
   code: string;
   installationId: string;
@@ -91,31 +118,59 @@ export async function refreshSentryGrant(input: {
   refreshToken: string;
 }) {
   const { clientId, clientSecret } = sentryEnvironment();
-  const response = await fetch(
-    `https://sentry.io/api/0/sentry-app-installations/${encodeURIComponent(input.installationId)}/authorizations/`,
-    {
-      method: "POST",
-      signal: AbortSignal.timeout(SENTRY_REQUEST_TIMEOUT_MS),
-      headers: {
-        accept: "application/json",
-        "content-type": "application/json",
-      },
-      body: JSON.stringify({
-        grant_type: "refresh_token",
-        refresh_token: input.refreshToken,
-        client_id: clientId,
-        client_secret: clientSecret,
-      }),
+  const authorizationUrl =
+    `https://sentry.io/api/0/sentry-app-installations/${encodeURIComponent(input.installationId)}/authorizations/`;
+  const response = await fetch(authorizationUrl, {
+    method: "POST",
+    signal: AbortSignal.timeout(SENTRY_REQUEST_TIMEOUT_MS),
+    headers: {
+      accept: "application/json",
+      "content-type": "application/json",
     },
-  );
-  if (!response.ok) {
+    body: JSON.stringify({
+      grant_type: "refresh_token",
+      refresh_token: input.refreshToken,
+      client_id: clientId,
+      client_secret: clientSecret,
+    }),
+  });
+  if (response.ok) {
+    return sentryAuthorizationSchema.parse(await response.json());
+  }
+
+  // Sentry can revoke a refresh token while leaving the installation in place
+  // (for example after an administrator changes the app's access). A client
+  // secret JWT refreshes the existing installation token without requiring an
+  // uninstall/reinstall cycle. Only use it for authorization failures; a
+  // timeout or provider outage should remain retryable as-is.
+  if (response.status !== 401 && response.status !== 403) {
     throw new SentryApiError(
       "Unable to refresh Sentry access",
       response.status,
       "authorization",
     );
   }
-  return sentryAuthorizationSchema.parse(await response.json());
+
+  const manualResponse = await fetch(authorizationUrl, {
+    method: "POST",
+    signal: AbortSignal.timeout(SENTRY_REQUEST_TIMEOUT_MS),
+    headers: {
+      accept: "application/json",
+      "content-type": "application/json",
+      authorization: `Bearer ${sentryClientSecretJwt(clientId, clientSecret)}`,
+    },
+    body: JSON.stringify({
+      grant_type: "client_secret_jwt",
+    }),
+  });
+  if (!manualResponse.ok) {
+    throw new SentryApiError(
+      "Unable to refresh Sentry access",
+      manualResponse.status,
+      "authorization",
+    );
+  }
+  return sentryAuthorizationSchema.parse(await manualResponse.json());
 }
 
 function nextSentryPage(linkHeader: string | null): string | null {

--- a/apps/control-plane/src/pages/agent-create.tsx
+++ b/apps/control-plane/src/pages/agent-create.tsx
@@ -1453,6 +1453,7 @@ export function AgentCreatePage() {
     if (integration.id === "slack") return false;
     if (
       integration.accountCount > 0 &&
+      integration.id !== "sentry" &&
       !MULTI_ACCOUNT_CONTEXT_PROVIDERS.has(integration.id)
     ) {
       return false;

--- a/apps/control-plane/src/pages/tag-mode-settings.tsx
+++ b/apps/control-plane/src/pages/tag-mode-settings.tsx
@@ -227,6 +227,7 @@ export function TagModeSettingsPage() {
     if (integration.id === "slack") return false;
     if (
       integration.accountCount > 0 &&
+      integration.id !== "sentry" &&
       !multiAccountContextProviders.has(integration.id)
     ) {
       return false;


### PR DESCRIPTION
## Summary\n- recover existing Sentry installations with a short-lived client-secret JWT when refresh tokens are revoked\n- retry connection checks before marking accounts broken\n- keep errored Sentry accounts visible in integration context pickers\n\n## Validation\n- pnpm --dir open-core typecheck\n- pnpm --dir open-core lint\n- pnpm --dir open-core test

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recovers existing Sentry installations instead of forcing a full reinstall when refresh tokens are revoked, and keeps errored accounts visible in integration context pickers.

- Restores Sentry access tokens with a short-lived client-secret JWT when a refresh token returns 401/403.
- Retries connection checks once before marking an account broken; only a failed retry marks it for reconnect.
- Keeps errored Sentry accounts selectable in agent and tag-mode context pickers.
- Reconnect now triggers automatic recovery first, so the `?mode=reconnect` start URL is no longer needed.

<sup>Written for commit 1a9b455f5365c210fbf89e6593dc0c072949b6de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/responder-oss/pull/105?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

