### PR TITLE
Refresh existing Sentry installations

### DIFF
--- a/apps/control-plane/server/integrations/routes.test.ts
+++ b/apps/control-plane/server/integrations/routes.test.ts
@@ -208,6 +208,57 @@ describe("integration callback routing", () => {
     );
   });
 
+  it("refreshes an existing connected Sentry installation before fresh authorization", async () => {
+    vi.stubEnv("BETTER_AUTH_URL", "https://responder.example");
+    vi.stubEnv("SENTRY_APP_SLUG", "responder-test");
+    vi.stubEnv("SENTRY_CLIENT_ID", "sentry-client");
+    vi.stubEnv("SENTRY_CLIENT_SECRET", "sentry-secret");
+    vi.mocked(getRecoverableSentryIntegrationAccount).mockResolvedValue({
+      id: "30000000-0000-4000-8000-000000000000",
+      encryptedCredentials: "encrypted-credentials",
+      externalAccountId: "40000000-0000-4000-8000-000000000000",
+      metadata: { organizationSlug: "example" },
+    });
+    vi.mocked(decryptCredentials).mockReturnValue({
+      accessToken: "old-token",
+      expiresAt: "2099-01-01T00:00:00.000Z",
+      installationId: "40000000-0000-4000-8000-000000000000",
+      refreshToken: "old-refresh-token",
+    });
+    vi.mocked(encryptCredentials).mockReturnValue("refreshed-credentials");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn()
+        .mockResolvedValueOnce(
+          Response.json({
+            id: "1",
+            token: "new-token",
+            refreshToken: "new-refresh-token",
+            expiresAt: "2099-01-01T01:00:00.000Z",
+          }),
+        )
+        .mockResolvedValueOnce(
+          Response.json([
+            { id: "1", name: "Backend", platform: "node", slug: "backend" },
+          ]),
+        )
+        .mockResolvedValueOnce(new Response(null, { status: 200 })),
+    );
+
+    const response = await app.request("/api/integrations/sentry/start");
+
+    expect(response.status).toBe(302);
+    expect(new URL(response.headers.get("location")!).searchParams.get("status"))
+      .toBe("connected");
+    expect(createIntegrationConnectionState).not.toHaveBeenCalled();
+    expect(replaceIntegrationResourcesIfCredentialsMatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        encryptedCredentials: "refreshed-credentials",
+        integrationAccountId: "30000000-0000-4000-8000-000000000000",
+      }),
+    );
+  });
+
   it("falls back to fresh Sentry authorization when an old retry fails", async () => {
     vi.stubEnv("BETTER_AUTH_URL", "https://responder.example");
     vi.stubEnv("SENTRY_APP_SLUG", "responder-test");

--- a/packages/core/src/db/integrations.ts
+++ b/packages/core/src/db/integrations.ts
@@ -459,7 +459,11 @@ export async function getRecoverableSentryIntegrationAccount(
       and(
         eq(integrationAccounts.organizationId, organizationId),
         eq(integrationAccounts.provider, "sentry"),
-        inArray(integrationAccounts.status, ["pending", "error"]),
+        // A reconnect can be requested while the account is still marked
+        // connected (for example when the provider revoked its refresh
+        // token). Keep the existing installation eligible so the route can
+        // refresh it in place instead of starting a duplicate install flow.
+        inArray(integrationAccounts.status, ["connected", "pending", "error"]),
         isNotNull(integrationAccounts.encryptedCredentials),
       ),
     )


### PR DESCRIPTION
When a Sentry account is already installed and marked connected, reconnect currently skips recovery and opens Sentry's duplicate-install page. Include connected accounts in the recoverable lookup so reconnect refreshes the existing installation in place. Adds a route regression test.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reconnect now refreshes an existing connected Sentry installation instead of sending the user to Sentry's duplicate-install page. Previously, reconnect skipped recovery for accounts already marked connected, so we now include connected accounts in the recoverable lookup.

- Adds a route regression test verifying the refresh path.

<sup>Written for commit 6888803e6c7af3dc726a124a9af47f66cd88a255. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/responder-oss/pull/106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

