### PR TITLE
Add Google Cloud investigation context

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ maintained separately.
 ## What it does
 
 - Watches selected Slack channels and Sentry projects for new alerts.
-- Connects GitHub, Slack, Sentry, Datadog, Axiom, AWS, Upstash, Langfuse,
+- Connects GitHub, Slack, Sentry, Datadog, Axiom, AWS, Google Cloud, Upstash, Langfuse,
   Vercel, ClickStack,
   and custom MCP servers.
 - Investigates incidents with a versioned operator-managed runtime profile.

--- a/apps/control-plane/e2e/settings-scroll.spec.ts
+++ b/apps/control-plane/e2e/settings-scroll.spec.ts
@@ -23,6 +23,7 @@ const providers = [
   ["github", "GitHub"],
   ["slack", "Slack"],
   ["aws", "AWS"],
+  ["gcp", "Google Cloud"],
   ["sentry", "Sentry"],
   ["datadog", "Datadog"],
   ["axiom", "Axiom"],
@@ -109,4 +110,28 @@ test("scrolls to integrations below the viewport", async ({ page }) => {
 
   await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThan(0);
   await expect(lastIntegration).toBeInViewport();
+});
+
+test("prepares a Google Cloud connection", async ({ page }) => {
+  await mockSettingsApis(page);
+  await page.route("**/api/integrations/gcp/start", (route) =>
+    route.fulfill({
+      json: {
+        accountId: "33333333-3333-4333-8333-333333333333",
+        projectId: "responder-production",
+        script: "#!/usr/bin/env bash\necho ready\n",
+      },
+    }),
+  );
+  await page.goto("/settings");
+
+  await page.getByRole("button", { name: "Add project manually" }).click();
+  await page.getByLabel("Project ID").fill("responder-production");
+  await page.getByLabel("Project number").fill("123456789012");
+  await page.getByRole("button", { name: "Continue" }).click();
+
+  await expect(
+    page.getByRole("heading", { name: "Create the investigation identities" }),
+  ).toBeVisible();
+  await expect(page.getByRole("button", { name: "Download script" })).toBeVisible();
 });

--- a/apps/control-plane/server/integrations/catalog.ts
+++ b/apps/control-plane/server/integrations/catalog.ts
@@ -1,5 +1,6 @@
 export const productIntegrationIds = [
   "aws",
+  "gcp",
   "github",
   "slack",
   "sentry",
@@ -28,6 +29,13 @@ export const integrationCatalog: IntegrationDefinition[] = [
     id: "aws",
     name: "AWS",
     description: "Read-only infrastructure, telemetry, and service context.",
+    implemented: true,
+    requiredEnvironment: ["AWS_INTEGRATION_PRINCIPAL_ARN"],
+  },
+  {
+    id: "gcp",
+    name: "Google Cloud",
+    description: "Read-only infrastructure, logs, metrics, and alert context.",
     implemented: true,
     requiredEnvironment: ["AWS_INTEGRATION_PRINCIPAL_ARN"],
   },

--- a/apps/control-plane/server/integrations/routes.test.ts
+++ b/apps/control-plane/server/integrations/routes.test.ts
@@ -7,6 +7,7 @@ import {
 import {
   consumeIntegrationConnectionState,
   createIntegrationConnectionState,
+  deleteIntegrationAccount,
   getOrganizationIntegrationAccount,
   getOrganizationIntegrationAccountByExternalId,
   getRecoverableSentryIntegrationAccount,
@@ -26,6 +27,10 @@ import {
   createAwsExternalId,
   verifyAwsInvestigationRole,
 } from "../../../../packages/core/src/integrations/aws.js";
+import {
+  createGcpSessionName,
+  verifyGcpProject,
+} from "../../../../packages/core/src/integrations/gcp.js";
 import {
   beginCustomMcpOAuth,
   finishCustomMcpOAuth,
@@ -58,6 +63,7 @@ vi.mock("../../../../packages/core/src/credentials/encryption.js", () => ({
 vi.mock("../../../../packages/core/src/db/integrations.js", () => ({
   consumeIntegrationConnectionState: vi.fn(),
   createIntegrationConnectionState: vi.fn(),
+  deleteIntegrationAccount: vi.fn(),
   getOrganizationIntegrationAccount: vi.fn(),
   getOrganizationIntegrationAccountByExternalId: vi.fn(),
   getRecoverableSentryIntegrationAccount: vi.fn(),
@@ -83,6 +89,17 @@ vi.mock("../../../../packages/core/src/integrations/aws.js", async (importOrigin
     createAwsCloudFormationTemplateUrl: vi.fn(),
     createAwsExternalId: vi.fn(),
     verifyAwsInvestigationRole: vi.fn(),
+  };
+});
+
+vi.mock("../../../../packages/core/src/integrations/gcp.js", async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import("../../../../packages/core/src/integrations/gcp.js")
+  >();
+  return {
+    ...actual,
+    createGcpSessionName: vi.fn(),
+    verifyGcpProject: vi.fn(),
   };
 });
 
@@ -1366,6 +1383,110 @@ describe("integration callback routing", () => {
     await expect(response.json()).resolves.toMatchObject({
       redirectUrl:
         "https://responder.example/agents/new?integration=aws&status=connected&integration_account_id=30000000-0000-4000-8000-000000000000",
+    });
+  });
+
+  it("prepares a keyless read-only GCP setup script", async () => {
+    vi.stubEnv(
+      "AWS_INTEGRATION_PRINCIPAL_ARN",
+      "arn:aws:iam::111122223333:role/ResponderAwsIntegrationBroker",
+    );
+    vi.mocked(createGcpSessionName).mockReturnValue(
+      "responder-gcp-abcdefghijklmnopqrstuvwxyz123456",
+    );
+    vi.mocked(encryptCredentials).mockReturnValue("encrypted-gcp-credentials");
+    vi.mocked(upsertIntegrationAccount).mockResolvedValue(
+      "30000000-0000-4000-8000-000000000000",
+    );
+
+    const response = await app.request("/api/integrations/gcp/connect", {
+      body: JSON.stringify({
+        projectId: "responder-production",
+        projectNumber: "123456789012",
+      }),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body).toMatchObject({
+      accountId: "30000000-0000-4000-8000-000000000000",
+      projectId: "responder-production",
+      script: expect.stringContaining("roles/cloudasset.viewer"),
+    });
+    expect(body.script).toContain("roles/mcp.toolUser");
+    expect(body.script).toContain(
+      "responder-gcp-abcdefghijklmnopqrstuvwxyz123456",
+    );
+    expect(encryptCredentials).toHaveBeenCalledWith({
+      projectId: "responder-production",
+      projectNumber: "123456789012",
+      sessionName: "responder-gcp-abcdefghijklmnopqrstuvwxyz123456",
+    });
+    expect(upsertIntegrationAccount).toHaveBeenCalledWith(
+      expect.objectContaining({
+        displayName: "GCP · responder-production",
+        externalAccountId: "responder-production",
+        provider: "gcp",
+        status: "pending",
+      }),
+    );
+  });
+
+  it("removes one GCP project account without touching other providers", async () => {
+    vi.mocked(deleteIntegrationAccount).mockResolvedValue(true);
+
+    const response = await app.request(
+      "/api/integrations/gcp/30000000-0000-4000-8000-000000000000",
+      { method: "DELETE" },
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ removed: true });
+    expect(deleteIntegrationAccount).toHaveBeenCalledWith({
+      integrationAccountId: "30000000-0000-4000-8000-000000000000",
+      organizationId: tenant.organizationId,
+      provider: "gcp",
+    });
+  });
+
+  it("verifies federated GCP access before connecting the project", async () => {
+    vi.stubEnv("BETTER_AUTH_URL", "https://responder.example");
+    vi.mocked(getOrganizationIntegrationAccount).mockResolvedValue({
+      encryptedCredentials: "encrypted-gcp-credentials",
+      id: "30000000-0000-4000-8000-000000000000",
+      metadata: {},
+      status: "pending",
+    });
+    vi.mocked(decryptCredentials).mockReturnValue({
+      projectId: "responder-production",
+      projectNumber: "123456789012",
+      sessionName: "responder-gcp-abcdefghijklmnopqrstuvwxyz123456",
+    });
+    vi.mocked(verifyGcpProject).mockResolvedValue(undefined);
+    vi.mocked(setIntegrationAccountStatus).mockResolvedValue(undefined);
+
+    const response = await app.request("/api/integrations/gcp/verify", {
+      body: JSON.stringify({
+        integrationAccountId: "30000000-0000-4000-8000-000000000000",
+        returnTo: "/agents/new",
+      }),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    });
+
+    expect(response.status).toBe(200);
+    expect(verifyGcpProject).toHaveBeenCalledWith(
+      expect.objectContaining({ projectId: "responder-production" }),
+    );
+    expect(setIntegrationAccountStatus).toHaveBeenCalledWith(
+      "30000000-0000-4000-8000-000000000000",
+      "connected",
+    );
+    await expect(response.json()).resolves.toMatchObject({
+      redirectUrl:
+        "https://responder.example/agents/new?integration=gcp&status=connected&integration_account_id=30000000-0000-4000-8000-000000000000",
     });
   });
 

--- a/apps/control-plane/server/integrations/routes.ts
+++ b/apps/control-plane/server/integrations/routes.ts
@@ -8,6 +8,7 @@ import {
 import {
   consumeIntegrationConnectionState,
   createIntegrationConnectionState,
+  deleteIntegrationAccount,
   getOrganizationIntegrationAccount,
   getOrganizationIntegrationAccountByExternalId,
   getRecoverableSentryIntegrationAccount,
@@ -117,6 +118,14 @@ import {
   createAwsExternalId,
   verifyAwsInvestigationRole,
 } from "../../../../packages/core/src/integrations/aws.js";
+import {
+  createGcpSessionName,
+  gcpConnectionCredentialsSchema,
+  gcpProjectIdSchema,
+  gcpProjectNumberSchema,
+  gcpSetupScript,
+  verifyGcpProject,
+} from "../../../../packages/core/src/integrations/gcp.js";
 
 const providerSchema = z.enum(productIntegrationIds);
 const awsConnectionSchema = z.object({
@@ -127,10 +136,29 @@ const awsVerificationSchema = z.object({
   integrationAccountId: z.uuid(),
   returnTo: z.string().max(2_048).optional(),
 });
+const gcpConnectionSchema = z.object({
+  projectId: gcpProjectIdSchema,
+  projectNumber: gcpProjectNumberSchema,
+  returnTo: z.string().max(2_048).optional(),
+});
+const gcpVerificationSchema = z.object({
+  integrationAccountId: z.uuid(),
+  returnTo: z.string().max(2_048).optional(),
+});
 
 function recoverAwsConnectionCredentials(encryptedCredentials: string) {
   try {
     return awsConnectionCredentialsSchema.safeParse(
+      decryptCredentials<Record<string, unknown>>(encryptedCredentials),
+    );
+  } catch {
+    return null;
+  }
+}
+
+function recoverGcpConnectionCredentials(encryptedCredentials: string) {
+  try {
+    return gcpConnectionCredentialsSchema.safeParse(
       decryptCredentials<Record<string, unknown>>(encryptedCredentials),
     );
   } catch {
@@ -220,6 +248,7 @@ type BrowserOAuthProvider =
   | "axiom"
   | "clickstack"
   | "custom_mcp"
+  | "gcp"
   | "github"
   | "linear"
   | "sentry"
@@ -582,10 +611,19 @@ export const integrationRoutes = new Hono()
                 : account.status,
             resourceCount: account.resourceCount,
             updatedAt: account.updatedAt,
+            ...(definition.id === "gcp"
+              ? {
+                  projectId: account.externalAccountId,
+                  ...(typeof account.metadata.projectNumber === "string"
+                    ? { projectNumber: account.metadata.projectNumber }
+                    : {}),
+                }
+              : {}),
           })),
           connectUrl:
             definition.implemented && configured
               ? definition.id === "aws" ||
+                  definition.id === "gcp" ||
                   definition.id === "datadog" ||
                   definition.id === "clickstack" ||
                   definition.id === "upstash" ||
@@ -728,6 +766,7 @@ export const integrationRoutes = new Hono()
     }
     if (
       parsedProvider.data === "aws" ||
+      parsedProvider.data === "gcp" ||
       parsedProvider.data === "datadog" ||
       parsedProvider.data === "clickstack" ||
       parsedProvider.data === "upstash" ||
@@ -1031,6 +1070,156 @@ export const integrationRoutes = new Hono()
         {
           error:
             "Responder could not assume the role yet. Wait for the CloudFormation stack to finish, then try again.",
+        },
+        401,
+      );
+    }
+  })
+  .delete("/gcp/:integrationAccountId", async (context) => {
+    const tenant = await getActiveTenant(context.req.raw.headers);
+    if (tenant.ok === false) {
+      return context.json({ error: tenant.error }, tenant.status);
+    }
+    const accountId = z.uuid().safeParse(context.req.param("integrationAccountId"));
+    if (!accountId.success) {
+      return context.json({ error: "The Google Cloud account is invalid" }, 400);
+    }
+    const deleted = await deleteIntegrationAccount({
+      integrationAccountId: accountId.data,
+      organizationId: tenant.organizationId,
+      provider: "gcp",
+    });
+    if (!deleted) {
+      return context.json({ error: "Google Cloud project connection not found" }, 404);
+    }
+    return context.json({ removed: true });
+  })
+  .post("/gcp/connect", async (context) => {
+    const tenant = await getActiveTenant(context.req.raw.headers);
+    if (tenant.ok === false) {
+      return context.json({ error: tenant.error }, tenant.status);
+    }
+    const parsed = gcpConnectionSchema.safeParse(
+      await context.req.json().catch(() => null),
+    );
+    if (!parsed.success) {
+      return context.json(
+        { error: "Enter a valid Google Cloud project ID and project number" },
+        400,
+      );
+    }
+
+    try {
+      const existing = await getOrganizationIntegrationAccountByExternalId({
+        externalAccountId: parsed.data.projectId,
+        organizationId: tenant.organizationId,
+        provider: "gcp",
+      });
+      const existingCredentials = existing?.encryptedCredentials
+        ? recoverGcpConnectionCredentials(existing.encryptedCredentials)
+        : null;
+      const credentials = {
+        projectId: parsed.data.projectId,
+        projectNumber: parsed.data.projectNumber,
+        sessionName: existingCredentials?.success
+          ? existingCredentials.data.sessionName
+          : createGcpSessionName(),
+      };
+      const accountId =
+        existing?.status === "connected" && existingCredentials?.success &&
+          existingCredentials.data.projectNumber === parsed.data.projectNumber
+          ? existing.id
+          : await upsertIntegrationAccount({
+              organizationId: tenant.organizationId,
+              provider: "gcp",
+              externalAccountId: parsed.data.projectId,
+              displayName: `GCP · ${parsed.data.projectId}`,
+              encryptedCredentials: encryptCredentials(credentials),
+              credentialKeyVersion: 1,
+              metadata: {
+                permissionRoles: [
+                  "roles/cloudasset.viewer",
+                  "roles/logging.viewer",
+                  "roles/monitoring.viewer",
+                ],
+                projectNumber: parsed.data.projectNumber,
+                serviceAccountId: "responder-investigation",
+              },
+              status: "pending",
+            });
+      return context.json({
+        accountId,
+        projectId: parsed.data.projectId,
+        script: gcpSetupScript(credentials),
+      });
+    } catch (error) {
+      logCallbackError("GCP", error, {
+        organizationId: tenant.organizationId,
+        stage: "setup",
+      });
+      return context.json(
+        { error: "Unable to prepare the Google Cloud connection" },
+        502,
+      );
+    }
+  })
+  .post("/gcp/verify", async (context) => {
+    const tenant = await getActiveTenant(context.req.raw.headers);
+    if (tenant.ok === false) {
+      return context.json({ error: tenant.error }, tenant.status);
+    }
+    const parsed = gcpVerificationSchema.safeParse(
+      await context.req.json().catch(() => null),
+    );
+    if (!parsed.success) {
+      return context.json({ error: "The Google Cloud setup session is invalid" }, 400);
+    }
+
+    const account = await getOrganizationIntegrationAccount({
+      integrationAccountId: parsed.data.integrationAccountId,
+      organizationId: tenant.organizationId,
+      provider: "gcp",
+    });
+    if (!account?.encryptedCredentials) {
+      return context.json({ error: "Start the Google Cloud connection again" }, 404);
+    }
+    try {
+      const credentials = gcpConnectionCredentialsSchema.parse(
+        decryptCredentials<Record<string, unknown>>(account.encryptedCredentials),
+      );
+      await verifyGcpProject(credentials);
+      await setIntegrationAccountStatus(account.id, "connected");
+      await captureAnalyticsEvent({
+        distinctId: tenant.user.id,
+        event: "integration connected",
+        organizationId: tenant.organizationId,
+        properties: {
+          integration_account_id: account.id,
+          provider: "gcp",
+        },
+      });
+      return context.json({
+        accountId: account.id,
+        redirectUrl: withIntegrationAccountId(
+          settingsRedirect(
+            parsed.data.returnTo ?? "/settings",
+            "gcp",
+            "connected",
+          ),
+          account.id,
+        ),
+      });
+    } catch (error) {
+      await setIntegrationAccountStatus(account.id, "error");
+      logCallbackError("GCP", error, {
+        accountId: account.id,
+        organizationId: tenant.organizationId,
+        stage: "verify",
+      });
+      return context.json(
+        {
+          error:
+            "Responder could not use the Google Cloud identity yet. Wait for the setup script to finish, then try again.",
         },
         401,
       );

--- a/apps/control-plane/src/agent-context-defaults.test.ts
+++ b/apps/control-plane/src/agent-context-defaults.test.ts
@@ -11,6 +11,7 @@ const OPTIONS: AgentOptions = {
     { id: "axiom-1", provider: "axiom", displayName: "Production" },
     { id: "aws-1", provider: "aws", displayName: "Production" },
     { id: "aws-2", provider: "aws", displayName: "Staging" },
+    { id: "gcp-1", provider: "gcp", displayName: "Production" },
     {
       id: "slack-1",
       provider: "slack",
@@ -58,7 +59,14 @@ const OPTIONS: AgentOptions = {
 describe("defaultAgentContext", () => {
   it("enables direct connections and supported resource providers", () => {
     expect(defaultAgentContext(OPTIONS)).toEqual({
-      contextAccountIds: ["sentry-1", "axiom-1", "aws-1", "aws-2", "vercel-1"],
+      contextAccountIds: [
+        "sentry-1",
+        "axiom-1",
+        "aws-1",
+        "aws-2",
+        "gcp-1",
+        "vercel-1",
+      ],
       contextResourceIds: ["slack-channel-1", "vercel-project-1"],
       repositoryIds: ["repository-1"],
     });

--- a/apps/control-plane/src/agent-context-defaults.ts
+++ b/apps/control-plane/src/agent-context-defaults.ts
@@ -4,6 +4,7 @@ const DIRECT_CONTEXT_PROVIDERS = new Set<
   AgentOptions["accounts"][number]["provider"]
 >([
   "aws",
+  "gcp",
   "sentry",
   "datadog",
   "axiom",

--- a/apps/control-plane/src/agent-detail-presentation.ts
+++ b/apps/control-plane/src/agent-detail-presentation.ts
@@ -20,6 +20,7 @@ export interface AgentPipelinePresentation {
 
 const providerLabels: Record<AgentOptions["accounts"][number]["provider"], string> = {
   aws: "AWS",
+  gcp: "Google Cloud",
   axiom: "Axiom",
   custom_mcp: "MCP",
   clickstack: "ClickStack / HyperDX",

--- a/apps/control-plane/src/agents-api.ts
+++ b/apps/control-plane/src/agents-api.ts
@@ -69,6 +69,7 @@ export interface AgentOptions {
     id: string;
     provider:
       | "aws"
+      | "gcp"
       | "github"
       | "slack"
       | "sentry"
@@ -130,6 +131,7 @@ export interface AgentListItem {
 export interface IntegrationSummary {
   id:
     | "aws"
+    | "gcp"
     | "github"
     | "slack"
     | "sentry"
@@ -202,6 +204,7 @@ export interface IssueEvidence {
   source:
     | "alert"
     | "aws"
+    | "gcp"
     | "datadog"
     | "axiom"
     | "sentry"

--- a/apps/control-plane/src/components/gcp-connection-dialog.tsx
+++ b/apps/control-plane/src/components/gcp-connection-dialog.tsx
@@ -1,0 +1,280 @@
+import { useCallback, useEffect, useState, type FormEvent } from "react";
+
+export interface GcpProjectOption {
+  displayName: string;
+  projectId: string;
+  projectNumber: string;
+}
+
+interface GcpSetup {
+  accountId: string;
+  projectId: string;
+  script: string;
+}
+
+async function prepareProject(
+  connectUrl: string,
+  project: GcpProjectOption,
+  returnTo: string,
+): Promise<GcpSetup> {
+  const response = await fetch(connectUrl, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ ...project, returnTo }),
+  });
+  const body = (await response.json().catch(() => null)) as
+    | (Partial<GcpSetup> & { error?: string })
+    | null;
+  if (!response.ok || !body?.accountId || !body.projectId || !body.script) {
+    throw new Error(body?.error ?? `Unable to prepare ${project.projectId}`);
+  }
+  return body as GcpSetup;
+}
+
+export function GcpConnectionDialog({
+  connectUrl,
+  open,
+  onCancel,
+  returnTo,
+  initialProject,
+}: {
+  connectUrl: string;
+  open: boolean;
+  onCancel: () => void;
+  returnTo: string;
+  initialProject?: GcpProjectOption;
+}) {
+  const [projectId, setProjectId] = useState(initialProject?.projectId ?? "");
+  const [projectNumber, setProjectNumber] = useState(initialProject?.projectNumber ?? "");
+  const [setups, setSetups] = useState<GcpSetup[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const cancel = useCallback(() => {
+    if (isSubmitting) return;
+    setProjectId("");
+    setProjectNumber("");
+    setSetups([]);
+    setError(null);
+    onCancel();
+  }, [isSubmitting, onCancel]);
+
+  useEffect(() => {
+    if (!open) return;
+    const closeOnEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") cancel();
+    };
+    window.addEventListener("keydown", closeOnEscape);
+    return () => window.removeEventListener("keydown", closeOnEscape);
+  }, [cancel, open]);
+
+  async function prepareProjectConnection(project: GcpProjectOption) {
+    if (isSubmitting) return;
+    setError(null);
+    setIsSubmitting(true);
+    try {
+      setSetups([await prepareProject(connectUrl, project, returnTo)]);
+    } catch (caught) {
+      setError(
+        caught instanceof Error
+          ? caught.message
+          : "Unable to prepare Google Cloud access",
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  async function prepareManual(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    await prepareProjectConnection({ displayName: projectId, projectId, projectNumber });
+  }
+
+  async function verify() {
+    if (setups.length === 0 || isSubmitting) return;
+    setError(null);
+    setIsSubmitting(true);
+    try {
+      const redirects = await Promise.all(
+        setups.map(async (setup) => {
+          const response = await fetch(connectUrl.replace(/\/connect$/u, "/verify"), {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({
+              integrationAccountId: setup.accountId,
+              returnTo,
+            }),
+          });
+          const body = (await response.json().catch(() => null)) as
+            | { error?: string; redirectUrl?: string }
+            | null;
+          if (!response.ok || !body?.redirectUrl) {
+            throw new Error(
+              body?.error ?? `Unable to verify ${setup.projectId}`,
+            );
+          }
+          return body.redirectUrl;
+        }),
+      );
+      window.location.assign(redirects.at(-1)!);
+    } catch (caught) {
+      setError(
+        caught instanceof Error
+          ? caught.message
+          : "Unable to verify Google Cloud access",
+      );
+      setIsSubmitting(false);
+    }
+  }
+
+  function downloadScript() {
+    if (setups.length === 0) return;
+    const script = setups
+      .map(({ projectId: selectedProjectId, script }) =>
+        `\n# Responder access for ${selectedProjectId}\n${script}`,
+      )
+      .join("\n");
+    const url = URL.createObjectURL(
+      new Blob([script], { type: "text/x-shellscript" }),
+    );
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = "responder-gcp-access.sh";
+    link.click();
+    setTimeout(() => URL.revokeObjectURL(url), 0);
+  }
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="siteDialogBackdrop"
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget) cancel();
+      }}
+    >
+      <section
+        aria-labelledby="gcp-connection-title"
+        aria-modal="true"
+        className="siteDialog siteDialog--credentials"
+        role="dialog"
+      >
+        <header className="siteDialog__header">
+          <span>Connect Google Cloud</span>
+          <h2 id="gcp-connection-title">
+            {setups.length > 0
+              ? "Create the investigation identities"
+              : "Add a GCP project"}
+          </h2>
+          <p>
+            Responder receives short-lived, read-only tokens. No service-account
+            keys are created or stored.
+          </p>
+        </header>
+
+        {setups.length > 0 ? (
+          <div className="siteDialog__form">
+            <ol className="siteDialog__instructions">
+              <li>Download the setup script.</li>
+              <li>
+                Open Cloud Shell and run <code>bash responder-gcp-access.sh</code>.
+                It will configure {setups.length} project
+                {setups.length === 1 ? "" : "s"}.
+              </li>
+              <li>Return here after the script reports that access is ready.</li>
+            </ol>
+            {error ? <p className="siteDialog__error" role="alert">{error}</p> : null}
+            <footer className="siteDialog__footer siteDialog__footer--wrap">
+              <button
+                className="button button--secondary button--small"
+                onClick={downloadScript}
+                type="button"
+              >
+                Download script
+              </button>
+              <button
+                className="button button--secondary button--small"
+                onClick={() => window.open(
+                  `https://console.cloud.google.com/cloudshell/editor?project=${encodeURIComponent(setups[0]!.projectId)}`,
+                  "_blank",
+                  "noopener,noreferrer",
+                )}
+                type="button"
+              >
+                Open Cloud Shell
+              </button>
+              <button
+                className="button button--primary button--small"
+                disabled={isSubmitting}
+                onClick={() => void verify()}
+                type="button"
+              >
+                {isSubmitting ? "Verifying…" : "Verify connections"}
+              </button>
+            </footer>
+          </div>
+        ) : (
+          <form className="siteDialog__form" onSubmit={prepareManual}>
+            <label className="siteDialog__field">
+              <span>Project ID</span>
+              <input
+                autoFocus
+                disabled={isSubmitting}
+                maxLength={30}
+                minLength={6}
+                onChange={(event) => setProjectId(event.target.value.toLowerCase())}
+                placeholder="my-production-project"
+                required
+                value={projectId}
+              />
+            </label>
+            <label className="siteDialog__field">
+              <span>Project number</span>
+              <input
+                disabled={isSubmitting}
+                inputMode="numeric"
+                maxLength={20}
+                minLength={1}
+                onChange={(event) =>
+                  setProjectNumber(event.target.value.replace(/\D/gu, ""))
+                }
+                placeholder="123456789012"
+                required
+                value={projectNumber}
+              />
+            </label>
+            <p className="siteDialog__oauthNote">
+              Find both values in the{" "}
+              <a
+                href="https://console.cloud.google.com/cloud-resource-manager"
+                rel="noreferrer"
+                target="_blank"
+              >
+                Google Cloud project selector
+              </a>
+              . Access is limited to asset metadata, logs, metrics, and alerting
+              state.
+            </p>
+            {error ? <p className="siteDialog__error" role="alert">{error}</p> : null}
+            <footer className="siteDialog__footer">
+              <button
+                className="button button--secondary button--small"
+                onClick={cancel}
+                type="button"
+              >
+                Cancel
+              </button>
+              <button
+                className="button button--primary button--small"
+                disabled={isSubmitting || projectId.length < 6 || projectNumber.length < 1}
+                type="submit"
+              >
+                {isSubmitting ? "Preparing…" : "Continue"}
+              </button>
+            </footer>
+          </form>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/apps/control-plane/src/components/icons.test.ts
+++ b/apps/control-plane/src/components/icons.test.ts
@@ -83,4 +83,15 @@ describe("ProviderGlyph", () => {
     expect(markup).toContain('class="providerGlyph__asset"');
     expect(markup).not.toContain(">AWS</span>");
   });
+
+  it("renders the Google mark for Google Cloud", () => {
+    const markup = renderToStaticMarkup(
+      createElement(ProviderGlyph, { provider: "gcp" }),
+    );
+
+    expect(markup).toContain('aria-label="Google Cloud"');
+    expect(markup).toContain("providerGlyph--gcp");
+    expect(markup).toContain("#4285f4");
+    expect(markup).not.toContain(">GCP</span>");
+  });
 });

--- a/apps/control-plane/src/components/provider-glyphs.ts
+++ b/apps/control-plane/src/components/provider-glyphs.ts
@@ -5,6 +5,7 @@ export const providerGlyphs = {
   custom_mcp: { label: "Custom MCP", text: "MCP" },
   datadog: { label: "Datadog", logo: "datadog" },
   github: { label: "GitHub", logo: "github" },
+  gcp: { label: "Google Cloud", logo: "google" },
   google: { label: "Google", logo: "google" },
   linear: { label: "Linear", logo: "linear" },
   langfuse: { label: "Langfuse", logo: "langfuse" },

--- a/apps/control-plane/src/pages/agent-context-storyboard.tsx
+++ b/apps/control-plane/src/pages/agent-context-storyboard.tsx
@@ -75,6 +75,7 @@ const CATEGORY_DESCRIPTIONS: Record<IntegrationCategory, string> = {
 
 const MULTI_INSTANCE_PROVIDERS = new Set<ProviderId>([
   "aws",
+  "gcp",
   "custom_mcp",
   "langfuse",
 ]);
@@ -149,6 +150,13 @@ const INTEGRATIONS: StoryboardIntegration[] = [
     id: "aws",
     name: "AWS",
     searchTerms: "cloud infrastructure services iam accounts",
+  },
+  {
+    category: "Data & infrastructure",
+    description: "Asset inventory, logs, metrics, and alerting state",
+    id: "gcp",
+    name: "Google Cloud",
+    searchTerms: "gcp cloud infrastructure projects logs metrics assets",
   },
   {
     category: "Data & infrastructure",
@@ -776,7 +784,7 @@ export function AgentContextStoryboardPage() {
     const existing = instances.filter((connection) => connection.provider === integration.id);
     const nextNumber = existing.length + 1;
     const label = MULTI_INSTANCE_PROVIDERS.has(integration.id) && existing.length > 0
-      ? `New ${integration.id === "langfuse" ? "project" : integration.id === "aws" ? "account" : "MCP server"} ${nextNumber}`
+      ? `New ${integration.id === "langfuse" || integration.id === "gcp" ? "project" : integration.id === "aws" ? "account" : "MCP server"} ${nextNumber}`
       : integration.name;
     const configuration =
       integration.id === "github" ||

--- a/apps/control-plane/src/pages/agent-create.tsx
+++ b/apps/control-plane/src/pages/agent-create.tsx
@@ -38,6 +38,7 @@ import {
 } from "../components/datadog-site-dialog";
 import { ClickStackConnectionDialog } from "../components/clickstack-connection-dialog";
 import { AwsConnectionDialog } from "../components/aws-connection-dialog";
+import { GcpConnectionDialog } from "../components/gcp-connection-dialog";
 import { CustomMcpConnectionDialog } from "../components/custom-mcp-dialog";
 import { UpstashConnectionDialog } from "../components/upstash-connection-dialog";
 import { LangfuseConnectionDialog } from "../components/langfuse-connection-dialog";
@@ -106,12 +107,14 @@ const CONTEXT_PROVIDER_METADATA: Record<
   slack: { category: "Communication & workflow", searchTerms: "channels messages chat" },
   linear: { category: "Communication & workflow", searchTerms: "issues projects tickets" },
   aws: { category: "Data & infrastructure", searchTerms: "cloud accounts iam services" },
+  gcp: { category: "Data & infrastructure", searchTerms: "google cloud projects logs metrics assets" },
   upstash: { category: "Data & infrastructure", searchTerms: "redis vector qstash workflow" },
   custom_mcp: { category: "Data & infrastructure", searchTerms: "custom tools server mcp" },
 };
 
 const MULTI_ACCOUNT_CONTEXT_PROVIDERS = new Set<IntegrationSummary["id"]>([
   "aws",
+  "gcp",
   "custom_mcp",
   "langfuse",
 ]);
@@ -462,6 +465,7 @@ export function AgentCreatePage() {
   const linearJustConnected = successfulConnectionReturn("linear");
   const vercelJustConnected = successfulConnectionReturn("vercel");
   const awsJustConnected = successfulConnectionReturn("aws");
+  const gcpJustConnected = successfulConnectionReturn("gcp");
   const returnedIntegrationAccountId = new URLSearchParams(
     window.location.search,
   ).get("integration_account_id");
@@ -477,7 +481,8 @@ export function AgentCreatePage() {
     customMcpJustConnected ||
     clickStackJustConnected ||
     linearJustConnected ||
-    awsJustConnected;
+    awsJustConnected ||
+    gcpJustConnected;
   const [options, setOptions] = useState<AgentOptions>(EMPTY_OPTIONS);
   const [integrations, setIntegrations] = useState<IntegrationSummary[]>([]);
   const [existingConfiguration, setExistingConfiguration] =
@@ -524,6 +529,7 @@ export function AgentCreatePage() {
   const [connectingLangfuse, setConnectingLangfuse] = useState(false);
   const [connectingClickStack, setConnectingClickStack] = useState(false);
   const [connectingAws, setConnectingAws] = useState(false);
+  const [connectingGcp, setConnectingGcp] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [refreshingGithubRepositories, setRefreshingGithubRepositories] =
     useState(false);
@@ -806,6 +812,17 @@ export function AgentCreatePage() {
         ) {
           loadedDraft.contextAccountIds.push(connectedAwsId);
         }
+        const connectedGcpId = returnedIntegrationAccountId;
+        if (
+          gcpJustConnected &&
+          connectedGcpId &&
+          loadedOptions.accounts.some(
+            (account) => account.id === connectedGcpId && account.provider === "gcp",
+          ) &&
+          !loadedDraft.contextAccountIds.includes(connectedGcpId)
+        ) {
+          loadedDraft.contextAccountIds.push(connectedGcpId);
+        }
         setDraft(loadedDraft);
       })
       .catch((caught: unknown) => {
@@ -827,6 +844,7 @@ export function AgentCreatePage() {
     agentId,
     axiomJustConnected,
     awsJustConnected,
+    gcpJustConnected,
     clickStackJustConnected,
     customMcpJustConnected,
     datadogJustConnected,
@@ -865,6 +883,10 @@ export function AgentCreatePage() {
   );
   const awsAccounts = useMemo(
     () => accountsFor(options, "aws"),
+    [options],
+  );
+  const gcpAccounts = useMemo(
+    () => accountsFor(options, "gcp"),
     [options],
   );
   const datadogAccounts = useMemo(
@@ -1129,6 +1151,7 @@ export function AgentCreatePage() {
     }
     if (
       provider === "aws" ||
+      provider === "gcp" ||
       provider === "datadog" ||
       provider === "clickstack" ||
       provider === "upstash" ||
@@ -1136,6 +1159,7 @@ export function AgentCreatePage() {
     ) {
       saveDraftToSessionStorage(draftStorageKey, currentDraft, options);
       if (provider === "aws") setConnectingAws(true);
+      else if (provider === "gcp") setConnectingGcp(true);
       else if (provider === "datadog") setChoosingDatadogSite(true);
       else if (provider === "clickstack") setConnectingClickStack(true);
       else if (provider === "langfuse") setConnectingLangfuse(true);
@@ -1539,6 +1563,9 @@ export function AgentCreatePage() {
     awsAccounts.filter((account) =>
       draft.contextAccountIds.includes(account.id),
     ).length +
+    gcpAccounts.filter((account) =>
+      draft.contextAccountIds.includes(account.id),
+    ).length +
     clickStackAccounts.filter((account) =>
       draft.contextAccountIds.includes(account.id),
     ).length +
@@ -1597,6 +1624,12 @@ export function AgentCreatePage() {
         connectUrl={integrationFor("aws")?.connectUrl ?? ""}
         onCancel={() => setConnectingAws(false)}
         open={connectingAws}
+        returnTo={returnTo}
+      />
+      <GcpConnectionDialog
+        connectUrl={integrationFor("gcp")?.connectUrl ?? ""}
+        onCancel={() => setConnectingGcp(false)}
+        open={connectingGcp}
         returnTo={returnTo}
       />
       <section className="createAgentHeading">
@@ -2420,6 +2453,25 @@ export function AgentCreatePage() {
                         key={account.id}
                         label={account.displayName}
                         provider="aws"
+                      />
+                    );
+                  })}
+                  {gcpAccounts.map((account) => {
+                    const connected = draft.contextAccountIds.includes(account.id);
+                    return (
+                      <ContextRow
+                        action={
+                          <ContextIntegrationControls
+                            enabled={connected}
+                            label={account.displayName}
+                            onConfigure={() => setConnectionSettingsOpen(account)}
+                            onToggle={() => toggleContextAccount(account.id)}
+                          />
+                        }
+                        detail="Asset inventory, logs, metrics, and alerting state"
+                        key={account.id}
+                        label={account.displayName}
+                        provider="gcp"
                       />
                     );
                   })}

--- a/apps/control-plane/src/pages/issue-detail-presentation.test.ts
+++ b/apps/control-plane/src/pages/issue-detail-presentation.test.ts
@@ -123,6 +123,7 @@ describe("evidenceSourceGlyph", () => {
   it("uses the provider logo when the source is a provider", () => {
     expect(evidenceSourceGlyph("sentry")).toBe("sentry");
     expect(evidenceSourceGlyph("aws")).toBe("aws");
+    expect(evidenceSourceGlyph("gcp")).toBe("gcp");
     expect(evidenceSourceGlyph("langfuse")).toBe("langfuse");
   });
 

--- a/apps/control-plane/src/pages/settings.tsx
+++ b/apps/control-plane/src/pages/settings.tsx
@@ -5,6 +5,7 @@ import {
 } from "../components/datadog-site-dialog";
 import { ClickStackConnectionDialog } from "../components/clickstack-connection-dialog";
 import { AwsConnectionDialog } from "../components/aws-connection-dialog";
+import { GcpConnectionDialog } from "../components/gcp-connection-dialog";
 import { CustomMcpConnectionDialog } from "../components/custom-mcp-dialog";
 import { UpstashConnectionDialog } from "../components/upstash-connection-dialog";
 import { LangfuseConnectionDialog } from "../components/langfuse-connection-dialog";
@@ -24,6 +25,7 @@ type IntegrationState =
 interface IntegrationSummary {
   id:
     | "aws"
+    | "gcp"
     | "github"
     | "slack"
     | "sentry"
@@ -46,6 +48,8 @@ interface IntegrationSummary {
     status: "connected" | "error" | "pending";
     resourceCount: number;
     updatedAt: string;
+    projectId?: string;
+    projectNumber?: string;
   }>;
   connectUrl: string | null;
   configurationUrl: string | null;
@@ -223,6 +227,7 @@ export function SettingsPage() {
   const secondary = integrations.filter((integration) =>
     [
       "aws",
+      "gcp",
       "sentry",
       "datadog",
       "axiom",
@@ -335,6 +340,19 @@ function integrationDetail(
 }
 
 function IntegrationCard({
+  integration,
+  sentryHealth,
+}: {
+  integration: IntegrationSummary;
+  sentryHealth: SentryHealth | null;
+}) {
+  if (integration.id === "gcp") {
+    return <GcpIntegrationCard integration={integration} />;
+  }
+  return <DefaultIntegrationCard integration={integration} sentryHealth={sentryHealth} />;
+}
+
+function DefaultIntegrationCard({
   integration,
   sentryHealth,
 }: {
@@ -463,5 +481,142 @@ function IntegrationCard({
         returnTo="/settings"
       />
     </>
+  );
+}
+
+function GcpIntegrationCard({
+  integration,
+}: {
+  integration: IntegrationSummary;
+}) {
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [reconnectProject, setReconnectProject] = useState<{
+    displayName: string;
+    projectId: string;
+    projectNumber: string;
+  } | undefined>();
+  const [removingAccountId, setRemovingAccountId] = useState<string | null>(null);
+  const [removeError, setRemoveError] = useState<string | null>(null);
+  const canConnect = Boolean(integration.connectUrl);
+
+  return (
+    <article className="integrationCard integrationCard--managed">
+      <div className="integrationCard__top">
+        <ProviderGlyph
+          className="integrationLogo integrationLogo--gcp"
+          decorative
+          provider="gcp"
+        />
+        {integration.accounts.some((account) => account.status === "error") ? (
+          <span className="connectedBadge connectedBadge--warning">Action needed</span>
+        ) : integration.accountCount > 0 ? (
+          <span className="connectedBadge">Connected</span>
+        ) : null}
+      </div>
+      <div className="integrationCard__body">
+        <strong>Google Cloud</strong>
+        <small>
+          {integration.accountCount > 0
+            ? `${integration.accountCount} connected project${integration.accountCount === 1 ? "" : "s"}`
+            : "Read-only infrastructure, logs, metrics, and alert context."}
+        </small>
+        {integration.accounts.length > 0 ? (
+          <ul className="integrationCard__accounts" aria-label="Connected Google Cloud projects">
+            {integration.accounts.map((account) => (
+              <li key={account.id}>
+                <span>
+                  <strong>{account.displayName.replace(/^GCP · /u, "")}</strong>
+                  <small>
+                    {account.projectNumber
+                      ? `Project number ${account.projectNumber}`
+                      : account.status === "pending"
+                        ? "Setup pending"
+                        : account.status === "error"
+                          ? "Needs attention"
+                          : "Read-only access"}
+                  </small>
+                </span>
+                <span className="integrationCard__accountStatus">
+                  {account.status === "connected"
+                    ? "Connected"
+                    : account.status === "pending"
+                      ? "Pending"
+                      : "Error"}
+                </span>
+                <span className="integrationCard__accountActions">
+                  {account.projectNumber ? (
+                    <button
+                      className="button button--secondary button--small"
+                      onClick={() => {
+                        setReconnectProject({
+                          displayName: account.displayName.replace(/^GCP · /u, ""),
+                          projectId: account.projectId ?? account.displayName.replace(/^GCP · /u, ""),
+                          projectNumber: account.projectNumber!,
+                        });
+                        setDialogOpen(true);
+                      }}
+                      type="button"
+                    >
+                      Reconnect
+                    </button>
+                  ) : null}
+                  <button
+                    className="button button--secondary button--small"
+                    disabled={removingAccountId === account.id}
+                    onClick={() => {
+                      if (!window.confirm(
+                        `Remove ${account.displayName.replace(/^GCP · /u, "")} from Responder? This does not revoke IAM in Google Cloud.`,
+                      )) return;
+                      setRemoveError(null);
+                      setRemovingAccountId(account.id);
+                      void fetch(`/api/integrations/gcp/${account.id}`, { method: "DELETE" })
+                        .then(async (response) => {
+                          if (!response.ok) {
+                            const body = (await response.json().catch(() => null)) as { error?: string } | null;
+                            throw new Error(body?.error ?? "Unable to remove the project");
+                          }
+                          window.location.reload();
+                        })
+                        .catch((cause: unknown) => {
+                          setRemoveError(cause instanceof Error ? cause.message : "Unable to remove the project");
+                          setRemovingAccountId(null);
+                        });
+                    }}
+                    type="button"
+                  >
+                    {removingAccountId === account.id ? "Removing…" : "Remove"}
+                  </button>
+                </span>
+              </li>
+            ))}
+          </ul>
+        ) : null}
+      </div>
+      {removeError ? <p className="siteDialog__error">{removeError}</p> : null}
+      <div className="integrationCard__actions">
+        {canConnect ? (
+          <button
+            className="button button--primary button--small"
+            onClick={() => setDialogOpen(true)}
+            type="button"
+          >
+            Add project manually
+          </button>
+        ) : (
+          <small>Provider configuration required</small>
+        )}
+      </div>
+      <GcpConnectionDialog
+        connectUrl={integration.connectUrl ?? "/api/integrations/gcp/connect"}
+        initialProject={reconnectProject}
+        key={reconnectProject?.projectId ?? "manual"}
+        onCancel={() => {
+          setDialogOpen(false);
+          setReconnectProject(undefined);
+        }}
+        open={dialogOpen}
+        returnTo="/settings"
+      />
+    </article>
   );
 }

--- a/apps/control-plane/src/pages/tag-mode-settings.tsx
+++ b/apps/control-plane/src/pages/tag-mode-settings.tsx
@@ -10,6 +10,7 @@ import {
   type SlackThreadModeConfiguration,
 } from "../agents-api";
 import { AwsConnectionDialog } from "../components/aws-connection-dialog";
+import { GcpConnectionDialog } from "../components/gcp-connection-dialog";
 import { ClickStackConnectionDialog } from "../components/clickstack-connection-dialog";
 import { CustomMcpConnectionDialog } from "../components/custom-mcp-dialog";
 import { DatadogConnectionDialog } from "../components/datadog-site-dialog";
@@ -73,11 +74,13 @@ const contextProviderMetadata: Record<
   slack: { category: "Communication & workflow", searchTerms: "channels messages chat" },
   linear: { category: "Communication & workflow", searchTerms: "issues projects tickets" },
   aws: { category: "Data & infrastructure", searchTerms: "cloud accounts iam services" },
+  gcp: { category: "Data & infrastructure", searchTerms: "google cloud projects logs metrics assets" },
   upstash: { category: "Data & infrastructure", searchTerms: "redis vector qstash workflow" },
   custom_mcp: { category: "Data & infrastructure", searchTerms: "custom tools server mcp" },
 };
 const multiAccountContextProviders = new Set<IntegrationSummary["id"]>([
   "aws",
+  "gcp",
   "custom_mcp",
   "langfuse",
 ]);
@@ -85,6 +88,7 @@ const multiAccountContextProviders = new Set<IntegrationSummary["id"]>([
 const contextProviderOrder: ContextAccount["provider"][] = [
   "sentry",
   "aws",
+  "gcp",
   "upstash",
   "langfuse",
   "datadog",
@@ -107,6 +111,8 @@ function accountDetail(account: ContextAccount): string {
       return `${prefix}Issues, events, and traces`;
     case "aws":
       return "Infrastructure, telemetry, configuration, and service health";
+    case "gcp":
+      return "Asset inventory, logs, metrics, and alerting state";
     case "upstash":
       return `${prefix}Redis, Vector, Search, QStash, and Workflow`;
     case "langfuse":
@@ -144,6 +150,7 @@ export function TagModeSettingsPage() {
   const [connectingProvider, setConnectingProvider] =
     useState<IntegrationSummary["id"] | null>(null);
   const [connectingAws, setConnectingAws] = useState(false);
+  const [connectingGcp, setConnectingGcp] = useState(false);
   const [choosingDatadogSite, setChoosingDatadogSite] = useState(false);
   const [configuringCustomMcp, setConfiguringCustomMcp] = useState(false);
   const [connectingUpstash, setConnectingUpstash] = useState(false);
@@ -320,6 +327,10 @@ export function TagModeSettingsPage() {
       setConnectingAws(true);
       return;
     }
+    if (integration.id === "gcp") {
+      setConnectingGcp(true);
+      return;
+    }
     if (integration.id === "datadog") {
       setChoosingDatadogSite(true);
       return;
@@ -419,6 +430,12 @@ export function TagModeSettingsPage() {
         connectUrl={integrations.find((item) => item.id === "aws")?.connectUrl ?? ""}
         onCancel={() => setConnectingAws(false)}
         open={connectingAws}
+        returnTo="/settings/tag-mode"
+      />
+      <GcpConnectionDialog
+        connectUrl={integrations.find((item) => item.id === "gcp")?.connectUrl ?? ""}
+        onCancel={() => setConnectingGcp(false)}
+        open={connectingGcp}
         returnTo="/settings/tag-mode"
       />
       <section className="settingsHeading">

--- a/apps/control-plane/src/styles.css
+++ b/apps/control-plane/src/styles.css
@@ -603,6 +603,77 @@ body:has(.appShell--investigation) {
   line-height: 18px;
 }
 
+.appShell--settings .integrationCard--managed {
+  min-height: 260px;
+  display: flex;
+  flex-direction: column;
+}
+
+.appShell--settings .integrationCard--managed .integrationCard__body {
+  flex: 1;
+}
+
+.appShell--settings .integrationCard__accounts {
+  margin: 14px 0 0;
+  padding: 0;
+  display: grid;
+  gap: 6px;
+  list-style: none;
+}
+
+.appShell--settings .integrationCard__accounts li {
+  padding: 8px 10px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  border: 1px solid var(--ds-border-subtle);
+  border-radius: var(--ds-radius-small);
+  background: var(--ds-surface-raised);
+}
+
+.appShell--settings .integrationCard__accounts li > span:first-child {
+  min-width: 0;
+  display: grid;
+  gap: 1px;
+}
+
+.appShell--settings .integrationCard__accounts li strong {
+  overflow: hidden;
+  color: var(--ds-text-primary);
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 16px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.appShell--settings .integrationCard__accounts li small {
+  overflow: hidden;
+  font-size: 10px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.appShell--settings .integrationCard__accountStatus {
+  flex: 0 0 auto;
+  color: var(--ds-text-muted);
+  font-size: 10px;
+}
+
+.appShell--settings .integrationCard__accountActions {
+  flex: 0 0 auto;
+  display: flex;
+  gap: 5px;
+}
+
+.appShell--settings .integrationCard__actions {
+  margin-top: 16px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
 .appShell--settings .integrationCard__arrow {
   right: 17px;
   bottom: 17px;

--- a/apps/worker/src/gcp.test.ts
+++ b/apps/worker/src/gcp.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { gcpReadOnlyToolFilter } from "./gcp.js";
+
+describe("GCP MCP", () => {
+  it("exposes only tools explicitly annotated read-only", async () => {
+    await expect(
+      gcpReadOnlyToolFilter({}, {
+        annotations: { readOnlyHint: true },
+        name: "list_assets",
+      }),
+    ).resolves.toBe(true);
+    await expect(
+      gcpReadOnlyToolFilter({}, {
+        annotations: { readOnlyHint: false },
+        name: "create_alert_policy",
+      }),
+    ).resolves.toBe(false);
+    await expect(
+      gcpReadOnlyToolFilter({}, { name: "unknown_tool" }),
+    ).resolves.toBe(false);
+  });
+});

--- a/apps/worker/src/gcp.ts
+++ b/apps/worker/src/gcp.ts
@@ -1,0 +1,46 @@
+import { MCPServerStreamableHttp } from "@openai/agents";
+import type { RuntimeGcpConnection } from "@responder/core/db/investigations";
+import { createGcpAuthClient } from "@responder/core/integrations/gcp";
+
+const GCP_MCP_SERVERS = [
+  { id: "assets", url: "https://cloudasset.googleapis.com/mcp" },
+  { id: "logging", url: "https://logging.googleapis.com/mcp" },
+  { id: "monitoring", url: "https://monitoring.googleapis.com/mcp" },
+] as const;
+
+export function gcpReadOnlyToolFilter(
+  _context: unknown,
+  tool: unknown,
+): Promise<boolean> {
+  const candidate = tool as { annotations?: { readOnlyHint?: boolean } };
+  return Promise.resolve(candidate.annotations?.readOnlyHint === true);
+}
+
+export function createGcpMcpServers(
+  connection: RuntimeGcpConnection,
+  environment: NodeJS.ProcessEnv = process.env,
+): MCPServerStreamableHttp[] {
+  const auth = createGcpAuthClient(connection, { environment });
+  const authenticatedFetch: typeof fetch = async (input, init) => {
+    const request = new Request(input, init);
+    const authHeaders = await auth.getRequestHeaders();
+    const headers = new Headers(request.headers);
+    for (const [name, value] of authHeaders) headers.set(name, value);
+    headers.set("x-goog-user-project", connection.projectId);
+    return fetch(request, { headers });
+  };
+
+  return GCP_MCP_SERVERS.map(
+    ({ id, url }) =>
+      new MCPServerStreamableHttp({
+        cacheToolsList: true,
+        clientSessionTimeoutSeconds: 300,
+        fetch: authenticatedFetch,
+        name: `gcp-${connection.accountId}-${id}`,
+        timeout: 60_000,
+        toolFilter: gcpReadOnlyToolFilter,
+        url,
+        useStructuredContent: true,
+      }),
+  );
+}

--- a/apps/worker/src/investigate.test.ts
+++ b/apps/worker/src/investigate.test.ts
@@ -75,6 +75,24 @@ describe("sandbox agent configuration", () => {
     });
   });
 
+  it("identifies GCP connection failures without exposing federated credentials", () => {
+    expect(
+      contextServerConnectFailureEvent({
+        customMcpConnections: [],
+        error: new Error("request failed with federated access token"),
+        gcpConnections: [{ accountId: "account-gcp" }],
+        investigationId: "investigation-123",
+        serverName: "gcp-account-gcp-logging",
+      }),
+    ).toEqual({
+      accountId: "account-gcp",
+      error: "Unable to connect to GCP context",
+      event: "context_server_connect_failed",
+      investigationId: "investigation-123",
+      server: "gcp-account-gcp-logging",
+    });
+  });
+
   it("identifies Langfuse connection failures without exposing project keys", () => {
     expect(
       contextServerConnectFailureEvent({
@@ -320,6 +338,23 @@ describe("sandbox agent configuration", () => {
     expect(instructions).toContain("exact PascalCase AWS API operation names");
     expect(instructions).toContain("outer success status");
     expect(instructions).toContain("# AWS Observability");
+  });
+
+  it("keeps GCP investigation access read-only", () => {
+    const instructions = investigationInstructions({
+      agentPrompt: "Inspect the reported failure.",
+      clickStackConnected: false,
+      datadogConnected: false,
+      gcpProjectNames: ["GCP · production (production-123)"],
+      repositories: [],
+      sentryConnected: false,
+    });
+
+    expect(instructions).toContain("Google Cloud Asset Inventory");
+    expect(instructions).toContain("GCP · production (production-123)");
+    expect(instructions).toContain("Never request secret values");
+    expect(instructions).toContain("Never request secret values or attempt to change");
+    expect(instructions).not.toContain("No observability data source is connected");
   });
 
   it("stores the exact initial message that is sent to the agent", () => {

--- a/apps/worker/src/investigate.ts
+++ b/apps/worker/src/investigate.ts
@@ -6,6 +6,7 @@ import {
 } from "@openai/agents-extensions/sandbox/daytona";
 import {
   getRuntimeAwsConnections,
+  getRuntimeGcpConnections,
   getRuntimeAxiomConnection,
   getRuntimeCustomMcpConnections,
   getRuntimeDatadogConnection,
@@ -41,6 +42,7 @@ import {
   loadAwsAlarmSkillContext,
 } from "./aws.js";
 import { createAwsInspectionTools } from "./aws-inspection-tools.js";
+import { createGcpMcpServers } from "./gcp.js";
 import { createAxiomMcpServer } from "./axiom.js";
 import { createDatadogMcpServer } from "./datadog.js";
 import { createCustomMcpServer, createLinearMcpServer } from "./custom-mcp.js";
@@ -127,6 +129,7 @@ export function investigationTraceWriteFailure(
 
 export function contextServerConnectFailureEvent(input: {
   awsConnections?: ReadonlyArray<{ accountId: string }>;
+  gcpConnections?: ReadonlyArray<{ accountId: string }>;
   customMcpConnections: ReadonlyArray<{ accountId: string }>;
   langfuseConnections?: ReadonlyArray<{ accountId: string }>;
   error: unknown;
@@ -136,6 +139,8 @@ export function contextServerConnectFailureEvent(input: {
 }) {
   const protectedProvider = input.serverName.startsWith("aws-")
     ? "AWS"
+    : input.serverName.startsWith("gcp-")
+      ? "GCP"
     : input.serverName.startsWith("langfuse-")
       ? "Langfuse"
       : input.serverName.startsWith("upstash-")
@@ -147,6 +152,10 @@ export function contextServerConnectFailureEvent(input: {
       ? input.awsConnections?.find(
           (connection) => input.serverName === `aws-${connection.accountId}`,
         )?.accountId
+      : input.serverName.startsWith("gcp-")
+        ? input.gcpConnections?.find(
+            (connection) => input.serverName.startsWith(`gcp-${connection.accountId}-`),
+          )?.accountId
       : input.serverName.startsWith("langfuse-")
         ? input.langfuseConnections?.find(
             (connection) =>
@@ -270,6 +279,7 @@ export function investigationInstructions(input: {
   awsAlarmTriggered?: boolean;
   awsAccountNames?: string[];
   awsSkillContext?: string;
+  gcpProjectNames?: string[];
   customMcpNames?: string[];
   axiomConnected?: boolean;
   datadogConnected: boolean;
@@ -292,6 +302,7 @@ export function investigationInstructions(input: {
 }): string {
   const awsAccountNames = input.awsAccountNames ?? [];
   const customMcpNames = input.customMcpNames ?? [];
+  const gcpProjectNames = input.gcpProjectNames ?? [];
   const langfuseProjectNames = input.langfuseProjectNames ?? [];
   const slackChannels = input.slackChannels ?? [];
   const workspaceSecrets = input.workspaceSecrets ?? [];
@@ -306,6 +317,7 @@ export function investigationInstructions(input: {
     langfuseProjectNames.length > 0 ||
     vercelAccountIds.length > 0 ||
     awsAccountNames.length > 0 ||
+    gcpProjectNames.length > 0 ||
     customMcpNames.length > 0;
   return [
     input.runtimeSystemPrompt,
@@ -322,6 +334,9 @@ export function investigationInstructions(input: {
       : null,
     awsAccountNames.length > 0
       ? "Prefer the typed aws_inspect_cloudwatch_alarm, aws_inspect_cloudwatch_metric, aws_query_cloudwatch_logs, aws_inspect_sqs_queue, and aws_inspect_lambda_function tools for AWS evidence. If aws___run_script is necessary, use top-level await instead of asyncio.run, use exact PascalCase AWS API operation names, and inspect every nested api_calls result. An outer success status does not mean the nested AWS calls succeeded; retry failed nested calls with corrected operation names."
+      : null,
+    gcpProjectNames.length > 0
+      ? `Use the connected read-only Google Cloud Asset Inventory, Logging, and Monitoring tools to inspect relevant resources and telemetry before concluding. Connected GCP projects: ${gcpProjectNames.join(", ")}. Never request secret values or attempt to change cloud resources.`
       : null,
     input.datadogConnected
       ? "Use the connected Datadog tools to inspect the matching logs and surrounding service activity before concluding."
@@ -472,6 +487,7 @@ export async function runInvestigationAgent(
   const [
     runtimeProfile,
     awsConnections,
+    gcpConnections,
     axiomConnection,
     datadogConnection,
     sentryConnection,
@@ -486,6 +502,7 @@ export async function runInvestigationAgent(
   ] = await Promise.all([
     getRuntimeProfile(job.runtimeProfileId),
     getRuntimeAwsConnections(job.config.id),
+    getRuntimeGcpConnections(job.config.id),
     getRuntimeAxiomConnection(job.config.id),
     getRuntimeDatadogConnection(job.config.id),
     loadSentryConnectionForInvestigation({
@@ -508,6 +525,9 @@ export async function runInvestigationAgent(
   ]);
   const awsServers = await Promise.all(
     awsConnections.map((connection) => createAwsMcpServer(connection, environment)),
+  );
+  const gcpServers = gcpConnections.flatMap((connection) =>
+    createGcpMcpServers(connection, environment)
   );
   const datadogServer = datadogConnection
     ? createDatadogMcpServer(datadogConnection)
@@ -547,6 +567,7 @@ export async function runInvestigationAgent(
     upstashServer,
     ...langfuseServers,
     ...awsServers,
+    ...gcpServers,
     ...customMcpServers,
   ].filter(
     (server): server is NonNullable<typeof server> => server !== null,
@@ -571,6 +592,7 @@ export async function runInvestigationAgent(
             JSON.stringify(
               contextServerConnectFailureEvent({
                 awsConnections,
+                gcpConnections,
                 customMcpConnections,
                 error,
                 investigationId: job.investigationId,
@@ -585,6 +607,9 @@ export async function runInvestigationAgent(
           }
           if (server.name.startsWith("aws-")) {
             throw new Error("Unable to connect to AWS context");
+          }
+          if (server.name.startsWith("gcp-")) {
+            throw new Error("Unable to connect to GCP context");
           }
           if (server.name.startsWith("langfuse-")) {
             throw new Error("Unable to connect to Langfuse context");
@@ -687,6 +712,9 @@ export async function runInvestigationAgent(
           `${connection.displayName} (${connection.roleArn.split(":")[4] ?? "unknown"})`,
       ),
       awsSkillContext,
+      gcpProjectNames: gcpConnections.map(
+        (connection) => `${connection.displayName} (${connection.projectId})`,
+      ),
       axiomConnected: axiomServer !== null,
       customMcpNames: customMcpConnections.map((connection) => connection.displayName),
       clickStackConnected: clickStackServer !== null,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -46,6 +46,11 @@ types. `drizzle/` contains the ordered schema history.
   the existing Slack trigger. The control plane normalizes available alarm
   identity and location fields, ignores recovery states, and the worker uses
   only AWS accounts selected on the pinned Agent version as read-only context.
+- Google Cloud context uses customer-owned Workload Identity Federation and a
+  dedicated service account. A unique AWS broker session is the federated
+  principal, so Responder exchanges short-lived credentials without creating
+  or storing service-account keys. The worker exposes only managed Cloud Asset
+  Inventory, Logging, and Monitoring tools annotated read-only.
 - Remote MCP destinations must use HTTPS and resolve to public addresses.
   Redirects are revalidated and authorization is not forwarded across origins.
 - Linear context uses its read-only MCP endpoint. Ticket creation goes through

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -237,6 +237,38 @@ Self-hosted deployments must also set `AWS_INTEGRATION_PRINCIPAL_ARN` to a
 stable broker role that the runtime can assume. The broker must allow
 `sts:AssumeRole` only on customer roles named `ResponderInvestigationRole`.
 
+## Google Cloud
+
+Google Cloud is optional read-only context for investigations. A workspace
+owner enters a project ID and numeric project number, which they can find in
+the [Google Cloud project selector](https://console.cloud.google.com/cloud-resource-manager),
+then downloads a generated setup script. No Google OAuth project-listing
+session is required.
+
+Each project is a separate integration account. The setup script verifies that
+its project ID and number match before changing IAM.
+
+The script enables the IAM, Security Token Service, Service Account
+Credentials, Cloud Asset Inventory, Logging, and Monitoring APIs. It creates a
+fixed `responder-investigation` service account and a customer-owned Workload
+Identity Federation pool/provider that trusts the configured Responder AWS
+broker. The service-account binding is restricted to one encrypted, randomly
+generated broker session name. It grants only MCP Tool User, Cloud Asset
+Viewer, Logs Viewer, Monitoring Viewer, and Service Usage Consumer.
+
+During an investigation, Responder assumes the broker with that connection's
+stable session name, exchanges the AWS identity for a short-lived Google token,
+and impersonates the customer service account. It never asks for or stores a
+service-account key. Google Cloud Asset Inventory, Logging, and Monitoring run
+through Google's managed remote MCP servers. Responder exposes only tools that
+the servers explicitly annotate read-only; the customer IAM roles remain the
+authorization boundary.
+
+This integration requires `AWS_INTEGRATION_PRINCIPAL_ARN`, the same stable
+broker role used by AWS context. Self-hosted deployments must run on AWS with
+permission to assume that role. Native Google Cloud alert ingestion is a
+separate integration boundary.
+
 ## Custom MCP servers
 
 Organizations can connect remote Streamable HTTP MCP servers with either a

--- a/drizzle/0035_add_gcp_context.sql
+++ b/drizzle/0035_add_gcp_context.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "public"."integration_provider" ADD VALUE 'gcp' BEFORE 'github';

--- a/drizzle/meta/0035_snapshot.json
+++ b/drizzle/meta/0035_snapshot.json
@@ -1,0 +1,4117 @@
+{
+  "id": "41c758de-baa8-4028-a127-823111e77b5e",
+  "prevId": "d4a89c8a-8717-4e47-894f-f3fc5f4de30e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "invitation_organizationId_idx": {
+          "name": "invitation_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_email_idx": {
+          "name": "invitation_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "member_organizationId_idx": {
+          "name": "member_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_userId_idx": {
+          "name": "member_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'user'"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_organization_id": {
+          "name": "last_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_config_versions": {
+      "name": "agent_config_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "trigger_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_config": {
+          "name": "trigger_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "report_config": {
+          "name": "report_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context_account_ids": {
+          "name": "context_account_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "context_resource_ids": {
+          "name": "context_resource_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "pr_mode": {
+          "name": "pr_mode",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pr_mode_policy": {
+          "name": "pr_mode_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'disabled'"
+        },
+        "create_linear_tickets": {
+          "name": "create_linear_tickets",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "linear_issue_template": {
+          "name": "linear_issue_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'## Responder issue\n[{{issue_id}}]({{issue_url}})\n\n## Description\n{{description}}\n\n## Evidence\n{{evidence}}\n\n## Recommended remediation\n{{remediation}}'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_config_versions_agent_version_idx": {
+          "name": "agent_config_versions_agent_version_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_config_versions_agent_idx": {
+          "name": "agent_config_versions_agent_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_config_versions_agent_id_agents_id_fk": {
+          "name": "agent_config_versions_agent_id_agents_id_fk",
+          "tableFrom": "agent_config_versions",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_config_versions_created_by_user_id_fk": {
+          "name": "agent_config_versions_created_by_user_id_fk",
+          "tableFrom": "agent_config_versions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_version_repositories": {
+      "name": "agent_version_repositories",
+      "schema": "",
+      "columns": {
+        "agent_config_version_id": {
+          "name": "agent_config_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_version_repositories_agent_config_version_id_agent_config_versions_id_fk": {
+          "name": "agent_version_repositories_agent_config_version_id_agent_config_versions_id_fk",
+          "tableFrom": "agent_version_repositories",
+          "tableTo": "agent_config_versions",
+          "columnsFrom": [
+            "agent_config_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_version_repositories_repository_id_repositories_id_fk": {
+          "name": "agent_version_repositories_repository_id_repositories_id_fk",
+          "tableFrom": "agent_version_repositories",
+          "tableTo": "repositories",
+          "columnsFrom": [
+            "repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_version_repositories_agent_config_version_id_repository_id_pk": {
+          "name": "agent_version_repositories_agent_config_version_id_repository_id_pk",
+          "columns": [
+            "agent_config_version_id",
+            "repository_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_version_secrets": {
+      "name": "agent_version_secrets",
+      "schema": "",
+      "columns": {
+        "agent_config_version_id": {
+          "name": "agent_config_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_secret_id": {
+          "name": "workspace_secret_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_version_secrets_agent_config_version_id_agent_config_versions_id_fk": {
+          "name": "agent_version_secrets_agent_config_version_id_agent_config_versions_id_fk",
+          "tableFrom": "agent_version_secrets",
+          "tableTo": "agent_config_versions",
+          "columnsFrom": [
+            "agent_config_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_version_secrets_workspace_secret_id_workspace_secrets_id_fk": {
+          "name": "agent_version_secrets_workspace_secret_id_workspace_secrets_id_fk",
+          "tableFrom": "agent_version_secrets",
+          "tableTo": "workspace_secrets",
+          "columnsFrom": [
+            "workspace_secret_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_version_secrets_agent_config_version_id_workspace_secret_id_pk": {
+          "name": "agent_version_secrets_agent_config_version_id_workspace_secret_id_pk",
+          "columns": [
+            "agent_config_version_id",
+            "workspace_secret_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'standard'"
+        },
+        "active_version_id": {
+          "name": "active_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agents_organization_idx": {
+          "name": "agents_organization_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agents_organization_slack_thread_idx": {
+          "name": "agents_organization_slack_thread_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"agents\".\"purpose\" = 'slack_thread'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agents_organization_id_organization_id_fk": {
+          "name": "agents_organization_id_organization_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.billing_notification_deliveries": {
+      "name": "billing_notification_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integration_account_id": {
+          "name": "integration_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_key": {
+          "name": "period_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination": {
+          "name": "destination",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "billing_notification_delivery_target_idx": {
+          "name": "billing_notification_delivery_target_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "integration_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "destination",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "billing_notification_delivery_status_idx": {
+          "name": "billing_notification_delivery_status_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "billing_notification_deliveries_organization_id_organization_id_fk": {
+          "name": "billing_notification_deliveries_organization_id_organization_id_fk",
+          "tableFrom": "billing_notification_deliveries",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "billing_notification_deliveries_integration_account_id_integration_accounts_id_fk": {
+          "name": "billing_notification_deliveries_integration_account_id_integration_accounts_id_fk",
+          "tableFrom": "billing_notification_deliveries",
+          "tableTo": "integration_accounts",
+          "columnsFrom": [
+            "integration_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.delivery_attempts": {
+      "name": "delivery_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "investigation_id": {
+          "name": "investigation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination": {
+          "name": "destination",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "delivery_attempts_idempotency_idx": {
+          "name": "delivery_attempts_idempotency_idx",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_attempts_investigation_idx": {
+          "name": "delivery_attempts_investigation_idx",
+          "columns": [
+            {
+              "expression": "investigation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "delivery_attempts_investigation_id_investigations_id_fk": {
+          "name": "delivery_attempts_investigation_id_investigations_id_fk",
+          "tableFrom": "delivery_attempts",
+          "tableTo": "investigations",
+          "columnsFrom": [
+            "investigation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instance_configuration": {
+      "name": "instance_configuration",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "active_runtime_profile_id": {
+          "name": "active_runtime_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "instance_configuration_active_runtime_profile_id_runtime_profiles_id_fk": {
+          "name": "instance_configuration_active_runtime_profile_id_runtime_profiles_id_fk",
+          "tableFrom": "instance_configuration",
+          "tableTo": "runtime_profiles",
+          "columnsFrom": [
+            "active_runtime_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_accounts": {
+      "name": "integration_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "integration_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_account_id": {
+          "name": "external_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'connected'"
+        },
+        "encrypted_credentials": {
+          "name": "encrypted_credentials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_key_version": {
+          "name": "credential_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "integration_accounts_organization_provider_external_idx": {
+          "name": "integration_accounts_organization_provider_external_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_accounts_organization_idx": {
+          "name": "integration_accounts_organization_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_accounts_organization_id_organization_id_fk": {
+          "name": "integration_accounts_organization_id_organization_id_fk",
+          "tableFrom": "integration_accounts",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_connection_states": {
+      "name": "integration_connection_states",
+      "schema": "",
+      "columns": {
+        "state_hash": {
+          "name": "state_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "integration_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_verifier": {
+          "name": "code_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "return_to": {
+          "name": "return_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'/settings'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "integration_connection_states_expires_idx": {
+          "name": "integration_connection_states_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_connection_states_organization_idx": {
+          "name": "integration_connection_states_organization_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_connection_states_owner_provider_idx": {
+          "name": "integration_connection_states_owner_provider_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_connection_states_organization_id_organization_id_fk": {
+          "name": "integration_connection_states_organization_id_organization_id_fk",
+          "tableFrom": "integration_connection_states",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "integration_connection_states_user_id_user_id_fk": {
+          "name": "integration_connection_states_user_id_user_id_fk",
+          "tableFrom": "integration_connection_states",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_resources": {
+      "name": "integration_resources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "integration_account_id": {
+          "name": "integration_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "integration_resource_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "available": {
+          "name": "available",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "integration_resources_account_kind_external_idx": {
+          "name": "integration_resources_account_kind_external_idx",
+          "columns": [
+            {
+              "expression": "integration_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_resources_account_idx": {
+          "name": "integration_resources_account_idx",
+          "columns": [
+            {
+              "expression": "integration_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_resources_integration_account_id_integration_accounts_id_fk": {
+          "name": "integration_resources_integration_account_id_integration_accounts_id_fk",
+          "tableFrom": "integration_resources",
+          "tableTo": "integration_accounts",
+          "columnsFrom": [
+            "integration_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.investigation_issues": {
+      "name": "investigation_issues",
+      "schema": "",
+      "columns": {
+        "investigation_id": {
+          "name": "investigation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relationship": {
+          "name": "relationship",
+          "type": "issue_relationship",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "investigation_issues_issue_idx": {
+          "name": "investigation_issues_issue_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "investigation_issues_investigation_id_investigations_id_fk": {
+          "name": "investigation_issues_investigation_id_investigations_id_fk",
+          "tableFrom": "investigation_issues",
+          "tableTo": "investigations",
+          "columnsFrom": [
+            "investigation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "investigation_issues_issue_id_issues_id_fk": {
+          "name": "investigation_issues_issue_id_issues_id_fk",
+          "tableFrom": "investigation_issues",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "investigation_issues_investigation_id_issue_id_pk": {
+          "name": "investigation_issues_investigation_id_issue_id_pk",
+          "columns": [
+            "investigation_id",
+            "issue_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.investigation_replay_requests": {
+      "name": "investigation_replay_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source_investigation_id": {
+          "name": "source_investigation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "replay_investigation_id": {
+          "name": "replay_investigation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_by": {
+          "name": "requested_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "investigation_replay_request_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "processing_started_at": {
+          "name": "processing_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "queued_at": {
+          "name": "queued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "investigation_replay_requests_replay_idx": {
+          "name": "investigation_replay_requests_replay_idx",
+          "columns": [
+            {
+              "expression": "replay_investigation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "investigation_replay_requests_claim_idx": {
+          "name": "investigation_replay_requests_claim_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "investigation_replay_requests_source_idx": {
+          "name": "investigation_replay_requests_source_idx",
+          "columns": [
+            {
+              "expression": "source_investigation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "investigation_replay_requests_source_investigation_id_investigations_id_fk": {
+          "name": "investigation_replay_requests_source_investigation_id_investigations_id_fk",
+          "tableFrom": "investigation_replay_requests",
+          "tableTo": "investigations",
+          "columnsFrom": [
+            "source_investigation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.investigation_trace_events": {
+      "name": "investigation_trace_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "investigation_id": {
+          "name": "investigation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event": {
+          "name": "event",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "investigation_trace_events_investigation_id_idx": {
+          "name": "investigation_trace_events_investigation_id_idx",
+          "columns": [
+            {
+              "expression": "investigation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "investigation_trace_events_investigation_id_investigations_id_fk": {
+          "name": "investigation_trace_events_investigation_id_investigations_id_fk",
+          "tableFrom": "investigation_trace_events",
+          "tableTo": "investigations",
+          "columnsFrom": [
+            "investigation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.investigations": {
+      "name": "investigations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_config_version_id": {
+          "name": "agent_config_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime_profile_id": {
+          "name": "runtime_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_mode": {
+          "name": "execution_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'standard'"
+        },
+        "slack_investigation_session_id": {
+          "name": "slack_investigation_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "investigation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finding": {
+          "name": "finding",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "structured_report": {
+          "name": "structured_report",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replay_report": {
+          "name": "replay_report",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "report_markdown": {
+          "name": "report_markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_replay": {
+          "name": "is_replay",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "replay_of_investigation_id": {
+          "name": "replay_of_investigation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eve_session_id": {
+          "name": "eve_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_message_timestamp": {
+          "name": "slack_message_timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_trace_items": {
+          "name": "slack_trace_items",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "slack_thread_snapshot": {
+          "name": "slack_thread_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "investigations_organization_created_idx": {
+          "name": "investigations_organization_created_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "investigations_agent_created_idx": {
+          "name": "investigations_agent_created_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "investigations_replay_source_idx": {
+          "name": "investigations_replay_source_idx",
+          "columns": [
+            {
+              "expression": "replay_of_investigation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "investigations_organization_id_organization_id_fk": {
+          "name": "investigations_organization_id_organization_id_fk",
+          "tableFrom": "investigations",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "investigations_agent_id_agents_id_fk": {
+          "name": "investigations_agent_id_agents_id_fk",
+          "tableFrom": "investigations",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "investigations_agent_config_version_id_agent_config_versions_id_fk": {
+          "name": "investigations_agent_config_version_id_agent_config_versions_id_fk",
+          "tableFrom": "investigations",
+          "tableTo": "agent_config_versions",
+          "columnsFrom": [
+            "agent_config_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "investigations_runtime_profile_id_runtime_profiles_id_fk": {
+          "name": "investigations_runtime_profile_id_runtime_profiles_id_fk",
+          "tableFrom": "investigations",
+          "tableTo": "runtime_profiles",
+          "columnsFrom": [
+            "runtime_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "investigations_slack_investigation_session_id_slack_investigation_sessions_id_fk": {
+          "name": "investigations_slack_investigation_session_id_slack_investigation_sessions_id_fk",
+          "tableFrom": "investigations",
+          "tableTo": "slack_investigation_sessions",
+          "columnsFrom": [
+            "slack_investigation_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "investigations_replay_source_fk": {
+          "name": "investigations_replay_source_fk",
+          "tableFrom": "investigations",
+          "tableTo": "investigations",
+          "columnsFrom": [
+            "replay_of_investigation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_linear_tickets": {
+      "name": "issue_linear_tickets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "investigation_id": {
+          "name": "investigation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_config_version_id": {
+          "name": "agent_config_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integration_account_id": {
+          "name": "integration_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linear_issue_id": {
+          "name": "linear_issue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linear_identifier": {
+          "name": "linear_identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linear_issue_url": {
+          "name": "linear_issue_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "issue_linear_tickets_issue_idx": {
+          "name": "issue_linear_tickets_issue_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_linear_tickets_investigation_idx": {
+          "name": "issue_linear_tickets_investigation_idx",
+          "columns": [
+            {
+              "expression": "investigation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_linear_tickets_status_created_idx": {
+          "name": "issue_linear_tickets_status_created_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_linear_tickets_issue_id_issues_id_fk": {
+          "name": "issue_linear_tickets_issue_id_issues_id_fk",
+          "tableFrom": "issue_linear_tickets",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_linear_tickets_investigation_id_investigations_id_fk": {
+          "name": "issue_linear_tickets_investigation_id_investigations_id_fk",
+          "tableFrom": "issue_linear_tickets",
+          "tableTo": "investigations",
+          "columnsFrom": [
+            "investigation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_linear_tickets_agent_config_version_id_agent_config_versions_id_fk": {
+          "name": "issue_linear_tickets_agent_config_version_id_agent_config_versions_id_fk",
+          "tableFrom": "issue_linear_tickets",
+          "tableTo": "agent_config_versions",
+          "columnsFrom": [
+            "agent_config_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "issue_linear_tickets_integration_account_id_integration_accounts_id_fk": {
+          "name": "issue_linear_tickets_integration_account_id_integration_accounts_id_fk",
+          "tableFrom": "issue_linear_tickets",
+          "tableTo": "integration_accounts",
+          "columnsFrom": [
+            "integration_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_pull_request_activities": {
+      "name": "issue_pull_request_activities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_key": {
+          "name": "external_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event": {
+          "name": "event",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_pull_request_activities_request_idx": {
+          "name": "issue_pull_request_activities_request_idx",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_pull_request_activities_external_key_idx": {
+          "name": "issue_pull_request_activities_external_key_idx",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"issue_pull_request_activities\".\"external_key\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_pull_request_activities_request_id_issue_pull_requests_id_fk": {
+          "name": "issue_pull_request_activities_request_id_issue_pull_requests_id_fk",
+          "tableFrom": "issue_pull_request_activities",
+          "tableTo": "issue_pull_requests",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_pull_request_slack_messages": {
+      "name": "issue_pull_request_slack_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integration_account_id": {
+          "name": "integration_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_timestamp": {
+          "name": "message_timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_pull_request_slack_messages_message_idx": {
+          "name": "issue_pull_request_slack_messages_message_idx",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "integration_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "message_timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_pull_request_slack_messages_request_idx": {
+          "name": "issue_pull_request_slack_messages_request_idx",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_pull_request_slack_messages_request_id_issue_pull_requests_id_fk": {
+          "name": "issue_pull_request_slack_messages_request_id_issue_pull_requests_id_fk",
+          "tableFrom": "issue_pull_request_slack_messages",
+          "tableTo": "issue_pull_requests",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_pull_request_slack_messages_integration_account_id_integration_accounts_id_fk": {
+          "name": "issue_pull_request_slack_messages_integration_account_id_integration_accounts_id_fk",
+          "tableFrom": "issue_pull_request_slack_messages",
+          "tableTo": "integration_accounts",
+          "columnsFrom": [
+            "integration_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_pull_requests": {
+      "name": "issue_pull_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "investigation_id": {
+          "name": "investigation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_config_version_id": {
+          "name": "agent_config_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "remediation_id": {
+          "name": "remediation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_full_name": {
+          "name": "repository_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pull_request_number": {
+          "name": "pull_request_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pull_request_url": {
+          "name": "pull_request_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eve_session_id": {
+          "name": "eve_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "issue_pull_requests_active_issue_idx": {
+          "name": "issue_pull_requests_active_issue_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"status\" in ('queued', 'creating', 'created') and \"repository_full_name\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_pull_requests_active_issue_repository_idx": {
+          "name": "issue_pull_requests_active_issue_repository_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repository_full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"status\" in ('queued', 'creating', 'created') and \"repository_full_name\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_pull_requests_issue_created_idx": {
+          "name": "issue_pull_requests_issue_created_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_pull_requests_investigation_idx": {
+          "name": "issue_pull_requests_investigation_idx",
+          "columns": [
+            {
+              "expression": "investigation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_pull_requests_issue_id_issues_id_fk": {
+          "name": "issue_pull_requests_issue_id_issues_id_fk",
+          "tableFrom": "issue_pull_requests",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_pull_requests_investigation_id_investigations_id_fk": {
+          "name": "issue_pull_requests_investigation_id_investigations_id_fk",
+          "tableFrom": "issue_pull_requests",
+          "tableTo": "investigations",
+          "columnsFrom": [
+            "investigation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_pull_requests_agent_config_version_id_agent_config_versions_id_fk": {
+          "name": "issue_pull_requests_agent_config_version_id_agent_config_versions_id_fk",
+          "tableFrom": "issue_pull_requests",
+          "tableTo": "agent_config_versions",
+          "columnsFrom": [
+            "agent_config_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issues": {
+      "name": "issues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root_cause": {
+          "name": "root_cause",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "timeline": {
+          "name": "timeline",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "severity": {
+          "name": "severity",
+          "type": "severity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "remediation": {
+          "name": "remediation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "remediations": {
+          "name": "remediations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_model": {
+          "name": "embedding_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issues_organization_created_idx": {
+          "name": "issues_organization_created_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issues_organization_id_organization_id_fk": {
+          "name": "issues_organization_id_organization_id_fk",
+          "tableFrom": "issues",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.legacy_account_redirect": {
+      "name": "legacy_account_redirect",
+      "schema": "",
+      "columns": {
+        "email_normalized": {
+          "name": "email_normalized",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "old_user_id": {
+          "name": "old_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_enabled": {
+          "name": "redirect_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "source_snapshot": {
+          "name": "source_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "legacy_account_redirect_enabled_idx": {
+          "name": "legacy_account_redirect_enabled_idx",
+          "columns": [
+            {
+              "expression": "redirect_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.repositories": {
+      "name": "repositories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "integration_account_id": {
+          "name": "integration_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'main'"
+        },
+        "private": {
+          "name": "private",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "available": {
+          "name": "available",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "repositories_installation_external_idx": {
+          "name": "repositories_installation_external_idx",
+          "columns": [
+            {
+              "expression": "integration_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "repositories_integration_account_id_integration_accounts_id_fk": {
+          "name": "repositories_integration_account_id_integration_accounts_id_fk",
+          "tableFrom": "repositories",
+          "tableTo": "integration_accounts",
+          "columnsFrom": [
+            "integration_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runtime_profiles": {
+      "name": "runtime_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "version": {
+          "name": "version",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_options": {
+          "name": "model_options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "runtime_profiles_version_idx": {
+          "name": "runtime_profiles_version_idx",
+          "columns": [
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_investigation_sessions": {
+      "name": "slack_investigation_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_config_version_id": {
+          "name": "agent_config_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime_profile_id": {
+          "name": "runtime_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_timestamp": {
+          "name": "thread_timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandbox_session_state": {
+          "name": "sandbox_session_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_response_id": {
+          "name": "previous_response_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "slack_investigation_sessions_thread_idx": {
+          "name": "slack_investigation_sessions_thread_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "thread_timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_investigation_sessions_organization_id_organization_id_fk": {
+          "name": "slack_investigation_sessions_organization_id_organization_id_fk",
+          "tableFrom": "slack_investigation_sessions",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "slack_investigation_sessions_agent_id_agents_id_fk": {
+          "name": "slack_investigation_sessions_agent_id_agents_id_fk",
+          "tableFrom": "slack_investigation_sessions",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "slack_investigation_sessions_agent_config_version_id_agent_config_versions_id_fk": {
+          "name": "slack_investigation_sessions_agent_config_version_id_agent_config_versions_id_fk",
+          "tableFrom": "slack_investigation_sessions",
+          "tableTo": "agent_config_versions",
+          "columnsFrom": [
+            "agent_config_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "slack_investigation_sessions_runtime_profile_id_runtime_profiles_id_fk": {
+          "name": "slack_investigation_sessions_runtime_profile_id_runtime_profiles_id_fk",
+          "tableFrom": "slack_investigation_sessions",
+          "tableTo": "runtime_profiles",
+          "columnsFrom": [
+            "runtime_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_receipts": {
+      "name": "webhook_receipts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_event_id": {
+          "name": "external_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "investigation_id": {
+          "name": "investigation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_hash": {
+          "name": "payload_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_receipts_provider_event_idx": {
+          "name": "webhook_receipts_provider_event_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_receipts_organization_id_organization_id_fk": {
+          "name": "webhook_receipts_organization_id_organization_id_fk",
+          "tableFrom": "webhook_receipts",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_secrets": {
+      "name": "workspace_secrets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "daytona_secret_id": {
+          "name": "daytona_secret_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "daytona_secret_name": {
+          "name": "daytona_secret_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allowed_hosts": {
+          "name": "allowed_hosts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workspace_secrets_organization_name_idx": {
+          "name": "workspace_secrets_organization_name_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_secrets_daytona_id_idx": {
+          "name": "workspace_secrets_daytona_id_idx",
+          "columns": [
+            {
+              "expression": "daytona_secret_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_secrets_daytona_name_idx": {
+          "name": "workspace_secrets_daytona_name_idx",
+          "columns": [
+            {
+              "expression": "daytona_secret_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_secrets_organization_id_organization_id_fk": {
+          "name": "workspace_secrets_organization_id_organization_id_fk",
+          "tableFrom": "workspace_secrets",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "workspace_secrets_created_by_user_id_fk": {
+          "name": "workspace_secrets_created_by_user_id_fk",
+          "tableFrom": "workspace_secrets",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.integration_provider": {
+      "name": "integration_provider",
+      "schema": "public",
+      "values": [
+        "aws",
+        "gcp",
+        "github",
+        "slack",
+        "sentry",
+        "datadog",
+        "axiom",
+        "clickstack",
+        "upstash",
+        "langfuse",
+        "vercel",
+        "custom_mcp",
+        "linear"
+      ]
+    },
+    "public.integration_resource_kind": {
+      "name": "integration_resource_kind",
+      "schema": "public",
+      "values": [
+        "slack_channel",
+        "sentry_project",
+        "datadog_monitor",
+        "vercel_project"
+      ]
+    },
+    "public.investigation_replay_request_status": {
+      "name": "investigation_replay_request_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "queued",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.investigation_status": {
+      "name": "investigation_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "investigating",
+        "resolved",
+        "failed"
+      ]
+    },
+    "public.issue_relationship": {
+      "name": "issue_relationship",
+      "schema": "public",
+      "values": [
+        "new",
+        "recurrence"
+      ]
+    },
+    "public.severity": {
+      "name": "severity",
+      "schema": "public",
+      "values": [
+        "SEV-1",
+        "SEV-2",
+        "SEV-3"
+      ]
+    },
+    "public.trigger_kind": {
+      "name": "trigger_kind",
+      "schema": "public",
+      "values": [
+        "sentry_issue",
+        "datadog_monitor",
+        "slack_channel",
+        "slack_mention"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -246,6 +246,13 @@
       "when": 1788194736221,
       "tag": "0034_steady_vargas",
       "breakpoints": true
+    },
+    {
+      "idx": 35,
+      "version": "7",
+      "when": 1788283103101,
+      "tag": "0035_add_gcp_context",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -14,6 +14,7 @@
     "@modelcontextprotocol/sdk": "1.30.0",
     "autumn-js": "1.2.45",
     "drizzle-orm": "0.45.2",
+    "google-auth-library": "11.0.2",
     "ipaddr.js": "2.5.0",
     "pg": "8.22.0",
     "pg-boss": "12.26.3",

--- a/packages/core/src/db/agents.ts
+++ b/packages/core/src/db/agents.ts
@@ -253,6 +253,7 @@ async function validateConfigurationResources(
       !account ||
       ![
         "aws",
+        "gcp",
         "sentry",
         "datadog",
         "axiom",

--- a/packages/core/src/db/integrations.ts
+++ b/packages/core/src/db/integrations.ts
@@ -201,6 +201,24 @@ export async function setIntegrationAccountStatus(
     .where(eq(integrationAccounts.id, integrationAccountId));
 }
 
+export async function deleteIntegrationAccount(input: {
+  integrationAccountId: string;
+  organizationId: string;
+  provider: IntegrationProvider;
+}): Promise<boolean> {
+  const deleted = await getDatabase()
+    .delete(integrationAccounts)
+    .where(
+      and(
+        eq(integrationAccounts.id, input.integrationAccountId),
+        eq(integrationAccounts.organizationId, input.organizationId),
+        eq(integrationAccounts.provider, input.provider),
+      ),
+    )
+    .returning({ id: integrationAccounts.id });
+  return deleted.length > 0;
+}
+
 export async function getOrganizationIntegrationAccount(input: {
   integrationAccountId: string;
   organizationId: string;

--- a/packages/core/src/db/investigations.ts
+++ b/packages/core/src/db/investigations.ts
@@ -23,6 +23,7 @@ import {
   normalizeClickStackMcpUrl,
 } from "../integrations/clickstack.js";
 import { awsConnectionCredentialsSchema } from "../integrations/aws.js";
+import { gcpConnectionCredentialsSchema } from "../integrations/gcp.js";
 import {
   type LinearOAuthCredentials,
   linearAccessTokenNeedsRefresh,
@@ -1356,6 +1357,62 @@ export async function getRuntimeAwsConnections(
       displayName: account.displayName,
       externalId: credentials.externalId,
       roleArn: credentials.roleArn,
+    });
+  }
+  return connections;
+}
+
+export interface RuntimeGcpConnection {
+  accountId: string;
+  displayName: string;
+  projectId: string;
+  projectNumber: string;
+  sessionName: string;
+}
+
+export async function getRuntimeGcpConnections(
+  versionId: string,
+): Promise<RuntimeGcpConnection[]> {
+  const configRows = await getDatabase()
+    .select({
+      contextAccountIds: agentConfigVersions.contextAccountIds,
+      organizationId: agents.organizationId,
+    })
+    .from(agentConfigVersions)
+    .innerJoin(agents, eq(agents.id, agentConfigVersions.agentId))
+    .where(eq(agentConfigVersions.id, versionId))
+    .limit(1);
+  const config = configRows[0];
+  if (!config?.contextAccountIds.length) return [];
+
+  const accountRows = await getDatabase()
+    .select({
+      id: integrationAccounts.id,
+      displayName: integrationAccounts.displayName,
+      encryptedCredentials: integrationAccounts.encryptedCredentials,
+    })
+    .from(integrationAccounts)
+    .where(
+      and(
+        eq(integrationAccounts.organizationId, config.organizationId),
+        eq(integrationAccounts.provider, "gcp"),
+        eq(integrationAccounts.status, "connected"),
+        inArray(integrationAccounts.id, config.contextAccountIds),
+      ),
+    );
+  const accountsById = new Map(accountRows.map((account) => [account.id, account]));
+  const connections: RuntimeGcpConnection[] = [];
+
+  for (const accountId of config.contextAccountIds) {
+    const account = accountsById.get(accountId);
+    if (!account?.encryptedCredentials) continue;
+    const credentials = gcpConnectionCredentialsSchema.parse(
+      decryptCredentials<Record<string, unknown>>(account.encryptedCredentials),
+    );
+    connections.push({
+      accountId: account.id,
+      displayName: account.displayName,
+      ...credentials,
     });
   }
   return connections;

--- a/packages/core/src/db/schema.ts
+++ b/packages/core/src/db/schema.ts
@@ -49,6 +49,7 @@ export const legacyAccountRedirect = pgTable(
 
 export const integrationProvider = pgEnum("integration_provider", [
   "aws",
+  "gcp",
   "github",
   "slack",
   "sentry",

--- a/packages/core/src/integrations/aws.ts
+++ b/packages/core/src/integrations/aws.ts
@@ -137,6 +137,28 @@ interface StsTemporaryCredentials {
   sessionToken: string;
 }
 
+export async function assumeAwsIntegrationBroker(
+  options: {
+    environment?: NodeJS.ProcessEnv;
+    sessionName?: string;
+  } = {},
+): Promise<AwsTemporaryCredentials> {
+  const principalArn = awsIntegrationPrincipalArn(options.environment);
+  const sessionSuffix = (options.sessionName ?? randomBytes(8).toString("hex"))
+    .replace(/[^A-Za-z0-9+=,.@_-]/g, "-")
+    .slice(0, 64);
+  const brokerResult = await new STSClient({
+    region: AWS_MCP_SIGNING_REGION,
+  }).send(
+    new AssumeRoleCommand({
+      DurationSeconds: 3600,
+      RoleArn: principalArn,
+      RoleSessionName: sessionSuffix,
+    }),
+  );
+  return temporaryCredentials(brokerResult.Credentials, "broker");
+}
+
 function temporaryCredentials(
   credentials: Credentials | undefined,
   stage: string,
@@ -172,20 +194,13 @@ export async function assumeAwsInvestigationRole(
   } = {},
 ): Promise<AwsTemporaryCredentials> {
   const parsed = awsConnectionCredentialsSchema.parse(connection);
-  const principalArn = awsIntegrationPrincipalArn(options.environment);
   const sessionSuffix = (options.sessionName ?? randomBytes(8).toString("hex"))
     .replace(/[^A-Za-z0-9+=,.@_-]/g, "-")
     .slice(0, 40);
-  const brokerResult = await new STSClient({
-    region: AWS_MCP_SIGNING_REGION,
-  }).send(
-    new AssumeRoleCommand({
-      DurationSeconds: 3600,
-      RoleArn: principalArn,
-      RoleSessionName: `responder-broker-${sessionSuffix}`,
-    }),
-  );
-  const broker = temporaryCredentials(brokerResult.Credentials, "broker");
+  const broker = await assumeAwsIntegrationBroker({
+    environment: options.environment,
+    sessionName: `responder-broker-${sessionSuffix}`,
+  });
   const customerResult = await new STSClient({
     credentials: {
       accessKeyId: broker.accessKeyId,

--- a/packages/core/src/integrations/gcp.test.ts
+++ b/packages/core/src/integrations/gcp.test.ts
@@ -1,0 +1,90 @@
+import { spawnSync } from "node:child_process";
+import { describe, expect, it, vi } from "vitest";
+import {
+  createGcpAuthClient,
+  createGcpSessionName,
+  GCP_ACCESS_SCOPES,
+  gcpConnectionCredentialsSchema,
+  gcpInvestigationServiceAccountEmail,
+  gcpSetupScript,
+  gcpWorkloadIdentityAudience,
+} from "./gcp.js";
+
+const connection = {
+  projectId: "responder-production",
+  projectNumber: "123456789012",
+  sessionName: "responder-gcp-abcdefghijklmnopqrstuvwxyz123456",
+};
+
+describe("GCP integration", () => {
+  it("validates project identifiers and creates broker session names", () => {
+    expect(gcpConnectionCredentialsSchema.safeParse(connection).success).toBe(true);
+    expect(gcpConnectionCredentialsSchema.safeParse({
+      ...connection,
+      projectId: "Responder Production",
+    }).success).toBe(false);
+    expect(gcpConnectionCredentialsSchema.safeParse({
+      ...connection,
+      projectNumber: "012345678901",
+    }).success).toBe(false);
+    expect(createGcpSessionName()).toMatch(/^responder-gcp-[A-Za-z0-9_-]{32}$/u);
+  });
+
+  it("derives only fixed Google identity resources", () => {
+    expect(gcpInvestigationServiceAccountEmail(connection)).toBe(
+      "responder-investigation@responder-production.iam.gserviceaccount.com",
+    );
+    expect(gcpWorkloadIdentityAudience(connection)).toBe(
+      "//iam.googleapis.com/projects/123456789012/locations/global/workloadIdentityPools/responder/providers/responder-aws",
+    );
+  });
+
+  it("builds a keyless, read-only setup script scoped to one broker session", () => {
+    const script = gcpSetupScript(connection, {
+      AWS_INTEGRATION_PRINCIPAL_ARN:
+        "arn:aws:iam::111122223333:role/ResponderAwsIntegrationBroker",
+    });
+    expect(script).toContain("--account-id=\"$RESPONDER_AWS_ACCOUNT\"");
+    expect(script).toContain("attribute.responder_connection");
+    expect(script).toContain(connection.sessionName);
+    expect(script).toContain("roles/cloudasset.viewer");
+    expect(script).toContain("roles/logging.viewer");
+    expect(script).toContain("roles/monitoring.viewer");
+    expect(script).toContain("roles/mcp.toolUser");
+    expect(script).not.toContain("roles/editor");
+    expect(script).not.toContain("roles/owner");
+    expect(spawnSync("bash", ["-n"], { input: script }).status).toBe(0);
+  });
+
+  it("supplies freshly assumed broker credentials to Google auth", async () => {
+    const assume = vi.fn().mockResolvedValue({
+      accessKeyId: "AKIAEXAMPLE",
+      expiration: new Date(Date.now() + 60 * 60 * 1_000),
+      secretAccessKey: "secret",
+      sessionToken: "token",
+    });
+    const client = createGcpAuthClient(connection, {
+      assume,
+      environment: { AWS_REGION: "eu-west-3" },
+    });
+    const supplier = (client as unknown as {
+      awsSecurityCredentialsSupplier: {
+        getAwsRegion(context: object): Promise<string>;
+        getAwsSecurityCredentials(context: object): Promise<unknown>;
+      };
+    }).awsSecurityCredentialsSupplier;
+
+    expect((client as unknown as { scopes: string[] }).scopes).toEqual([
+      ...GCP_ACCESS_SCOPES,
+    ]);
+    expect(await supplier.getAwsRegion({})).toBe("eu-west-3");
+    await supplier.getAwsSecurityCredentials({});
+    await supplier.getAwsSecurityCredentials({});
+    expect(assume).toHaveBeenCalledTimes(1);
+    expect(assume).toHaveBeenCalledWith({
+      environment: { AWS_REGION: "eu-west-3" },
+      sessionName: connection.sessionName,
+    });
+  });
+
+});

--- a/packages/core/src/integrations/gcp.ts
+++ b/packages/core/src/integrations/gcp.ts
@@ -1,0 +1,257 @@
+import { randomBytes } from "node:crypto";
+import {
+  AwsClient,
+  type AwsSecurityCredentials,
+  type AwsSecurityCredentialsSupplier,
+} from "google-auth-library";
+import { z } from "zod";
+import {
+  assumeAwsIntegrationBroker,
+  awsIntegrationPrincipalArn,
+  type AwsTemporaryCredentials,
+} from "./aws.js";
+
+export const GCP_WORKLOAD_IDENTITY_POOL_ID = "responder";
+export const GCP_WORKLOAD_IDENTITY_PROVIDER_ID = "responder-aws";
+export const GCP_INVESTIGATION_SERVICE_ACCOUNT_ID = "responder-investigation";
+export const GCP_ACCESS_SCOPES = [
+  "https://www.googleapis.com/auth/cloud-platform",
+] as const;
+
+export const gcpProjectIdSchema = z
+  .string()
+  .min(6)
+  .max(30)
+  .regex(/^[a-z][a-z0-9-]*[a-z0-9]$/u);
+export const gcpProjectNumberSchema = z.string().regex(/^[1-9]\d{0,19}$/u);
+export const gcpSessionNameSchema = z
+  .string()
+  .min(32)
+  .max(64)
+  .regex(/^responder-gcp-[A-Za-z0-9_-]+$/u);
+
+export const gcpConnectionCredentialsSchema = z.object({
+  projectId: gcpProjectIdSchema,
+  projectNumber: gcpProjectNumberSchema,
+  sessionName: gcpSessionNameSchema,
+});
+
+export type GcpConnectionCredentials = z.infer<
+  typeof gcpConnectionCredentialsSchema
+>;
+
+export function createGcpSessionName(): string {
+  return `responder-gcp-${randomBytes(24).toString("base64url")}`;
+}
+
+export function gcpWorkloadIdentityAudience(
+  connection: GcpConnectionCredentials,
+): string {
+  const parsed = gcpConnectionCredentialsSchema.parse(connection);
+  return `//iam.googleapis.com/projects/${parsed.projectNumber}/locations/global/workloadIdentityPools/${GCP_WORKLOAD_IDENTITY_POOL_ID}/providers/${GCP_WORKLOAD_IDENTITY_PROVIDER_ID}`;
+}
+
+export function gcpInvestigationServiceAccountEmail(
+  connection: GcpConnectionCredentials,
+): string {
+  const parsed = gcpConnectionCredentialsSchema.parse(connection);
+  return `${GCP_INVESTIGATION_SERVICE_ACCOUNT_ID}@${parsed.projectId}.iam.gserviceaccount.com`;
+}
+
+function brokerIdentity(principalArn: string): {
+  accountId: string;
+  roleName: string;
+} {
+  const match = principalArn.match(
+    /^arn:aws:iam::(\d{12}):role\/([A-Za-z0-9+=,.@_/-]+)$/u,
+  );
+  if (!match?.[1] || !match[2]) {
+    throw new Error("The AWS integration broker ARN is invalid");
+  }
+  return { accountId: match[1], roleName: match[2].split("/").at(-1)! };
+}
+
+export function gcpSetupScript(
+  connection: GcpConnectionCredentials,
+  environment: NodeJS.ProcessEnv = process.env,
+): string {
+  const parsed = gcpConnectionCredentialsSchema.parse(connection);
+  const { accountId, roleName } = brokerIdentity(
+    awsIntegrationPrincipalArn(environment),
+  );
+  const serviceAccountEmail = gcpInvestigationServiceAccountEmail(parsed);
+  const principalSet = `principalSet://iam.googleapis.com/projects/${parsed.projectNumber}/locations/global/workloadIdentityPools/${GCP_WORKLOAD_IDENTITY_POOL_ID}/attribute.responder_connection/${parsed.sessionName}`;
+
+  return `#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT_ID='${parsed.projectId}'
+PROJECT_NUMBER='${parsed.projectNumber}'
+POOL_ID='${GCP_WORKLOAD_IDENTITY_POOL_ID}'
+PROVIDER_ID='${GCP_WORKLOAD_IDENTITY_PROVIDER_ID}'
+SERVICE_ACCOUNT_ID='${GCP_INVESTIGATION_SERVICE_ACCOUNT_ID}'
+SERVICE_ACCOUNT_EMAIL='${serviceAccountEmail}'
+RESPONDER_AWS_ACCOUNT='${accountId}'
+
+actual_project_number="$(gcloud projects describe "$PROJECT_ID" --format='value(projectNumber)')"
+if [[ "$actual_project_number" != "$PROJECT_NUMBER" ]]; then
+  echo "Project number does not match $PROJECT_ID" >&2
+  exit 1
+fi
+
+gcloud services enable \
+  iam.googleapis.com \
+  iamcredentials.googleapis.com \
+  sts.googleapis.com \
+  cloudasset.googleapis.com \
+  logging.googleapis.com \
+  monitoring.googleapis.com \
+  --project="$PROJECT_ID"
+
+if ! gcloud iam service-accounts describe "$SERVICE_ACCOUNT_EMAIL" --project="$PROJECT_ID" >/dev/null 2>&1; then
+  gcloud iam service-accounts create "$SERVICE_ACCOUNT_ID" \
+    --display-name='Responder investigations' \
+    --description='Keyless read-only identity for Responder incident investigations' \
+    --project="$PROJECT_ID"
+fi
+
+if ! gcloud iam workload-identity-pools describe "$POOL_ID" --location=global --project="$PROJECT_ID" >/dev/null 2>&1; then
+  gcloud iam workload-identity-pools create "$POOL_ID" \
+    --location=global \
+    --display-name='Responder' \
+    --description='Keyless identities used by Responder investigations' \
+    --project="$PROJECT_ID"
+fi
+
+attribute_mapping="google.subject=assertion.arn,attribute.aws_role=assertion.arn.extract('assumed-role/{role}/'),attribute.responder_connection=assertion.arn.extract('assumed-role/${roleName}/{session}')"
+attribute_condition="attribute.aws_role == '${roleName}'"
+if gcloud iam workload-identity-pools providers describe "$PROVIDER_ID" --location=global --workload-identity-pool="$POOL_ID" --project="$PROJECT_ID" >/dev/null 2>&1; then
+  existing_aws_account="$(gcloud iam workload-identity-pools providers describe "$PROVIDER_ID" --location=global --workload-identity-pool="$POOL_ID" --project="$PROJECT_ID" --format='value(aws.accountId)')"
+  if [[ "$existing_aws_account" != "$RESPONDER_AWS_ACCOUNT" ]]; then
+    echo "Existing $PROVIDER_ID provider trusts a different AWS account" >&2
+    exit 1
+  fi
+  gcloud iam workload-identity-pools providers update-aws "$PROVIDER_ID" \
+    --location=global \
+    --workload-identity-pool="$POOL_ID" \
+    --attribute-mapping="$attribute_mapping" \
+    --attribute-condition="$attribute_condition" \
+    --project="$PROJECT_ID"
+else
+  gcloud iam workload-identity-pools providers create-aws "$PROVIDER_ID" \
+    --location=global \
+    --workload-identity-pool="$POOL_ID" \
+    --account-id="$RESPONDER_AWS_ACCOUNT" \
+    --attribute-mapping="$attribute_mapping" \
+    --attribute-condition="$attribute_condition" \
+    --display-name='Responder AWS broker' \
+    --project="$PROJECT_ID"
+fi
+
+gcloud iam service-accounts add-iam-policy-binding "$SERVICE_ACCOUNT_EMAIL" \
+  --member='${principalSet}' \
+  --role='roles/iam.workloadIdentityUser' \
+  --project="$PROJECT_ID"
+
+for role in \
+  roles/mcp.toolUser \
+  roles/cloudasset.viewer \
+  roles/logging.viewer \
+  roles/monitoring.viewer \
+  roles/serviceusage.serviceUsageConsumer
+do
+  gcloud projects add-iam-policy-binding "$PROJECT_ID" \
+    --member="serviceAccount:$SERVICE_ACCOUNT_EMAIL" \
+    --role="$role" \
+    --condition=None \
+    --quiet
+done
+
+echo "Responder read-only access is ready for $PROJECT_ID."
+`;
+}
+
+class BrokerCredentialsSupplier implements AwsSecurityCredentialsSupplier {
+  private credentials: AwsTemporaryCredentials | null = null;
+  private refresh: Promise<AwsTemporaryCredentials> | null = null;
+
+  constructor(
+    private readonly connection: GcpConnectionCredentials,
+    private readonly environment: NodeJS.ProcessEnv,
+    private readonly assume: typeof assumeAwsIntegrationBroker,
+    private readonly now: () => number,
+  ) {}
+
+  async getAwsRegion(): Promise<string> {
+    return this.environment.AWS_REGION ?? "us-east-1";
+  }
+
+  async getAwsSecurityCredentials(): Promise<AwsSecurityCredentials> {
+    if (
+      this.credentials &&
+      this.credentials.expiration.getTime() - 5 * 60 * 1_000 > this.now()
+    ) {
+      return this.toGoogleCredentials(this.credentials);
+    }
+    if (!this.refresh) {
+      this.refresh = this.assume({
+        environment: this.environment,
+        sessionName: this.connection.sessionName,
+      }).finally(() => {
+        this.refresh = null;
+      });
+    }
+    this.credentials = await this.refresh;
+    return this.toGoogleCredentials(this.credentials);
+  }
+
+  private toGoogleCredentials(
+    credentials: AwsTemporaryCredentials,
+  ): AwsSecurityCredentials {
+    return {
+      accessKeyId: credentials.accessKeyId,
+      secretAccessKey: credentials.secretAccessKey,
+      token: credentials.sessionToken,
+    };
+  }
+}
+
+export function createGcpAuthClient(
+  connection: GcpConnectionCredentials,
+  options: {
+    assume?: typeof assumeAwsIntegrationBroker;
+    environment?: NodeJS.ProcessEnv;
+    now?: () => number;
+  } = {},
+): AwsClient {
+  const parsed = gcpConnectionCredentialsSchema.parse(connection);
+  const environment = options.environment ?? process.env;
+  return new AwsClient({
+    audience: gcpWorkloadIdentityAudience(parsed),
+    aws_security_credentials_supplier: new BrokerCredentialsSupplier(
+      parsed,
+      environment,
+      options.assume ?? assumeAwsIntegrationBroker,
+      options.now ?? Date.now,
+    ),
+    scopes: [...GCP_ACCESS_SCOPES],
+    service_account_impersonation_url:
+      `https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/${gcpInvestigationServiceAccountEmail(parsed)}:generateAccessToken`,
+    subject_token_type: "urn:ietf:params:aws:token-type:aws4_request",
+  });
+}
+
+export async function verifyGcpProject(
+  connection: GcpConnectionCredentials,
+  environment: NodeJS.ProcessEnv = process.env,
+): Promise<void> {
+  const parsed = gcpConnectionCredentialsSchema.parse(connection);
+  const client = createGcpAuthClient(parsed, { environment });
+  const response = await client.request({
+    method: "GET",
+    url: `https://cloudasset.googleapis.com/v1/projects/${parsed.projectNumber}/assets?pageSize=1`,
+  });
+  if (response.status < 200 || response.status >= 300) {
+    throw new Error("Google Cloud Asset Inventory verification failed");
+  }
+}

--- a/packages/core/src/investigations/report.ts
+++ b/packages/core/src/investigations/report.ts
@@ -33,6 +33,7 @@ export const issueEvidenceSchema = z.object({
   source: z.enum([
     "alert",
     "aws",
+    "gcp",
     "datadog",
     "axiom",
     "sentry",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -232,6 +232,9 @@ importers:
       drizzle-orm:
         specifier: 0.45.2
         version: 0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.5)(pg@8.22.0)
+      google-auth-library:
+        specifier: 11.0.2
+        version: 11.0.2(supports-color@8.1.1)
       ipaddr.js:
         specifier: 2.5.0
         version: 2.5.0
@@ -1809,6 +1812,10 @@ packages:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
   ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
     peerDependencies:
@@ -1959,6 +1966,9 @@ packages:
       zod:
         optional: true
 
+  bignumber.js@9.3.1:
+    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
+
   body-parser@2.3.0:
     resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
     engines: {node: '>=18'}
@@ -1981,6 +1991,9 @@ packages:
     resolution: {integrity: sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
+
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
@@ -2165,6 +2178,10 @@ packages:
     resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
     engines: {node: '>=12'}
 
+  data-uri-to-buffer@4.0.1:
+    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
+    engines: {node: '>= 12'}
+
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -2320,6 +2337,9 @@ packages:
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
+
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
@@ -2511,6 +2531,10 @@ packages:
       picomatch:
         optional: true
 
+  fetch-blob@3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
+
   fflate@0.4.9:
     resolution: {integrity: sha512-zdxgIEddhfsyCaWpJ2SdXEP8ZMrKJ6+5jl4OupODcywU0IhRk6gdXuVGcPICyfx2H97hVK7xmJtRLPjkxAX8Vw==}
 
@@ -2557,6 +2581,10 @@ packages:
     resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
 
+  formdata-polyfill@4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
+
   forwarded-parse@2.1.2:
     resolution: {integrity: sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==}
 
@@ -2580,6 +2608,14 @@ packages:
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  gaxios@7.3.1:
+    resolution: {integrity: sha512-kB3rzJV7d9juLZh8/56QTXCwQfxyhdOMdyYk1HdQKFtF8TJTDTZQJtixWIwXdE9Jji91mC41DUNpjleo4L4eAQ==}
+    engines: {node: '>=18'}
+
+  gcp-metadata@9.0.3:
+    resolution: {integrity: sha512-2YYnIlHaKBGT2IPg3G2M57hia9Galz15zsEOvw9T3oRf0lSn6KN6VcHQLqby7x8ksYKnjXvp3rp2KJyLCN6zfQ==}
+    engines: {node: '>=22'}
 
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
@@ -2615,6 +2651,14 @@ packages:
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
     engines: {node: '>=18'}
+
+  google-auth-library@11.0.2:
+    resolution: {integrity: sha512-vzpgPutxrghPsnjrjpzLX2bdv8IOL719Rh0oEjGnQu8YCIbnbMuTTQ5zU9LcKvLdOPgCxBwppbvnhgW90Qna5Q==}
+    engines: {node: '>=22'}
+
+  google-logging-utils@2.0.1:
+    resolution: {integrity: sha512-HMhaQghlOTvbcb3c4T5jmmOMtG3JUF1iOQMezaJXL86CDS+Tm2vHd0IeLFRAx3+ewd+bo9E1HFHoy17X5aJa9A==}
+    engines: {node: '>=22'}
 
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
@@ -2675,6 +2719,10 @@ packages:
   https-proxy-agent@5.0.1:
     resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
     engines: {node: '>= 6'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
 
   iconv-lite@0.7.3:
     resolution: {integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==}
@@ -2783,6 +2831,9 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  json-bigint@1.0.0:
+    resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
+
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
@@ -2802,6 +2853,12 @@ packages:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
+
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+
+  jws@4.0.1:
+    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -3159,6 +3216,11 @@ packages:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
 
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
+
   node-fetch@2.7.0:
     resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
     engines: {node: 4.x || >=6.0.0}
@@ -3167,6 +3229,10 @@ packages:
     peerDependenciesMeta:
       encoding:
         optional: true
+
+  node-fetch@3.3.2:
+    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   node-releases@2.0.53:
     resolution: {integrity: sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==}
@@ -3924,6 +3990,10 @@ packages:
         optional: true
       jsdom:
         optional: true
+
+  web-streams-polyfill@3.3.3:
+    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
+    engines: {node: '>= 8'}
 
   web-vitals@5.3.0:
     resolution: {integrity: sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==}
@@ -5874,6 +5944,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  agent-base@7.1.4: {}
+
   ajv-formats@3.0.1(ajv@8.20.0):
     optionalDependencies:
       ajv: 8.20.0
@@ -5977,6 +6049,8 @@ snapshots:
     optionalDependencies:
       zod: 4.4.3
 
+  bignumber.js@9.3.1: {}
+
   body-parser@2.3.0(supports-color@8.1.1):
     dependencies:
       bytes: 3.1.2
@@ -6013,6 +6087,8 @@ snapshots:
       electron-to-chromium: 1.5.407
       node-releases: 2.0.53
       update-browserslist-db: 1.3.1(browserslist@4.28.8)
+
+  buffer-equal-constant-time@1.0.1: {}
 
   buffer-from@1.1.2: {}
 
@@ -6168,6 +6244,8 @@ snapshots:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
 
+  data-uri-to-buffer@4.0.1: {}
+
   debug@4.4.3(supports-color@8.1.1):
     dependencies:
       ms: 2.1.3
@@ -6225,6 +6303,10 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       es-errors: 1.3.0
       gopd: 1.2.0
+
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
 
   ee-first@1.1.1: {}
 
@@ -6481,6 +6563,11 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.5
 
+  fetch-blob@3.2.0:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.3.3
+
   fflate@0.4.9: {}
 
   fflate@0.8.3: {}
@@ -6530,6 +6617,10 @@ snapshots:
       hasown: 2.0.4
       mime-types: 2.1.35
 
+  formdata-polyfill@4.0.10:
+    dependencies:
+      fetch-blob: 3.2.0
+
   forwarded-parse@2.1.2: {}
 
   forwarded@0.2.0: {}
@@ -6543,6 +6634,22 @@ snapshots:
     optional: true
 
   function-bind@1.1.2: {}
+
+  gaxios@7.3.1(supports-color@8.1.1):
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6(supports-color@8.1.1)
+      node-fetch: 3.3.2
+    transitivePeerDependencies:
+      - supports-color
+
+  gcp-metadata@9.0.3(supports-color@8.1.1):
+    dependencies:
+      gaxios: 7.3.1(supports-color@8.1.1)
+      google-logging-utils: 2.0.1
+      json-bigint: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   gensync@1.0.0-beta.2: {}
 
@@ -6585,6 +6692,19 @@ snapshots:
       path-scurry: 2.0.2
 
   globals@14.0.0: {}
+
+  google-auth-library@11.0.2(supports-color@8.1.1):
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 7.3.1(supports-color@8.1.1)
+      gcp-metadata: 9.0.3(supports-color@8.1.1)
+      google-logging-utils: 2.0.1
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  google-logging-utils@2.0.1: {}
 
   gopd@1.2.0: {}
 
@@ -6671,6 +6791,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  https-proxy-agent@7.0.6(supports-color@8.1.1):
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3(supports-color@8.1.1)
+    transitivePeerDependencies:
+      - supports-color
+
   iconv-lite@0.7.3:
     dependencies:
       safer-buffer: 2.1.2
@@ -6747,6 +6874,10 @@ snapshots:
 
   jsesc@3.1.0: {}
 
+  json-bigint@1.0.0:
+    dependencies:
+      bignumber.js: 9.3.1
+
   json-buffer@3.0.1: {}
 
   json-schema-traverse@0.4.1: {}
@@ -6758,6 +6889,17 @@ snapshots:
   json-stable-stringify-without-jsonify@1.0.1: {}
 
   json5@2.2.3: {}
+
+  jwa@2.0.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+
+  jws@4.0.1:
+    dependencies:
+      jwa: 2.0.1
+      safe-buffer: 5.2.1
 
   keyv@4.5.4:
     dependencies:
@@ -7169,9 +7311,17 @@ snapshots:
 
   negotiator@1.0.0: {}
 
+  node-domexception@1.0.0: {}
+
   node-fetch@2.7.0:
     dependencies:
       whatwg-url: 5.0.0
+
+  node-fetch@3.3.2:
+    dependencies:
+      data-uri-to-buffer: 4.0.1
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
 
   node-releases@2.0.53: {}
 
@@ -7923,6 +8073,8 @@ snapshots:
       '@types/node': 26.0.0
     transitivePeerDependencies:
       - msw
+
+  web-streams-polyfill@3.3.3: {}
 
   web-vitals@5.3.0: {}
 


### PR DESCRIPTION
## Summary
- add manual multi-project Google Cloud connections with explicit per-project management
- use keyless AWS-to-GCP Workload Identity Federation for read-only investigation access
- expose managed Cloud Asset, Logging, and Monitoring tools to selected agent contexts
- add the GCP context migration, setup/verification flow, documentation, and tests

## Validation
- `pnpm typecheck`
- `pnpm lint`
- `pnpm exec vitest run --maxWorkers=1` (912 tests)
- `CI=1 pnpm test:e2e apps/control-plane/e2e/settings-scroll.spec.ts --workers=1`
- `pnpm build:app`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Google Cloud as a read-only investigation context, letting agents inspect asset inventory, logs, and metrics without storing service-account keys.

**New Features**

- Connects each GCP project manually with its own connection status, reconnect, and removal.
- Uses keyless AWS-to-GCP Workload Identity Federation with a unique broker session per project.
- Exposes only managed Cloud Asset Inventory, Logging, and Monitoring MCP tools annotated read-only.
- Adds GCP to agent context defaults, settings overview, and connection dialogs.

**Migration**

- Run `drizzle/0035_add_gcp_context.sql` to add the `gcp` integration provider enum value.
- Self‑hosted deployments need the same `AWS_INTEGRATION_PRINCIPAL_ARN` broker role already used for AWS.

<sup>Written for commit 52c612d74a5a1bc6a95a84e2a0e6e324a09fbaab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/responder-oss/pull/110?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

