### PR TITLE
Use Sentry JWT grant type for recovery

### DIFF
--- a/apps/control-plane/server/integrations/providers.test.ts
+++ b/apps/control-plane/server/integrations/providers.test.ts
@@ -557,7 +557,7 @@ describe("integration providers", () => {
         .digest("base64url"),
     );
     expect(JSON.parse(manualRequest[1].body as string)).toEqual({
-      grant_type: "client_secret_jwt",
+      grant_type: "urn:sentry:params:oauth:grant-type:jwt-bearer",
     });
   });
 

--- a/apps/control-plane/server/integrations/sentry.ts
+++ b/apps/control-plane/server/integrations/sentry.ts
@@ -160,7 +160,7 @@ export async function refreshSentryGrant(input: {
       authorization: `Bearer ${sentryClientSecretJwt(clientId, clientSecret)}`,
     },
     body: JSON.stringify({
-      grant_type: "client_secret_jwt",
+      grant_type: "urn:sentry:params:oauth:grant-type:jwt-bearer",
     }),
   });
   if (!manualResponse.ok) {


### PR DESCRIPTION
Production logs showed both recovery requests returning 401. The fallback client-secret JWT was sent with an invalid grant type (`client_secret_jwt`). Sentry expects `urn:sentry:params:oauth:grant-type:jwt-bearer`. This change updates the request and the local regression assertion. Local verification: 893 tests passed, typecheck passed, lint passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Sentry recovery requests returning 401 by using the correct JWT grant type.

- Switches the `grant_type` from `client_secret_jwt` to `urn:sentry:params:oauth:grant-type:jwt-bearer` in the recovery request and the regression test.
- Local verification: 893 tests passed, typecheck and lint passed.

<sup>Written for commit 0ccd4818e8d18ee9e2cda7c806e0354bc6e77a95. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/responder-oss/pull/107?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

