### PR TITLE
Add direct Slack channel search

### DIFF
--- a/apps/control-plane/server/integrations/providers.test.ts
+++ b/apps/control-plane/server/integrations/providers.test.ts
@@ -366,9 +366,7 @@ describe("integration providers", () => {
     expect(scopes).toContain("chat:write");
     expect(scopes).toContain("chat:write.public");
     const userScopes = url.searchParams.get("user_scope")?.split(",") ?? [];
-    expect(userScopes).toEqual(
-      expect.arrayContaining(["channels:history", "groups:history"]),
-    );
+    expect(userScopes).toEqual(["search:read"]);
   });
 
   it("joins a selected public Slack channel", async () => {
@@ -386,7 +384,7 @@ describe("integration providers", () => {
     );
   });
 
-  it("captures the Slack user token used by the hosted MCP", async () => {
+  it("captures the Slack user token used for channel search", async () => {
     vi.stubEnv("BETTER_AUTH_URL", "https://responder.example");
     vi.stubEnv("SLACK_CLIENT_ID", "slack-client");
     vi.stubEnv("SLACK_CLIENT_SECRET", "slack-secret");
@@ -405,7 +403,7 @@ describe("integration providers", () => {
             id: "U123",
             access_token: "xoxp-user-token",
             token_type: "user",
-            scope: "channels:history,groups:history",
+            scope: "search:read",
           },
         }),
       ),
@@ -415,7 +413,7 @@ describe("integration providers", () => {
       access_token: "xoxb-bot-token",
       authed_user: {
         access_token: "xoxp-user-token",
-        scope: "channels:history,groups:history",
+        scope: "search:read",
       },
     });
   });

--- a/apps/control-plane/server/integrations/slack.ts
+++ b/apps/control-plane/server/integrations/slack.ts
@@ -55,7 +55,7 @@ const SLACK_BOT_SCOPES = [
   "reactions:write",
 ].join(",");
 
-const SLACK_USER_SCOPES = ["channels:history", "groups:history"].join(",");
+const SLACK_USER_SCOPES = "search:read";
 
 export class SlackChannelJoinError extends Error {
   constructor(public readonly slackCode: string) {

--- a/apps/control-plane/src/agent-context-defaults.test.ts
+++ b/apps/control-plane/src/agent-context-defaults.test.ts
@@ -56,7 +56,7 @@ describe("defaultAgentContext", () => {
   it("enables direct connections and supported resource providers", () => {
     expect(defaultAgentContext(OPTIONS)).toEqual({
       contextAccountIds: ["sentry-1", "axiom-1", "aws-1", "aws-2", "vercel-1"],
-      contextResourceIds: ["vercel-project-1"],
+      contextResourceIds: ["slack-channel-1", "vercel-project-1"],
       repositoryIds: ["repository-1"],
     });
   });

--- a/apps/control-plane/src/agent-context-defaults.ts
+++ b/apps/control-plane/src/agent-context-defaults.ts
@@ -21,6 +21,14 @@ export interface DefaultAgentContext {
 }
 
 export function defaultAgentContext(options: AgentOptions): DefaultAgentContext {
+  const firstSlackAccount = options.accounts.find(
+    (account) => account.provider === "slack" && account.slackContextAvailable,
+  );
+  const firstSlackChannel = options.resources.find(
+    (resource) =>
+      resource.kind === "slack_channel" &&
+      resource.integrationAccountId === firstSlackAccount?.id,
+  );
   const firstVercelProject = options.resources.find(
     (resource) => resource.kind === "vercel_project",
   );
@@ -40,7 +48,10 @@ export function defaultAgentContext(options: AgentOptions): DefaultAgentContext 
 
   return {
     contextAccountIds,
-    contextResourceIds: firstVercelProject ? [firstVercelProject.id] : [],
+    contextResourceIds: [
+      ...(firstSlackChannel ? [firstSlackChannel.id] : []),
+      ...(firstVercelProject ? [firstVercelProject.id] : []),
+    ],
     repositoryIds: options.repositories[0] ? [options.repositories[0].id] : [],
   };
 }

--- a/apps/control-plane/src/pages/agent-create.tsx
+++ b/apps/control-plane/src/pages/agent-create.tsx
@@ -287,6 +287,7 @@ function createInitialDraft(
   const sentryProjects = resourcesOfKind(options, "sentry_project");
   const slackChannels = resourcesOfKind(options, "slack_channel");
   const vercelProjects = resourcesOfKind(options, "vercel_project");
+  const contextResources = [...slackChannels, ...vercelProjects];
   const githubAccounts = accountsFor(options, "github");
   const firstSentryAccount =
     sentryAccounts.find((account) =>
@@ -388,10 +389,10 @@ function createInitialDraft(
       (isEditing ? defaultContext.contextAccountIds : []),
     contextResourceIds:
       saved.contextResourceIds?.filter((id) =>
-        vercelProjects.some((resource) => resource.id === id),
+        contextResources.some((resource) => resource.id === id),
       ) ??
       configured.contextResourceIds?.filter((id) =>
-        vercelProjects.some((resource) => resource.id === id),
+        contextResources.some((resource) => resource.id === id),
       ) ??
       (isEditing ? defaultContext.contextResourceIds : []),
     workspaceSecretRecordIds,
@@ -463,6 +464,7 @@ export function AgentCreatePage() {
   ).get("integration_account_id");
   const contextIntegrationJustConnected =
     sentryJustConnected ||
+    slackJustConnected ||
     githubJustConnected ||
     datadogJustConnected ||
     axiomJustConnected ||
@@ -494,6 +496,7 @@ export function AgentCreatePage() {
     isEditing ? 4 : normalizedInitialStep,
   );
   const [githubDialogOpen, setGithubDialogOpen] = useState(githubJustConnected);
+  const [slackContextDialogOpen, setSlackContextDialogOpen] = useState(false);
   const [vercelDialogOpen, setVercelDialogOpen] = useState(vercelJustConnected);
   const [vercelAccountId, setVercelAccountId] = useState(
     returnedIntegrationAccountId ?? "",
@@ -581,6 +584,7 @@ export function AgentCreatePage() {
     if (
       !githubDialogOpen &&
       !linearDialogOpen &&
+      !slackContextDialogOpen &&
       !vercelDialogOpen &&
       !connectionSettingsOpen &&
       !secretDialogOpen
@@ -591,6 +595,7 @@ export function AgentCreatePage() {
       if (event.key === "Escape") {
         setGithubDialogOpen(false);
         setLinearDialogOpen(false);
+        setSlackContextDialogOpen(false);
         setVercelDialogOpen(false);
         setConnectionSettingsOpen(null);
         if (!creatingSecret) {
@@ -610,6 +615,7 @@ export function AgentCreatePage() {
     githubDialogOpen,
     linearDialogOpen,
     secretDialogOpen,
+    slackContextDialogOpen,
     vercelDialogOpen,
   ]);
 
@@ -643,6 +649,27 @@ export function AgentCreatePage() {
           !loadedDraft.contextAccountIds.includes(connectedSentry.id)
         ) {
           loadedDraft.contextAccountIds.push(connectedSentry.id);
+        }
+        const connectedSlackAccount = accountsFor(loadedOptions, "slack").find(
+          (account) => account.slackContextAvailable,
+        );
+        const connectedSlackChannel = resourcesOfKind(
+          loadedOptions,
+          "slack_channel",
+        ).find(
+          (channel) =>
+            channel.integrationAccountId === connectedSlackAccount?.id,
+        );
+        if (
+          slackJustConnected &&
+          connectedSlackChannel &&
+          !loadedDraft.contextResourceIds.some((id) =>
+            loadedOptions.resources.some(
+              (resource) => resource.id === id && resource.kind === "slack_channel",
+            ),
+          )
+        ) {
+          loadedDraft.contextResourceIds.push(connectedSlackChannel.id);
         }
         const connectedGithubRepository = loadedOptions.repositories.find(
           (repository) =>
@@ -873,6 +900,10 @@ export function AgentCreatePage() {
     () => accountsFor(options, "github"),
     [options],
   );
+  const slackAccounts = useMemo(
+    () => accountsFor(options, "slack"),
+    [options],
+  );
   const sentryProjects = useMemo(
     () => resourcesOfKind(options, "sentry_project"),
     [options],
@@ -1040,6 +1071,11 @@ export function AgentCreatePage() {
             )
               ? current.outputChannelResourceId
               : freshChannels[0]?.id ?? "",
+            contextResourceIds: current.contextResourceIds.filter(
+              (id) =>
+                !slackChannels.some((channel) => channel.id === id) ||
+                freshChannelIds.has(id),
+            ),
           };
         });
       })
@@ -1125,6 +1161,26 @@ export function AgentCreatePage() {
     });
   }
 
+  function toggleSlackContextResource(resourceId: string) {
+    const resource = slackChannels.find((channel) => channel.id === resourceId);
+    if (!resource) return;
+    const selected = currentDraft.contextResourceIds.includes(resourceId);
+    updateDraft({
+      contextResourceIds: selected
+        ? currentDraft.contextResourceIds.filter((id) => id !== resourceId)
+        : [
+            ...currentDraft.contextResourceIds.filter((id) => {
+              const channel = slackChannels.find((item) => item.id === id);
+              return (
+                !channel ||
+                channel.integrationAccountId === resource.integrationAccountId
+              );
+            }),
+            resourceId,
+          ],
+    });
+  }
+
   function toggleVercelProject(resourceId: string) {
     const resource = vercelProjects.find(
       (project) => project.id === resourceId,
@@ -1153,6 +1209,34 @@ export function AgentCreatePage() {
           (id) => !currentDraft.contextAccountIds.includes(id),
         ),
       ],
+    });
+  }
+
+  function toggleSlackContextIntegration() {
+    const selectedSlackIds = new Set(
+      slackChannels
+        .filter((channel) => currentDraft.contextResourceIds.includes(channel.id))
+        .map((channel) => channel.id),
+    );
+    if (selectedSlackIds.size > 0) {
+      updateDraft({
+        contextResourceIds: currentDraft.contextResourceIds.filter(
+          (id) => !selectedSlackIds.has(id),
+        ),
+      });
+      return;
+    }
+    const firstAccount = slackAccounts.find((account) => account.slackContextAvailable);
+    const firstChannel = slackChannels.find(
+      (channel) => channel.integrationAccountId === firstAccount?.id,
+    );
+    if (!firstChannel) {
+      setSlackContextDialogOpen(true);
+      void refreshSlackChannels();
+      return;
+    }
+    updateDraft({
+      contextResourceIds: [...currentDraft.contextResourceIds, firstChannel.id],
     });
   }
 
@@ -1415,6 +1499,9 @@ export function AgentCreatePage() {
   const sentryConnected = sentryProjects.length > 0;
   const outputChannelSelected = effectiveOutputMode === "output_channel";
   const vercelContextConnected = selectedVercelProjects.length > 0;
+  const selectedSlackContextChannels = slackChannels.filter((channel) =>
+    draft.contextResourceIds.includes(channel.id),
+  );
   const selectedWorkspaceSecrets = options.secrets.filter((secret) =>
     draft.workspaceSecretRecordIds.includes(secret.id),
   );
@@ -1423,6 +1510,7 @@ export function AgentCreatePage() {
     sentryAccounts.filter((account) =>
       draft.contextAccountIds.includes(account.id),
     ).length +
+    Number(selectedSlackContextChannels.length > 0) +
     datadogAccounts.filter((account) =>
       draft.contextAccountIds.includes(account.id),
     ).length +
@@ -1450,10 +1538,10 @@ export function AgentCreatePage() {
     ).length;
   const normalizedIntegrationQuery = integrationQuery.trim().toLocaleLowerCase();
   const visibleContextIntegrations = integrations.filter((integration) => {
-    if (integration.id === "slack") return false;
     if (
       integration.accountCount > 0 &&
       integration.id !== "sentry" &&
+      integration.id !== "slack" &&
       !MULTI_ACCOUNT_CONTEXT_PROVIDERS.has(integration.id)
     ) {
       return false;
@@ -1931,6 +2019,120 @@ export function AgentCreatePage() {
                       />
                     );
                   })}
+
+                  {slackAccounts.length > 0 ? (
+                    <ContextRow
+                      action={
+                        <ContextIntegrationControls
+                          enabled={selectedSlackContextChannels.length > 0}
+                          label="Slack"
+                          onConfigure={() => {
+                            setSlackContextDialogOpen(true);
+                            void refreshSlackChannels();
+                          }}
+                          onToggle={toggleSlackContextIntegration}
+                        />
+                      }
+                      detail={
+                        selectedSlackContextChannels.length > 0
+                          ? `${selectedSlackContextChannels.length} ${
+                              selectedSlackContextChannels.length === 1
+                                ? "channel"
+                                : "channels"
+                            } selected · Searchable messages`
+                          : `${slackAccounts[0]!.displayName} · Choose channels for search`
+                      }
+                      label="Slack"
+                      provider="slack"
+                    />
+                  ) : null}
+
+                  {slackContextDialogOpen ? (
+                    <div
+                      className="configurationDialogBackdrop"
+                      onMouseDown={(event) => {
+                        if (event.target === event.currentTarget) {
+                          setSlackContextDialogOpen(false);
+                        }
+                      }}
+                    >
+                      <section
+                        aria-labelledby="slack-context-configuration-title"
+                        aria-modal="true"
+                        className="configurationDialog"
+                        role="dialog"
+                      >
+                        <header className="configurationDialog__header">
+                          <ProviderMark provider="slack" />
+                          <span className="configurationDialog__copy">
+                            <strong id="slack-context-configuration-title">
+                              Configure Slack search
+                            </strong>
+                            <small>
+                              Choose one or more channels this agent may search.
+                            </small>
+                          </span>
+                          <IconButton
+                            aria-label="Close Slack context configuration"
+                            autoFocus
+                            onClick={() => setSlackContextDialogOpen(false)}
+                            size="small"
+                            variant="ghost"
+                          >
+                            ×
+                          </IconButton>
+                        </header>
+                        <div className="configurationDialog__body">
+                          <div className="projectPicker slackContextPicker">
+                            <span>Channels</span>
+                            <div>
+                              {slackChannels
+                                .filter((channel) =>
+                                  slackAccounts.some(
+                                    (account) =>
+                                      account.id === channel.integrationAccountId &&
+                                      account.slackContextAvailable,
+                                  ),
+                                )
+                                .map((channel) => {
+                                  const account = slackAccounts.find(
+                                    (item) => item.id === channel.integrationAccountId,
+                                  );
+                                  return (
+                                    <Checkbox
+                                      checked={draft.contextResourceIds.includes(channel.id)}
+                                      description={
+                                        slackAccounts.length > 1
+                                          ? account?.displayName
+                                          : undefined
+                                      }
+                                      key={channel.id}
+                                      label={slackChannelLabel(channel.displayName)}
+                                      onChange={() =>
+                                        toggleSlackContextResource(channel.id)
+                                      }
+                                    />
+                                  );
+                                })}
+                            </div>
+                          </div>
+                          {slackRefreshError ? (
+                            <Alert role="alert" title={slackRefreshError} tone="danger" />
+                          ) : null}
+                        </div>
+                        <footer className="configurationDialog__footer">
+                          <span>{selectedSlackContextChannels.length} selected</span>
+                          <Button
+                            onClick={() => setSlackContextDialogOpen(false)}
+                            size="small"
+                            variant="primary"
+                          >
+                            Done
+                          </Button>
+                        </footer>
+                      </section>
+                    </div>
+                  ) : null}
 
                   {githubAccounts.length > 0 ? (
                     <ContextRow

--- a/apps/worker/src/investigate.ts
+++ b/apps/worker/src/investigate.ts
@@ -74,7 +74,7 @@ import {
   traceEvent,
 } from "./trace.js";
 import { createSentryMcpServer } from "./sentry.js";
-import { createSlackMcpServer } from "./slack.js";
+import { createSlackSearchServer } from "./slack.js";
 import {
   createUpstashCliTools,
   createUpstashMcpServer,
@@ -528,7 +528,7 @@ export async function runInvestigationAgent(
     ? createLinearMcpServer(linearConnection)
     : null;
   const slackServer = slackConnection
-    ? createSlackMcpServer(slackConnection)
+    ? createSlackSearchServer(slackConnection)
     : null;
   const upstashServer = upstashConnection
     ? createUpstashMcpServer(upstashConnection)

--- a/apps/worker/src/slack.test.ts
+++ b/apps/worker/src/slack.test.ts
@@ -1,7 +1,7 @@
-import type { MCPServer } from "@openai/agents";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { RuntimeSlackConnection } from "@responder/core/db/investigations";
-import { ScopedSlackMcpServer } from "./slack.js";
+import { searchSlackChannel } from "@responder/core/integrations/slack-search";
+import { SlackSearchMcpServer } from "./slack.js";
 
 const activeSpan = vi.hoisted(() => ({
   recordException: vi.fn(),
@@ -12,6 +12,12 @@ vi.mock("@opentelemetry/api", () => ({
   SpanStatusCode: { ERROR: 2 },
   trace: { getActiveSpan: () => activeSpan },
 }));
+vi.mock("@responder/core/integrations/slack-search", async (importOriginal) => {
+  const original = await importOriginal<
+    typeof import("@responder/core/integrations/slack-search")
+  >();
+  return { ...original, searchSlackChannel: vi.fn() };
+});
 
 const connection: RuntimeSlackConnection = {
   accountId: "account-1",
@@ -19,79 +25,114 @@ const connection: RuntimeSlackConnection = {
     { id: "C123", name: "incidents" },
     { id: "C456", name: "engineering" },
   ],
-  mcpUrl: "https://mcp.slack.com/mcp",
   userAccessToken: "user-token",
 };
 
-function upstreamServer() {
-  const callTool = vi.fn().mockResolvedValue([{ type: "text", text: "ok" }]);
-  const tools = [
-    { name: "slack_read_channel" },
-    { name: "slack_read_thread" },
-    { name: "slack_send_message" },
-    { name: "slack_search_public" },
-  ] as Awaited<ReturnType<MCPServer["listTools"]>>;
-  const server = {
-    cacheToolsList: true,
-    callTool,
-    close: vi.fn().mockResolvedValue(undefined),
-    connect: vi.fn().mockResolvedValue(undefined),
-    invalidateToolsCache: vi.fn().mockResolvedValue(undefined),
-    listTools: vi.fn().mockResolvedValue(tools),
-    name: "slack-upstream",
-  } as MCPServer;
-  return { callTool, server };
-}
+const searchResult = {
+  channel: { id: "C123", name: "incidents" },
+  matches: [
+    {
+      permalink: "https://example.slack.com/archives/C123/p1",
+      text: "database timeout",
+      timestamp: "1.000001",
+      userId: "U123",
+    },
+  ],
+  query: "database timeout",
+  totalMatches: 1,
+};
 
-describe("scoped Slack MCP server", () => {
-  it("exposes only read tools that can be channel-scoped", async () => {
-    const { server } = upstreamServer();
-    const scoped = new ScopedSlackMcpServer(server, connection);
+describe("Slack channel search server", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
 
-    await expect(scoped.listTools()).resolves.toEqual([
-      expect.objectContaining({ name: "slack_read_channel" }),
-      expect.objectContaining({ name: "slack_read_thread" }),
+  it("exposes one search tool with the selected channel IDs", async () => {
+    const server = new SlackSearchMcpServer(connection);
+
+    await expect(server.listTools()).resolves.toEqual([
+      expect.objectContaining({
+        name: "slack_search_channel",
+        inputSchema: expect.objectContaining({
+          properties: expect.objectContaining({
+            channel_id: expect.objectContaining({ enum: ["C123", "C456"] }),
+          }),
+        }),
+      }),
     ]);
   });
 
-  it("forwards selected channel reads", async () => {
-    const { callTool, server } = upstreamServer();
-    const scoped = new ScopedSlackMcpServer(server, connection);
+  it("searches a selected channel with normalized arguments", async () => {
+    vi.mocked(searchSlackChannel).mockResolvedValue(searchResult);
+    const server = new SlackSearchMcpServer(connection);
 
-    await scoped.callTool("slack_read_channel", { channel_id: "C123" });
+    await expect(
+      server.callTool("slack_search_channel", {
+        channel_id: "C123",
+        query: "  database   timeout ",
+      }),
+    ).resolves.toEqual([
+      { type: "text", text: JSON.stringify(searchResult) },
+    ]);
+    expect(searchSlackChannel).toHaveBeenCalledWith({
+      accessToken: "user-token",
+      channel: { id: "C123", name: "incidents" },
+      limit: 10,
+      query: "database timeout",
+      signal: undefined,
+    });
+  });
 
-    expect(callTool).toHaveBeenCalledWith(
-      "slack_read_channel",
-      { channel_id: "C123" },
-      undefined,
-      undefined,
-    );
+  it("reuses identical searches within an investigation", async () => {
+    vi.mocked(searchSlackChannel).mockResolvedValue(searchResult);
+    const server = new SlackSearchMcpServer(connection);
+    const args = { channel_id: "C123", limit: 10, query: "database timeout" };
+
+    await server.callTool("slack_search_channel", args);
+    await server.callTool("slack_search_channel", args);
+
+    expect(searchSlackChannel).toHaveBeenCalledTimes(1);
+  });
+
+  it("removes failed searches from the investigation cache", async () => {
+    vi.mocked(searchSlackChannel)
+      .mockRejectedValueOnce(new Error("temporary failure"))
+      .mockResolvedValueOnce(searchResult);
+    const server = new SlackSearchMcpServer(connection);
+    const args = { channel_id: "C123", query: "database timeout" };
+
+    await expect(
+      server.callTool("slack_search_channel", args),
+    ).rejects.toThrow("temporary failure");
+    await expect(
+      server.callTool("slack_search_channel", args),
+    ).resolves.toBeDefined();
+
+    expect(searchSlackChannel).toHaveBeenCalledTimes(2);
   });
 
   it("blocks unselected channels before calling Slack", async () => {
-    const { callTool, server } = upstreamServer();
-    const scoped = new ScopedSlackMcpServer(server, connection);
+    const server = new SlackSearchMcpServer(connection);
     const logError = vi.spyOn(console, "error").mockImplementation(() => {});
 
     await expect(
-      scoped.callTool("slack_read_channel", { channel_id: "C999" }),
+      server.callTool("slack_search_channel", {
+        channel_id: "C999",
+        query: "database timeout",
+      }),
     ).rejects.toThrow("Slack channel is not selected");
-    expect(callTool).not.toHaveBeenCalled();
+    expect(searchSlackChannel).not.toHaveBeenCalled();
     expect(activeSpan.recordException).toHaveBeenCalledWith(
       expect.objectContaining({
         message: "Slack channel is not selected for this agent",
       }),
     );
-    expect(activeSpan.setStatus).toHaveBeenCalledWith({
-      code: 2,
-      message: "Slack channel is not selected for this agent",
-    });
     expect(logError).toHaveBeenCalledWith(
       JSON.stringify({
-        event: "slack_mcp_tool_blocked",
+        event: "slack_search_tool_blocked",
         reason: "Slack channel is not selected for this agent",
         serverName: "slack-account-1",
-        toolName: "slack_read_channel",
+        toolName: "slack_search_channel",
       }),
     );
   });

--- a/apps/worker/src/slack.ts
+++ b/apps/worker/src/slack.ts
@@ -1,93 +1,161 @@
-import {
-  MCPServerStreamableHttp,
-  type MCPCallToolOptions,
-  type MCPServer,
-} from "@openai/agents";
+import type { MCPCallToolOptions, MCPServer } from "@openai/agents";
 import { SpanStatusCode, trace } from "@opentelemetry/api";
 import type { RuntimeSlackConnection } from "@responder/core/db/investigations";
 import {
   SLACK_CONTEXT_MCP_TOOLS,
   slackContextToolAccess,
 } from "@responder/core/integrations/slack-mcp";
+import {
+  normalizeSlackSearchQuery,
+  searchSlackChannel,
+  type SlackChannelSearchResult,
+} from "@responder/core/integrations/slack-search";
+import { z } from "zod";
 
-export class ScopedSlackMcpServer implements MCPServer {
+const SLACK_SEARCH_TOOL = SLACK_CONTEXT_MCP_TOOLS[0];
+const MAX_CACHED_SEARCHES = 20;
+
+const slackSearchToolInputSchema = z
+  .object({
+    channel_id: z.string().min(1),
+    limit: z.number().int().min(1).max(20).optional().default(10),
+    query: z.string().min(1).max(500),
+  })
+  .strict();
+
+export class SlackSearchMcpServer implements MCPServer {
   readonly cacheToolsList = true;
   readonly name: string;
-  readonly useStructuredContent = true;
-  private readonly allowedChannelIds: ReadonlySet<string>;
+  private readonly channelsById: ReadonlyMap<
+    string,
+    RuntimeSlackConnection["channels"][number]
+  >;
+  private readonly searchCache = new Map<
+    string,
+    Promise<SlackChannelSearchResult>
+  >();
 
-  constructor(
-    private readonly server: MCPServer,
-    connection: RuntimeSlackConnection,
-  ) {
+  constructor(private readonly connection: RuntimeSlackConnection) {
     this.name = `slack-${connection.accountId}`;
-    this.allowedChannelIds = new Set(
-      connection.channels.map((channel) => channel.id),
+    this.channelsById = new Map(
+      connection.channels.map((channel) => [channel.id, channel]),
     );
   }
 
-  connect(): Promise<void> {
-    return this.server.connect();
-  }
+  async connect(): Promise<void> {}
 
-  close(): Promise<void> {
-    return this.server.close();
+  async close(): Promise<void> {
+    this.searchCache.clear();
   }
 
   async listTools(): ReturnType<MCPServer["listTools"]> {
-    const tools = await this.server.listTools();
-    return tools.filter((tool) =>
-      (SLACK_CONTEXT_MCP_TOOLS as readonly string[]).includes(tool.name),
-    );
+    const channels = this.connection.channels
+      .map((channel) => `#${channel.name} (${channel.id})`)
+      .join(", ");
+    return [
+      {
+        name: SLACK_SEARCH_TOOL,
+        description:
+          "Search one Slack channel selected for this agent. Use concise keywords from the incident. Search modifiers are not accepted. " +
+          `Available channels: ${channels}.`,
+        inputSchema: {
+          type: "object",
+          properties: {
+            channel_id: {
+              type: "string",
+              enum: this.connection.channels.map((channel) => channel.id),
+              description: "Selected Slack channel ID",
+            },
+            query: {
+              type: "string",
+              minLength: 1,
+              maxLength: 500,
+              description: "Keywords or an exact error phrase without Slack modifiers",
+            },
+            limit: {
+              type: "integer",
+              minimum: 1,
+              maximum: 20,
+              default: 10,
+              description: "Maximum matching messages to return",
+            },
+          },
+          required: ["channel_id", "query"],
+          additionalProperties: false,
+        },
+      },
+    ];
   }
 
   async callTool(
     toolName: string,
     args: Record<string, unknown> | null,
-    meta?: Record<string, unknown> | null,
+    _meta?: Record<string, unknown> | null,
     options?: MCPCallToolOptions,
-  ) {
+  ): ReturnType<MCPServer["callTool"]> {
     const access = slackContextToolAccess({
-      allowedChannelIds: this.allowedChannelIds,
+      allowedChannelIds: new Set(this.channelsById.keys()),
       args,
       toolName,
     });
     if (!access.allowed) {
-      const error = new Error(access.reason);
-      const span = trace.getActiveSpan();
-      span?.recordException(error);
-      span?.setStatus({ code: SpanStatusCode.ERROR, message: error.message });
-      console.error(
-        JSON.stringify({
-          event: "slack_mcp_tool_blocked",
-          reason: access.reason,
-          serverName: this.name,
-          toolName,
-        }),
-      );
-      throw error;
+      this.recordBlockedTool(toolName, access.reason);
+      throw new Error(access.reason);
     }
-    return this.server.callTool(toolName, args, meta, options);
+
+    const parsed = slackSearchToolInputSchema.safeParse(args);
+    if (!parsed.success) {
+      throw new Error("Invalid Slack channel search arguments");
+    }
+    const channel = this.channelsById.get(parsed.data.channel_id);
+    if (!channel) {
+      throw new Error("Slack channel is not selected for this agent");
+    }
+    const query = normalizeSlackSearchQuery(parsed.data.query);
+    const cacheKey = JSON.stringify([channel.id, query, parsed.data.limit]);
+    let search = this.searchCache.get(cacheKey);
+    if (!search) {
+      search = searchSlackChannel({
+        accessToken: this.connection.userAccessToken,
+        channel,
+        limit: parsed.data.limit,
+        query,
+        signal: options?.signal,
+      });
+      if (this.searchCache.size < MAX_CACHED_SEARCHES) {
+        this.searchCache.set(cacheKey, search);
+        void search.catch(() => {
+          if (this.searchCache.get(cacheKey) === search) {
+            this.searchCache.delete(cacheKey);
+          }
+        });
+      }
+    }
+
+    const result = await search;
+    return [{ type: "text", text: JSON.stringify(result) }];
   }
 
-  invalidateToolsCache(): Promise<void> {
-    return this.server.invalidateToolsCache();
+  async invalidateToolsCache(): Promise<void> {}
+
+  private recordBlockedTool(toolName: string, reason: string): void {
+    const error = new Error(reason);
+    const span = trace.getActiveSpan();
+    span?.recordException(error);
+    span?.setStatus({ code: SpanStatusCode.ERROR, message: error.message });
+    console.error(
+      JSON.stringify({
+        event: "slack_search_tool_blocked",
+        reason,
+        serverName: this.name,
+        toolName,
+      }),
+    );
   }
 }
 
-export function createSlackMcpServer(
+export function createSlackSearchServer(
   connection: RuntimeSlackConnection,
 ): MCPServer {
-  const server = new MCPServerStreamableHttp({
-    cacheToolsList: true,
-    clientSessionTimeoutSeconds: 300,
-    name: "slack-upstream",
-    requestInit: {
-      headers: { authorization: `Bearer ${connection.userAccessToken}` },
-    },
-    timeout: 30_000,
-    url: connection.mcpUrl,
-    useStructuredContent: true,
-  });
-  return new ScopedSlackMcpServer(server, connection);
+  return new SlackSearchMcpServer(connection);
 }

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -42,12 +42,18 @@ Configure a distributed Slack app with:
 - Bot scopes: `app_mentions:read`, `channels:history`, `channels:join`,
   `channels:read`, `chat:write`, `chat:write.public`, `groups:history`,
   `groups:read`, and `reactions:write`
-- User scopes: `channels:history` and `groups:history`
+- User scope: `search:read`
 - Environment: `SLACK_CLIENT_ID`, `SLACK_CLIENT_SECRET`, and
   `SLACK_SIGNING_SECRET`
 
-Reconnect existing installations after changing scopes. Private channels
-require the bot to be invited.
+Responder searches selected channels on demand through Slack's
+`search.messages` Web API method. The worker rejects Slack search modifiers,
+adds the selected channel constraint itself, and drops any result whose channel
+ID does not match the agent's immutable configuration. Identical searches share
+one in-memory request and result within an investigation; message content is not
+cached across investigations. Reconnect existing installations after changing
+scopes. The connecting user must be able to search each selected channel, and
+private channels also require the bot to be invited.
 
 Watched channels accept app-authored CloudWatch alarm notifications from AWS
 and Amazon Q Developer in chat applications. Responder starts investigations

--- a/packages/core/src/db/agents.ts
+++ b/packages/core/src/db/agents.ts
@@ -291,7 +291,6 @@ async function validateConfigurationResources(
         accountMetadata: integrationAccounts.metadata,
         kind: integrationResources.kind,
         provider: integrationAccounts.provider,
-        resourceMetadata: integrationResources.metadata,
       })
       .from(integrationResources)
       .innerJoin(
@@ -345,11 +344,8 @@ async function validateConfigurationResources(
           )
         : [],
     );
-    const missingScope = slackContextRows.some((resource) =>
-      resource.resourceMetadata.isPrivate === true
-        ? !userScopes.has("groups:history")
-        : !userScopes.has("channels:history"),
-    );
+    const missingScope =
+      slackContextRows.length > 0 && !userScopes.has("search:read");
     if (missingScope) {
       throw new AgentConfigurationError(
         "Reconnect Slack to use selected channels as agent context",
@@ -747,8 +743,7 @@ export async function listAgentOptions(organizationId: string) {
       slackContextAvailable:
         account.provider === "slack" &&
         Array.isArray(metadata.userScopes) &&
-        metadata.userScopes.includes("channels:history") &&
-        metadata.userScopes.includes("groups:history"),
+        metadata.userScopes.includes("search:read"),
     }));
   const accountIds = accounts.map((account) => account.id);
 

--- a/packages/core/src/db/investigations.ts
+++ b/packages/core/src/db/investigations.ts
@@ -30,7 +30,6 @@ import {
   parseLinearOAuthCredentials,
   refreshLinearOAuthCredentials,
 } from "../integrations/linear.js";
-import { SLACK_MCP_URL } from "../integrations/slack-mcp.js";
 import { parseUpstashCredentials } from "../integrations/upstash.js";
 import { parseLangfuseCredentials } from "../integrations/langfuse.js";
 import type { InvestigationReportSubmission } from "../investigations/report.js";
@@ -82,7 +81,6 @@ export interface RuntimeRepository {
 export interface RuntimeSlackConnection {
   accountId: string;
   channels: Array<{ id: string; name: string }>;
-  mcpUrl: string;
   userAccessToken: string;
 }
 
@@ -2306,7 +2304,6 @@ export async function getRuntimeSlackConnection(
       const resource = resourcesById.get(resourceId)!;
       return { id: resource.externalId, name: resource.displayName };
     }),
-    mcpUrl: SLACK_MCP_URL,
     userAccessToken: credentials.data.userAccessToken,
   };
 }

--- a/packages/core/src/db/slack-context.test.ts
+++ b/packages/core/src/db/slack-context.test.ts
@@ -86,7 +86,6 @@ describe("runtime Slack context", () => {
         { id: "C123", name: "incidents" },
         { id: "C456", name: "engineering" },
       ],
-      mcpUrl: "https://mcp.slack.com/mcp",
       userAccessToken: "user-token",
     });
   });
@@ -136,7 +135,6 @@ describe("runtime Slack context", () => {
     ).resolves.toEqual({
       accountId: "slack-account-1",
       channels: [{ id: "C123", name: "incidents" }],
-      mcpUrl: "https://mcp.slack.com/mcp",
       userAccessToken: "user-token",
     });
   });

--- a/packages/core/src/integrations/slack-live-card.test.ts
+++ b/packages/core/src/integrations/slack-live-card.test.ts
@@ -669,13 +669,13 @@ describe("Slack live investigation card", () => {
         {
           detail: JSON.stringify({
             channel_id: "C123",
-            thread_ts: "1785500000.000100",
-            limit: 50,
+            query: "database timeout",
+            limit: 10,
           }),
           id: "call-slack-thread",
           output: '{"messages":[]}',
           status: "complete",
-          title: "slack_read_thread",
+          title: "slack_search_channel",
         },
       ],
     });
@@ -750,8 +750,7 @@ describe("Slack live investigation card", () => {
             ],
           }),
           expect.objectContaining({
-            title:
-              "Read Slack thread `1785500000.000100` in `C123`",
+            title: "Search Slack channel `C123` for `database timeout`",
           }),
         ]),
       }),

--- a/packages/core/src/integrations/slack-live-card.ts
+++ b/packages/core/src/integrations/slack-live-card.ts
@@ -716,25 +716,16 @@ function formattedTraceTask(
     };
   }
 
-  if (
-    item.title === "slack_read_channel" ||
-    item.title === "slack_read_thread"
-  ) {
+  if (item.title === "slack_search_channel") {
     const channelId = input?.channel_id;
     if (!input || typeof channelId !== "string") return null;
-    const threadTimestamp = input?.thread_ts ?? input?.thread_timestamp;
-    const details = objectDetails(
-      input,
-      new Set(["channel_id", "thread_ts", "thread_timestamp"]),
-    );
+    const query = input.query;
+    if (typeof query !== "string") return null;
+    const details = objectDetails(input, new Set(["channel_id", "query"]));
     const url = firstUrl(item.output);
     return {
       task_id: taskId,
-      title:
-        item.title === "slack_read_thread" &&
-        typeof threadTimestamp === "string"
-          ? `Read Slack thread \`${threadTimestamp}\` in \`${channelId}\``
-          : `Read Slack channel \`${channelId}\``,
+      title: `Search Slack channel \`${channelId}\` for \`${query}\``,
       status,
       ...(details ? { details } : {}),
       ...(item.output ? { output: preformatted(item.output) } : {}),

--- a/packages/core/src/integrations/slack-mcp.test.ts
+++ b/packages/core/src/integrations/slack-mcp.test.ts
@@ -4,12 +4,12 @@ import { slackContextToolAccess } from "./slack-mcp.js";
 const allowedChannelIds = new Set(["C123", "C456"]);
 
 describe("Slack MCP context scope", () => {
-  it("allows read tools for selected channels", () => {
+  it("allows searches for selected channels", () => {
     expect(
       slackContextToolAccess({
         allowedChannelIds,
         args: { channel_id: "C123" },
-        toolName: "slack_read_channel",
+        toolName: "slack_search_channel",
       }),
     ).toEqual({ allowed: true });
   });
@@ -19,7 +19,7 @@ describe("Slack MCP context scope", () => {
       slackContextToolAccess({
         allowedChannelIds,
         args: { channel_id: "C999" },
-        toolName: "slack_read_thread",
+        toolName: "slack_search_channel",
       }),
     ).toEqual({
       allowed: false,
@@ -32,7 +32,7 @@ describe("Slack MCP context scope", () => {
       slackContextToolAccess({
         allowedChannelIds,
         args: { channel_id: "C123" },
-        toolName: "slack_send_message",
+        toolName: "slack_read_channel",
       }),
     ).toEqual({ allowed: false, reason: "Slack context is read-only" });
   });

--- a/packages/core/src/integrations/slack-mcp.ts
+++ b/packages/core/src/integrations/slack-mcp.ts
@@ -1,9 +1,4 @@
-export const SLACK_MCP_URL = "https://mcp.slack.com/mcp";
-
-export const SLACK_CONTEXT_MCP_TOOLS = [
-  "slack_read_channel",
-  "slack_read_thread",
-] as const;
+export const SLACK_CONTEXT_MCP_TOOLS = ["slack_search_channel"] as const;
 
 export function slackContextToolAccess(input: {
   allowedChannelIds: ReadonlySet<string>;

--- a/packages/core/src/integrations/slack-search.test.ts
+++ b/packages/core/src/integrations/slack-search.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  normalizeSlackSearchQuery,
+  searchSlackChannel,
+  SlackSearchError,
+} from "./slack-search.js";
+
+describe("Slack channel search", () => {
+  it("scopes the query by channel name and drops results from other channels", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      Response.json({
+        ok: true,
+        messages: {
+          total: 2,
+          matches: [
+            {
+              channel: { id: "C123", name: "incidents" },
+              permalink: "https://example.slack.com/archives/C123/p1",
+              text: "database timeout in checkout",
+              ts: "1.000001",
+              user: "U123",
+            },
+            {
+              channel: { id: "C999", name: "other" },
+              permalink: "https://example.slack.com/archives/C999/p2",
+              text: "must never cross the configured channel boundary",
+              ts: "2.000002",
+              username: "Example bot",
+            },
+          ],
+        },
+      }),
+    );
+
+    await expect(
+      searchSlackChannel({
+        accessToken: "xoxp-secret",
+        channel: { id: "C123", name: "incidents" },
+        fetchImpl: fetchMock,
+        limit: 10,
+        query: "  database   timeout  ",
+      }),
+    ).resolves.toEqual({
+      channel: { id: "C123", name: "incidents" },
+      matches: [
+        {
+          permalink: "https://example.slack.com/archives/C123/p1",
+          text: "database timeout in checkout",
+          timestamp: "1.000001",
+          userId: "U123",
+        },
+      ],
+      query: "database timeout",
+      totalMatches: 1,
+    });
+
+    const url = new URL(fetchMock.mock.calls[0]![0] as URL);
+    expect(url.origin + url.pathname).toBe(
+      "https://slack.com/api/search.messages",
+    );
+    expect(url.searchParams.get("query")).toBe(
+      "database timeout in:incidents",
+    );
+    expect(url.searchParams.get("count")).toBe("10");
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.any(URL),
+      expect.objectContaining({
+        headers: { authorization: "Bearer xoxp-secret" },
+      }),
+    );
+  });
+
+  it("rejects Slack search modifiers before making a request", async () => {
+    const fetchMock = vi.fn();
+
+    await expect(
+      searchSlackChannel({
+        accessToken: "xoxp-secret",
+        channel: { id: "C123", name: "incidents" },
+        fetchImpl: fetchMock,
+        limit: 10,
+        query: "timeout in:private-channel",
+      }),
+    ).rejects.toThrow("Slack search modifiers are not allowed");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("surfaces Slack rate limits without including credentials", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      Response.json(
+        { ok: false, error: "ratelimited" },
+        { status: 429, headers: { "retry-after": "30" } },
+      ),
+    );
+
+    const error = await searchSlackChannel({
+      accessToken: "xoxp-secret",
+      channel: { id: "C123", name: "incidents" },
+      fetchImpl: fetchMock,
+      limit: 10,
+      query: "timeout",
+    }).catch((caught: unknown) => caught);
+
+    expect(error).toEqual(
+      expect.objectContaining<Partial<SlackSearchError>>({
+        slackCode: "ratelimited",
+        retryAfterSeconds: 30,
+      }),
+    );
+    expect(String(error)).not.toContain("xoxp-secret");
+  });
+
+  it("normalizes equivalent whitespace for investigation-local caching", () => {
+    expect(normalizeSlackSearchQuery("  checkout\n timeout ")).toBe(
+      "checkout timeout",
+    );
+  });
+});

--- a/packages/core/src/integrations/slack-search.ts
+++ b/packages/core/src/integrations/slack-search.ts
@@ -1,0 +1,129 @@
+import { z } from "zod";
+import { SlackApiError } from "./slack.js";
+
+const slackSearchResponseSchema = z.object({
+  ok: z.literal(true),
+  messages: z.object({
+    matches: z.array(
+      z.object({
+        channel: z.object({ id: z.string().min(1) }),
+        permalink: z.string().url(),
+        text: z.string(),
+        ts: z.string().min(1),
+        user: z.string().optional(),
+        username: z.string().optional(),
+      }),
+    ),
+  }),
+});
+
+const slackErrorResponseSchema = z.object({
+  error: z.string().min(1).optional(),
+  ok: z.literal(false),
+});
+
+const slackSearchModifier =
+  /(?:^|\s)(?:after|before|during|from|has|in|is|on|to|with):\S+/iu;
+
+export interface SlackSearchChannel {
+  id: string;
+  name: string;
+}
+
+export interface SlackSearchMatch {
+  permalink: string;
+  text: string;
+  timestamp: string;
+  userId?: string;
+  username?: string;
+}
+
+export interface SlackChannelSearchResult {
+  channel: SlackSearchChannel;
+  matches: SlackSearchMatch[];
+  query: string;
+  totalMatches: number;
+}
+
+export class SlackSearchError extends SlackApiError {
+  constructor(
+    public readonly slackCode: string,
+    public readonly retryAfterSeconds?: number,
+  ) {
+    super(
+      "search.messages",
+      slackCode,
+      retryAfterSeconds === undefined
+        ? []
+        : [`retry_after=${retryAfterSeconds}`],
+    );
+    this.name = "SlackSearchError";
+  }
+}
+
+export function normalizeSlackSearchQuery(query: string): string {
+  const normalized = query.trim().replace(/\s+/gu, " ");
+  if (!normalized) throw new Error("Slack search query is required");
+  if (normalized.length > 500) {
+    throw new Error("Slack search query must be at most 500 characters");
+  }
+  if (slackSearchModifier.test(normalized)) {
+    throw new Error("Slack search modifiers are not allowed");
+  }
+  return normalized;
+}
+
+export async function searchSlackChannel(input: {
+  accessToken: string;
+  channel: SlackSearchChannel;
+  query: string;
+  limit: number;
+  signal?: AbortSignal;
+  fetchImpl?: typeof fetch;
+}): Promise<SlackChannelSearchResult> {
+  const query = normalizeSlackSearchQuery(input.query);
+  if (!Number.isInteger(input.limit) || input.limit < 1 || input.limit > 20) {
+    throw new Error("Slack search limit must be between 1 and 20");
+  }
+
+  const url = new URL("https://slack.com/api/search.messages");
+  url.searchParams.set("query", `${query} in:${input.channel.name}`);
+  url.searchParams.set("count", String(input.limit));
+  url.searchParams.set("sort", "timestamp");
+  url.searchParams.set("sort_dir", "desc");
+
+  const response = await (input.fetchImpl ?? fetch)(url, {
+    headers: { authorization: `Bearer ${input.accessToken}` },
+    signal: input.signal,
+  });
+  const payload: unknown = await response.json().catch(() => null);
+  const parsedError = slackErrorResponseSchema.safeParse(payload);
+  if (!response.ok || parsedError.success) {
+    const retryAfter = response.headers.get("retry-after");
+    const retryAfterSeconds = retryAfter ? Number.parseInt(retryAfter, 10) : NaN;
+    throw new SlackSearchError(
+      parsedError.success
+        ? (parsedError.data.error ?? "unknown_error")
+        : `http_${response.status}`,
+      Number.isFinite(retryAfterSeconds) ? retryAfterSeconds : undefined,
+    );
+  }
+
+  const page = slackSearchResponseSchema.parse(payload);
+  const matches = page.messages.matches
+    .filter((match) => match.channel.id === input.channel.id)
+    .map((match) => ({
+      permalink: match.permalink,
+      text: match.text,
+      timestamp: match.ts,
+      ...(match.user ? { userId: match.user } : {}),
+      ...(match.username ? { username: match.username } : {}),
+    }));
+
+  return {
+    channel: input.channel,
+    matches,
+    query,
+    totalMatches: matches.length,
+  };
+}


### PR DESCRIPTION
## Summary
- replace the hosted Slack context connection with Slack's search.messages API
- require the search:read user scope and restore channel selection in agent setup
- enforce selected-channel boundaries, reject raw search modifiers, and cache repeated searches per investigation
- update live cards, documentation, and coverage

## Validation
- pnpm typecheck
- pnpm lint
- pnpm test
- pnpm build:app

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the hosted Slack MCP connection with direct calls to Slack's `search.messages` API, removing the upstream MCP proxy dependency from investigations. Agent setup now exposes Slack channel selection as an agent context option again.

**Migration**
- Slack user scope changed from `channels:history` and `groups:history` to `search:read`; existing installs must reconnect.
- The connecting user must be able to search each selected channel.

**Behavior**
- Agents call a single `slack_search_channel` tool instead of `slack_read_channel` and `slack_read_thread`.
- Queries are scoped to the selected channel, results outside it are dropped, and Slack search modifiers are rejected.
- Identical searches within an investigation share one request and result.

<sup>Written for commit 8958f9056f679cc33d9671930a4c3f49210c07b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/responder-oss/pull/108?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

