### PR TITLE
Fix empty Slack channel selector

### DIFF
--- a/apps/control-plane/src/agent-context-defaults.test.ts
+++ b/apps/control-plane/src/agent-context-defaults.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { AgentOptions } from "./agents-api";
-import { defaultAgentContext } from "./agent-context-defaults";
+import {
+  defaultAgentContext,
+  resolveSlackSearchContext,
+} from "./agent-context-defaults";
 
 const OPTIONS: AgentOptions = {
   accounts: [
@@ -108,5 +111,43 @@ describe("defaultAgentContext", () => {
     expect(defaults.contextAccountIds).toHaveLength(20);
     expect(defaults.contextAccountIds).toContain("vercel-1");
     expect(defaults.contextResourceIds).toEqual(["vercel-project-1"]);
+  });
+});
+
+describe("resolveSlackSearchContext", () => {
+  it("returns channels belonging to Slack connections with search access", () => {
+    expect(resolveSlackSearchContext(OPTIONS)).toMatchObject({
+      connectedAccounts: [
+        expect.objectContaining({ id: "slack-1" }),
+      ],
+      searchableAccounts: [
+        expect.objectContaining({ id: "slack-1" }),
+      ],
+      searchableChannels: [
+        expect.objectContaining({ id: "slack-channel-1" }),
+        expect.objectContaining({ id: "slack-channel-2" }),
+      ],
+      reconnectRequired: false,
+    });
+  });
+
+  it("reports when an existing Slack connection needs the search permission", () => {
+    const options: AgentOptions = {
+      ...OPTIONS,
+      accounts: OPTIONS.accounts.map((account) =>
+        account.id === "slack-1"
+          ? { ...account, slackContextAvailable: false }
+          : account,
+      ),
+    };
+
+    expect(resolveSlackSearchContext(options)).toMatchObject({
+      connectedAccounts: [
+        expect.objectContaining({ id: "slack-1" }),
+      ],
+      searchableAccounts: [],
+      searchableChannels: [],
+      reconnectRequired: true,
+    });
   });
 });

--- a/apps/control-plane/src/agent-context-defaults.ts
+++ b/apps/control-plane/src/agent-context-defaults.ts
@@ -20,15 +20,39 @@ export interface DefaultAgentContext {
   repositoryIds: string[];
 }
 
+export interface SlackSearchContext {
+  connectedAccounts: AgentOptions["accounts"];
+  searchableAccounts: AgentOptions["accounts"];
+  searchableChannels: AgentOptions["resources"];
+  reconnectRequired: boolean;
+}
+
+export function resolveSlackSearchContext(options: AgentOptions): SlackSearchContext {
+  const connectedAccounts = options.accounts.filter(
+    (account) => account.provider === "slack",
+  );
+  const searchableAccounts = connectedAccounts.filter(
+    (account) => account.slackContextAvailable,
+  );
+  const searchableAccountIds = new Set(
+    searchableAccounts.map((account) => account.id),
+  );
+
+  return {
+    connectedAccounts,
+    searchableAccounts,
+    searchableChannels: options.resources.filter(
+      (resource) =>
+        resource.kind === "slack_channel" &&
+        searchableAccountIds.has(resource.integrationAccountId),
+    ),
+    reconnectRequired:
+      connectedAccounts.length > 0 && searchableAccounts.length === 0,
+  };
+}
+
 export function defaultAgentContext(options: AgentOptions): DefaultAgentContext {
-  const firstSlackAccount = options.accounts.find(
-    (account) => account.provider === "slack" && account.slackContextAvailable,
-  );
-  const firstSlackChannel = options.resources.find(
-    (resource) =>
-      resource.kind === "slack_channel" &&
-      resource.integrationAccountId === firstSlackAccount?.id,
-  );
+  const firstSlackChannel = resolveSlackSearchContext(options).searchableChannels[0];
   const firstVercelProject = options.resources.find(
     (resource) => resource.kind === "vercel_project",
   );

--- a/apps/control-plane/src/pages/agent-create.tsx
+++ b/apps/control-plane/src/pages/agent-create.tsx
@@ -22,7 +22,10 @@ import {
   saveAgent,
   slackChannelLabel,
 } from "../agents-api";
-import { defaultAgentContext } from "../agent-context-defaults";
+import {
+  defaultAgentContext,
+  resolveSlackSearchContext,
+} from "../agent-context-defaults";
 import { AppShell } from "../components/app-shell";
 import {
   AgentContextIntegrationControls as ContextIntegrationControls,
@@ -900,10 +903,14 @@ export function AgentCreatePage() {
     () => accountsFor(options, "github"),
     [options],
   );
-  const slackAccounts = useMemo(
-    () => accountsFor(options, "slack"),
+  const slackSearchContext = useMemo(
+    () => resolveSlackSearchContext(options),
     [options],
   );
+  const slackAccounts = slackSearchContext.connectedAccounts;
+  const searchableSlackAccounts = slackSearchContext.searchableAccounts;
+  const searchableSlackChannels = slackSearchContext.searchableChannels;
+  const slackSearchReconnectRequired = slackSearchContext.reconnectRequired;
   const sentryProjects = useMemo(
     () => resourcesOfKind(options, "sentry_project"),
     [options],
@@ -1226,13 +1233,15 @@ export function AgentCreatePage() {
       });
       return;
     }
-    const firstAccount = slackAccounts.find((account) => account.slackContextAvailable);
-    const firstChannel = slackChannels.find(
+    const firstAccount = searchableSlackAccounts[0];
+    const firstChannel = searchableSlackChannels.find(
       (channel) => channel.integrationAccountId === firstAccount?.id,
     );
     if (!firstChannel) {
       setSlackContextDialogOpen(true);
-      void refreshSlackChannels();
+      if (!slackSearchReconnectRequired) {
+        void refreshSlackChannels();
+      }
       return;
     }
     updateDraft({
@@ -2028,7 +2037,9 @@ export function AgentCreatePage() {
                           label="Slack"
                           onConfigure={() => {
                             setSlackContextDialogOpen(true);
-                            void refreshSlackChannels();
+                            if (!slackSearchReconnectRequired) {
+                              void refreshSlackChannels();
+                            }
                           }}
                           onToggle={toggleSlackContextIntegration}
                         />
@@ -2040,7 +2051,9 @@ export function AgentCreatePage() {
                                 ? "channel"
                                 : "channels"
                             } selected · Searchable messages`
-                          : `${slackAccounts[0]!.displayName} · Choose channels for search`
+                          : slackSearchReconnectRequired
+                            ? `${slackAccounts[0]!.displayName} · Reconnect to enable channel search`
+                            : `${slackAccounts[0]!.displayName} · Choose channels for search`
                       }
                       label="Slack"
                       provider="slack"
@@ -2086,15 +2099,7 @@ export function AgentCreatePage() {
                           <div className="projectPicker slackContextPicker">
                             <span>Channels</span>
                             <div>
-                              {slackChannels
-                                .filter((channel) =>
-                                  slackAccounts.some(
-                                    (account) =>
-                                      account.id === channel.integrationAccountId &&
-                                      account.slackContextAvailable,
-                                  ),
-                                )
-                                .map((channel) => {
+                              {searchableSlackChannels.map((channel) => {
                                   const account = slackAccounts.find(
                                     (item) => item.id === channel.integrationAccountId,
                                   );
@@ -2114,6 +2119,56 @@ export function AgentCreatePage() {
                                     />
                                   );
                                 })}
+                              {slackSearchReconnectRequired ? (
+                                <div className="slackContextPicker__empty">
+                                  <span>
+                                    <strong>Reconnect Slack to search messages</strong>
+                                    <small>
+                                      Your existing connection needs permission to search
+                                      the channels you select.
+                                    </small>
+                                  </span>
+                                  <Button
+                                    disabled={connectingProvider === "slack"}
+                                    loading={connectingProvider === "slack"}
+                                    onClick={() => connect("slack")}
+                                    size="small"
+                                    type="button"
+                                    variant="primary"
+                                  >
+                                    {connectingProvider === "slack"
+                                      ? "Reconnecting…"
+                                      : "Reconnect Slack"}
+                                  </Button>
+                                </div>
+                              ) : null}
+                              {!slackSearchReconnectRequired &&
+                              searchableSlackChannels.length === 0 ? (
+                                <div className="slackContextPicker__empty">
+                                  <span>
+                                    <strong>
+                                      {refreshingSlackChannels
+                                        ? "Refreshing Slack channels…"
+                                        : "No Slack channels are available"}
+                                    </strong>
+                                    <small>
+                                      {refreshingSlackChannels
+                                        ? "This should only take a moment."
+                                        : "Invite Responder to a channel, then refresh the list."}
+                                    </small>
+                                  </span>
+                                  {!refreshingSlackChannels ? (
+                                    <Button
+                                      onClick={() => void refreshSlackChannels()}
+                                      size="small"
+                                      type="button"
+                                      variant="secondary"
+                                    >
+                                      Refresh
+                                    </Button>
+                                  ) : null}
+                                </div>
+                              ) : null}
                             </div>
                           </div>
                           {slackRefreshError ? (
@@ -2121,7 +2176,11 @@ export function AgentCreatePage() {
                           ) : null}
                         </div>
                         <footer className="configurationDialog__footer">
-                          <span>{selectedSlackContextChannels.length} selected</span>
+                          <span>
+                            {slackSearchReconnectRequired
+                              ? "Reconnect required"
+                              : `${selectedSlackContextChannels.length} selected`}
+                          </span>
                           <Button
                             onClick={() => setSlackContextDialogOpen(false)}
                             size="small"

--- a/apps/control-plane/src/styles.css
+++ b/apps/control-plane/src/styles.css
@@ -7694,6 +7694,39 @@ body:has(.appShell--create) {
   color: var(--ds-text-secondary);
 }
 
+.appShell--create .slackContextPicker__empty {
+  width: 100%;
+  min-height: 72px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.appShell--create .slackContextPicker__empty > span {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.appShell--create .slackContextPicker__empty strong {
+  color: var(--ds-text-primary);
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 18px;
+}
+
+.appShell--create .slackContextPicker__empty small {
+  color: var(--ds-text-muted);
+  font-size: 12px;
+  line-height: 17px;
+}
+
+.appShell--create .slackContextPicker__empty > .dsButton {
+  flex: 0 0 auto;
+}
+
 .appShell--create .requiredOutput__label small,
 .appShell--create .contextToolbar small,
 .appShell--create .contextRow__copy > small {


### PR DESCRIPTION
## Summary
- show a reconnect action when an existing Slack installation lacks message-search permission
- show explicit loading and no-channel states instead of an empty picker
- keep searchable channel filtering and default selection in one tested resolver

## Validation
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test` (901 tests)
- `pnpm build`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Slack channel selector rendering empty when a connected Slack workspace lacks message-search permission.

**Bug Fixes**
- Shows a Reconnect Slack action in the picker when permission is missing instead of an empty list.
- Adds explicit loading and no-channel empty states with a refresh button.
- Consolidates channel filtering and default selection into the tested `resolveSlackSearchContext` helper.

<sup>Written for commit f22838b2335ab3b6e7f8c7e8306ca4ec7bdbd0a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/responder-oss/pull/109?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

