### PR TITLE
Continue issue investigations from Slack replies

### DIFF
--- a/apps/control-plane/server/investigations/queue.ts
+++ b/apps/control-plane/server/investigations/queue.ts
@@ -62,6 +62,14 @@ async function getBoss() {
 
 export async function queueInvestigation(
   request: InvestigationRequest,
+  options?: {
+    slackIssueFollowup?: {
+      originalInvestigationId: string;
+      issueIds: string[];
+      channelId: string;
+      threadTimestamp: string;
+    };
+  },
 ): Promise<QueueResult> {
   const input = toInvestigationInput(request);
   const result = await beginInvestigation(request.agentId, input);
@@ -121,6 +129,9 @@ export async function queueInvestigation(
         queuedAt: new Date().toISOString(),
         request,
         runtimeProfileId: result.runtimeProfileId,
+        ...(options?.slackIssueFollowup
+          ? { slackIssueFollowup: options.slackIssueFollowup }
+          : {}),
       },
       { singletonKey: result.investigationId },
     );

--- a/apps/control-plane/server/webhooks/slack.ts
+++ b/apps/control-plane/server/webhooks/slack.ts
@@ -7,6 +7,7 @@ import { findAgentsForSlackEvent } from "../../../../packages/core/src/db/agents
 import { getSlackChannelConnection } from "../../../../packages/core/src/db/integrations.js";
 import {
   getInvestigationForSlackAction,
+  findSlackIssueThread,
   recordInvestigationSlackMessage,
   recordInvestigationSlackSource,
   removeInvestigationSlackReply,
@@ -793,6 +794,68 @@ export const slackWebhookRoutes = new Hono().post("/", async (context) => {
   const body = event.type === "app_mention"
     ? rawMessageBody.replace(/^\s*<@[A-Z0-9]+>\s*/iu, "").trim() || rawMessageBody
     : rawMessageBody;
+  if (event.type === "app_mention" && event.thread_ts) {
+    const linked = await findSlackIssueThread({
+      channelId: event.channel,
+      teamId: callback.data.team_id,
+      threadTimestamp: event.thread_ts,
+    }).catch(() => null);
+    if (linked) {
+      const priorIssues = linked.issues
+        .map((issue) => [
+          `Issue ${issue.id}: ${issue.title}`,
+          `Description: ${issue.description}`,
+          `Root cause: ${issue.rootCause || "Not established"}`,
+          `Current remediation: ${issue.remediation}`,
+          `Remediation options: ${JSON.stringify(issue.remediations)}`,
+        ].join("\n"))
+        .join("\n\n");
+      const priorContext = [
+        "This is follow-up feedback on an existing issue investigation.",
+        `Original investigation ID: ${linked.id}`,
+        linked.reportMarkdown ? `Original report:\n${linked.reportMarkdown}` : null,
+        priorIssues,
+        `Latest Slack feedback from ${event.user ?? "a teammate"}:\n${body}`,
+      ].filter((value): value is string => Boolean(value)).join("\n\n");
+      const result = await queueInvestigation(
+        {
+          agentId: linked.agentId,
+          provider: "slack",
+          externalEventId: `${callback.data.event_id}:${linked.agentId}`,
+          title: `Follow-up: ${linked.issueTitle}`,
+          body: priorContext,
+          sourceUrl: `https://slack.com/archives/${event.channel}/p${event.ts.replace(".", "")}`,
+          attributes: {
+            channelId: event.channel,
+            integrationAccountId: linked.integrationAccountId,
+            slackEventId: callback.data.event_id,
+            teamId: callback.data.team_id,
+            threadTimestamp: event.thread_ts,
+            timestamp: event.ts,
+            originalInvestigationId: linked.id,
+          },
+        },
+        {
+          slackIssueFollowup: {
+            originalInvestigationId: linked.id,
+            issueIds: linked.issueIds,
+            channelId: event.channel,
+            threadTimestamp: event.thread_ts,
+          },
+        },
+      );
+      if (result.kind === "blocked") {
+        throw new Error("Monthly investigation allowance exhausted");
+      }
+      return context.json({
+        ok: true,
+        matchedAgents: 1,
+        followup: true,
+        investigationId: result.investigationId,
+      });
+    }
+  }
+  let matches: Awaited<ReturnType<typeof findAgentsForSlackEvent>> = [];
   let alertProvider: SlackAlertProvider | null = null;
   let awsAlarm: SlackAwsAlarm | null = null;
   if (event.type === "message") {
@@ -828,6 +891,7 @@ export const slackWebhookRoutes = new Hono().post("/", async (context) => {
       awsAlarm = slackAwsAlarm({ body, senderName });
     }
     if (
+      alertProvider &&
       shouldIgnoreResolvedSlackAlert(
         alertProvider,
         body,
@@ -899,13 +963,13 @@ export const slackWebhookRoutes = new Hono().post("/", async (context) => {
     }
   }
 
-  const matches = await findAgentsForSlackEvent({
+  matches = await findAgentsForSlackEvent({
     teamId: callback.data.team_id,
     channelId: event.channel,
     eventType: event.type,
     userId: event.user,
     senderAppId: event.app_id ?? event.bot_profile?.app_id,
-  });
+  }) ?? [];
   await Promise.all(
     matches.map(async (match) => {
       const result = await forwardSlackEvent({

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -19,6 +19,7 @@ import {
 } from "@responder/core/jobs";
 import {
   appendInvestigationTraceEvent,
+  completeInvestigation,
   completeSlackThreadInvestigationTurn,
   failInvestigation,
   failInvestigationReplayRequest,
@@ -45,7 +46,10 @@ import {
   slackProgressFromTrace,
   type SlackInvestigationTraceItem,
 } from "@responder/core/integrations/slack-live-progress";
-import { deliverSlackThreadInvestigationResponse } from "@responder/core/integrations/slack-delivery";
+import {
+  deliverSlackIssueFollowupResponse,
+  deliverSlackThreadInvestigationResponse,
+} from "@responder/core/integrations/slack-delivery";
 import {
   completeInvestigationRun,
   deliverPersistedInvestigationAfterFailure,
@@ -436,12 +440,27 @@ await boss.work(investigationQueue, { localConcurrency: 1 }, async ([job]) => {
     `openai-daytona:${job.id}`,
   );
   if (investigationState === "completed") {
-    const deliveryWarnings = await deliverPersistedInvestigationAfterFailure({
-      deliveryRunId: job.id,
-      investigationFailed: false,
-      investigationId: payload.investigationId,
-      replay: payload.replay,
-    });
+    let deliveryWarnings: string[] = [];
+    if (payload.slackIssueFollowup) {
+      const report = await getInvestigationReportMarkdown(payload.investigationId);
+      if (report) {
+        await deliverSlackIssueFollowupResponse({
+          channelId: payload.slackIssueFollowup.channelId,
+          deliveryRunId: job.id,
+          originalInvestigationId: payload.slackIssueFollowup.originalInvestigationId,
+          response: report,
+          threadTimestamp: payload.slackIssueFollowup.threadTimestamp,
+          updatedIssueIds: payload.slackIssueFollowup.issueIds,
+        });
+      }
+    } else {
+      deliveryWarnings = await deliverPersistedInvestigationAfterFailure({
+        deliveryRunId: job.id,
+        investigationFailed: false,
+        investigationId: payload.investigationId,
+        replay: payload.replay,
+      });
+    }
     await reportIncompleteSlackDelivery({
       deliveryWarnings,
       investigationId: payload.investigationId,
@@ -575,12 +594,25 @@ await boss.work(investigationQueue, { localConcurrency: 1 }, async ([job]) => {
         });
       },
     );
-    const deliveryWarnings = await completeInvestigationRun({
-      deliveryRunId: job.id,
-      investigationId: payload.investigationId,
-      replay: payload.replay,
-      report: result.report,
-    });
+    let deliveryWarnings: string[] = [];
+    if (payload.slackIssueFollowup) {
+      await completeInvestigation(payload.investigationId, result.report);
+      await deliverSlackIssueFollowupResponse({
+        channelId: payload.slackIssueFollowup.channelId,
+        deliveryRunId: job.id,
+        originalInvestigationId: payload.slackIssueFollowup.originalInvestigationId,
+        response: result.report,
+        threadTimestamp: payload.slackIssueFollowup.threadTimestamp,
+        updatedIssueIds: result.updatedIssueIds ?? [],
+      });
+    } else {
+      deliveryWarnings = await completeInvestigationRun({
+        deliveryRunId: job.id,
+        investigationId: payload.investigationId,
+        replay: payload.replay,
+        report: result.report,
+      });
+    }
     await reportIncompleteSlackDelivery({
       deliveryWarnings,
       investigationId: payload.investigationId,

--- a/apps/worker/src/investigate.test.ts
+++ b/apps/worker/src/investigate.test.ts
@@ -195,6 +195,8 @@ describe("sandbox agent configuration", () => {
     expect(instructions).toContain("Never create or update issues");
     expect(instructions).toContain("nothing in it is published");
     expect(instructions).toContain("response directly to the Slack thread");
+    expect(instructions).toContain("reconsider prior conclusions and the proposed remediation");
+    expect(instructions).toContain("provide the updated remediation");
     expect(instructions).not.toContain("search_existing_issues");
     expect(instructions).not.toContain("submit_investigation_report");
   });

--- a/apps/worker/src/investigate.ts
+++ b/apps/worker/src/investigate.ts
@@ -86,6 +86,7 @@ import {
   workspaceSecretUsageInstructions,
 } from "./secret-safety.js";
 import { createVercelTools } from "./vercel.js";
+import { createIssueRemediationUpdateTool } from "./issue-followup.js";
 
 export interface SandboxAgentConfig extends DaytonaClientConfig {
   model: string;
@@ -299,6 +300,7 @@ export function investigationInstructions(input: {
   }>;
   vercelAccountIds?: string[];
   threadMode?: boolean;
+  issueFollowup?: boolean;
 }): string {
   const awsAccountNames = input.awsAccountNames ?? [];
   const customMcpNames = input.customMcpNames ?? [];
@@ -401,16 +403,19 @@ export function investigationInstructions(input: {
     input.threadMode
       ? "This is an ad-hoc Slack thread investigation. Never create or update issues, tickets, branches, commits, or pull requests. You may use the sandbox for notes, experiments, and local code changes, but nothing in it is published."
       : "For every distinct problem you find, call search_existing_issues before deciding whether it is a new issue or a recurrence. Use an existing issue ID when the evidence matches; this attaches the investigation to that issue instead of creating a duplicate.",
-    input.threadMode
+    input.issueFollowup
+      ? "This is a follow-up to an existing Slack issue investigation. Use the supplied prior investigation context and the latest Slack feedback to decide which bound issue remediations need to change. Do not create new issues, tickets, or pull requests. Call update_issue_remediation for each affected issue, and do not update unrelated issues. If the feedback is ambiguous, ask for clarification instead of guessing."
+      : null,
+    input.threadMode || input.issueFollowup
       ? null
       : "For every new issue, submit one or more concrete remediation options with the report. Keep each remediation description to at most one sentence. A code_change must contain a changes array with one complete unified diff per attached repository; use one element for a single-repository fix, and combine changes for the same repository. Use external_action for work outside the attached repositories, describe the action for a human, and include a self-contained prompt they can pass to an agent with access to that system. Do not claim that a proposed diff has been applied.",
     input.threadMode
       ? null
       : "Do not include actions performed by Responder during the investigation in an issue timeline; include only events in the incident's causal sequence.",
-    input.threadMode
-      ? "Return a concise Markdown response directly to the Slack thread. Answer the latest request using evidence gathered in this session."
+    input.threadMode || input.issueFollowup
+      ? "Return a concise Markdown response directly to the Slack thread. Answer the latest request using evidence gathered in this session. Treat every follow-up reply as new information: reconsider prior conclusions and the proposed remediation, explain what changed, and provide the updated remediation (including concrete code changes or steps when appropriate)."
       : "Before your final response, you must call submit_investigation_report exactly once with the structured result. That action saves or attaches the issues and posts the report to Slack.",
-    input.threadMode
+    input.threadMode || input.issueFollowup
       ? null
       : "After submitting, return a concise Markdown report with: Summary, Evidence, Impact, and Recommended next step.",
     "Clearly say when the available evidence is insufficient.",
@@ -451,9 +456,12 @@ export async function runInvestigationAgent(
   report: string;
   previousResponseId?: string;
   sandboxSessionState?: Record<string, unknown>;
+  updatedIssueIds?: string[];
 }> {
   const threadMode = job.kind === "slack_thread_investigation";
   const replay = job.kind === "investigation" && job.replay;
+  const issueFollowup = job.kind === "investigation" ? job.slackIssueFollowup : undefined;
+  const updatedIssueIds = new Set<string>();
   const investigationInput = toInvestigationInput(job.request);
   let sentryConnectionDegraded = false;
   const awsAlarmTriggered =
@@ -696,6 +704,13 @@ export async function runInvestigationAgent(
       organizationId: job.config.organizationId,
       environment,
     });
+    const issueUpdateTool = issueFollowup
+      ? createIssueRemediationUpdateTool({
+          allowedIssueIds: new Set(issueFollowup.issueIds),
+          onUpdated: (issueId) => updatedIssueIds.add(issueId),
+          organizationId: job.config.organizationId,
+        })
+      : null;
     const repositoryInspectionTools = createRepositoryInspectionTools({
       repositories,
       session,
@@ -733,6 +748,7 @@ export async function runInvestigationAgent(
       workspaceSecrets,
       vercelAccountIds: vercelConnections.map((connection) => connection.accountId),
       threadMode,
+      issueFollowup: Boolean(issueFollowup),
     });
     // Save the same string passed to the agent so the trace never reconstructs it.
     await writeTrace(investigationInstructionsTraceEvent(instructions));
@@ -751,7 +767,11 @@ export async function runInvestigationAgent(
       mcpConfig: { includeServerInToolNames: true },
       mcpServers: contextServers,
       tools: [
-        ...(threadMode ? [] : [issueSearchTool, reportTool!]),
+        ...(threadMode
+          ? []
+          : issueFollowup
+            ? [issueUpdateTool!]
+            : [issueSearchTool, reportTool!]),
         ...awsInspectionTools,
         ...repositoryInspectionTools,
         ...upstashTools,
@@ -800,6 +820,9 @@ export async function runInvestigationAgent(
     return {
       report,
       ...(result.lastResponseId ? { previousResponseId: result.lastResponseId } : {}),
+      ...(updatedIssueIds.size > 0
+        ? { updatedIssueIds: [...updatedIssueIds] }
+        : {}),
     };
   } catch (error) {
     await writeTrace(

--- a/apps/worker/src/issue-followup.ts
+++ b/apps/worker/src/issue-followup.ts
@@ -1,0 +1,42 @@
+import { tool } from "@openai/agents";
+import {
+  updateIssueRemediations,
+} from "@responder/core/db/issues";
+import {
+  issueRemediationSubmissionSchema,
+} from "@responder/core/investigations/report";
+import { z } from "zod";
+
+export function createIssueRemediationUpdateTool(input: {
+  allowedIssueIds: ReadonlySet<string>;
+  onUpdated: (issueId: string) => void;
+  organizationId: string;
+}) {
+  return tool({
+    name: "update_issue_remediation",
+    description:
+      "Replace the proposed remediation options for an existing issue after follow-up feedback. Only update an issue when the new evidence changes its remediation; do not create issues or pull requests.",
+    parameters: z.object({
+      issueId: z.uuid(),
+      remediations: z.array(issueRemediationSubmissionSchema).min(1).max(10),
+    }),
+    async execute(request) {
+      if (!input.allowedIssueIds.has(request.issueId)) {
+        throw new Error("The issue is not part of this Slack investigation thread");
+      }
+      const updated = await updateIssueRemediations({
+        issueId: request.issueId,
+        organizationId: input.organizationId,
+        remediations: request.remediations,
+      });
+      if (!updated) throw new Error("Issue is unavailable for remediation update");
+      input.onUpdated(updated.id);
+      return {
+        issueId: updated.id,
+        remediation: updated.remediation,
+        remediations: updated.remediations,
+        updated: true,
+      };
+    },
+  });
+}

--- a/apps/worker/src/sandbox.test.ts
+++ b/apps/worker/src/sandbox.test.ts
@@ -64,14 +64,14 @@ describe("Daytona sandbox preparation", () => {
     expect(session.execCommand).toHaveBeenCalledWith(
       expect.objectContaining({
         cmd: expect.stringContaining(
-          "command -v curl >/dev/null 2>&1 && command -v git >/dev/null 2>&1 && command -v node >/dev/null 2>&1 && command -v python3 >/dev/null 2>&1 && command -v rg >/dev/null 2>&1 && command -v bun >/dev/null 2>&1",
+          "command -v curl >/dev/null 2>&1 && command -v git >/dev/null 2>&1 && command -v node >/dev/null 2>&1 && command -v python3 >/dev/null 2>&1 && command -v rg >/dev/null 2>&1 && command -v unzip >/dev/null 2>&1 && command -v bun >/dev/null 2>&1",
         ),
       }),
     );
     expect(session.execCommand).toHaveBeenCalledWith(
       expect.objectContaining({
         cmd: expect.stringContaining(
-          "install -y -qq curl git nodejs python3 ripgrep",
+          "install -y -qq curl git nodejs python3 ripgrep unzip",
         ),
       }),
     );
@@ -92,7 +92,7 @@ describe("Daytona sandbox preparation", () => {
     } as unknown as DaytonaSandboxSession;
 
     await expect(prepareDaytonaSandbox(session)).rejects.toThrow(
-      "Unable to install curl, git, Node.js, Python 3, ripgrep, and Bun in Daytona: python3 unavailable",
+      "Unable to install curl, git, Node.js, Python 3, ripgrep, unzip, and Bun in Daytona: python3 unavailable",
     );
   });
 
@@ -102,7 +102,7 @@ describe("Daytona sandbox preparation", () => {
     } as unknown as DaytonaSandboxSession;
 
     await expect(prepareDaytonaSandbox(session)).rejects.toThrow(
-      "Unable to install curl, git, Node.js, Python 3, ripgrep, and Bun in Daytona",
+      "Unable to install curl, git, Node.js, Python 3, ripgrep, unzip, and Bun in Daytona",
     );
   });
 });

--- a/apps/worker/src/sandbox.ts
+++ b/apps/worker/src/sandbox.ts
@@ -278,18 +278,18 @@ export async function prepareDaytonaSandbox(
   const output = await session.execCommand({
     cmd: [
       "set -eu",
-      "if command -v curl >/dev/null 2>&1 && command -v git >/dev/null 2>&1 && command -v node >/dev/null 2>&1 && command -v python3 >/dev/null 2>&1 && command -v rg >/dev/null 2>&1 && command -v bun >/dev/null 2>&1; then exit 0; fi",
-      "if ! command -v apt-get >/dev/null 2>&1; then echo 'curl, git, Node.js, Python 3, ripgrep, or Bun is unavailable and apt-get is missing' >&2; exit 1; fi",
+      "if command -v curl >/dev/null 2>&1 && command -v git >/dev/null 2>&1 && command -v node >/dev/null 2>&1 && command -v python3 >/dev/null 2>&1 && command -v rg >/dev/null 2>&1 && command -v unzip >/dev/null 2>&1 && command -v bun >/dev/null 2>&1; then exit 0; fi",
+      "if ! command -v apt-get >/dev/null 2>&1; then echo 'curl, git, Node.js, Python 3, ripgrep, unzip, or Bun is unavailable and apt-get is missing' >&2; exit 1; fi",
       "if [ \"$(id -u)\" -eq 0 ]; then",
       "  apt-get update -qq",
-      "  DEBIAN_FRONTEND=noninteractive apt-get install -y -qq curl git nodejs python3 ripgrep",
+      "  DEBIAN_FRONTEND=noninteractive apt-get install -y -qq curl git nodejs python3 ripgrep unzip",
       "  if ! command -v bun >/dev/null 2>&1; then curl -fsSL https://bun.sh/install | BUN_INSTALL=/usr/local bash; fi",
       "elif command -v sudo >/dev/null 2>&1; then",
       "  sudo apt-get update -qq",
-      "  sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq curl git nodejs python3 ripgrep",
+      "  sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq curl git nodejs python3 ripgrep unzip",
       "  if ! command -v bun >/dev/null 2>&1; then curl -fsSL https://bun.sh/install | sudo BUN_INSTALL=/usr/local bash; fi",
       "else",
-      "  echo 'curl, git, Node.js, Python 3, ripgrep, and Bun installation require root access' >&2",
+      "  echo 'curl, git, Node.js, Python 3, ripgrep, unzip, and Bun installation require root access' >&2",
       "  exit 1",
       "fi",
       "command -v curl >/dev/null",
@@ -297,6 +297,7 @@ export async function prepareDaytonaSandbox(
       "command -v node >/dev/null",
       "command -v python3 >/dev/null",
       "command -v rg >/dev/null",
+      "command -v unzip >/dev/null",
       "command -v bun >/dev/null",
     ].join("\n"),
     maxOutputTokens: 2_000,
@@ -305,7 +306,7 @@ export async function prepareDaytonaSandbox(
   if (!execSucceeded(output)) {
     const detail = output.split("\nOutput:\n", 2)[1]?.trim();
     throw new Error(
-      `Unable to install curl, git, Node.js, Python 3, ripgrep, and Bun in Daytona${detail ? `: ${detail}` : ""}`,
+      `Unable to install curl, git, Node.js, Python 3, ripgrep, unzip, and Bun in Daytona${detail ? `: ${detail}` : ""}`,
     );
   }
 }

--- a/drizzle/0036_slack_issue_followups.sql
+++ b/drizzle/0036_slack_issue_followups.sql
@@ -1,0 +1,21 @@
+CREATE TABLE "slack_investigation_thread_links" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"organization_id" uuid NOT NULL,
+	"investigation_id" uuid NOT NULL,
+	"issue_id" uuid NOT NULL,
+	"team_id" text NOT NULL,
+	"channel_id" text NOT NULL,
+	"integration_account_id" uuid NOT NULL,
+	"thread_timestamp" text NOT NULL,
+	"message_timestamp" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "slack_investigation_thread_links" ADD CONSTRAINT "slack_investigation_thread_links_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "slack_investigation_thread_links" ADD CONSTRAINT "slack_investigation_thread_links_investigation_id_investigations_id_fk" FOREIGN KEY ("investigation_id") REFERENCES "public"."investigations"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "slack_investigation_thread_links" ADD CONSTRAINT "slack_investigation_thread_links_issue_id_issues_id_fk" FOREIGN KEY ("issue_id") REFERENCES "public"."issues"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "slack_investigation_thread_links" ADD CONSTRAINT "slack_investigation_thread_links_integration_account_id_integration_accounts_id_fk" FOREIGN KEY ("integration_account_id") REFERENCES "public"."integration_accounts"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "slack_investigation_thread_links_message_idx" ON "slack_investigation_thread_links" USING btree ("integration_account_id","channel_id","message_timestamp");--> statement-breakpoint
+CREATE INDEX "slack_investigation_thread_links_thread_idx" ON "slack_investigation_thread_links" USING btree ("integration_account_id","channel_id","thread_timestamp");--> statement-breakpoint
+CREATE INDEX "slack_investigation_thread_links_investigation_idx" ON "slack_investigation_thread_links" USING btree ("investigation_id");

--- a/drizzle/meta/0036_snapshot.json
+++ b/drizzle/meta/0036_snapshot.json
@@ -1,0 +1,4322 @@
+{
+  "id": "a20dadae-1b73-4393-b350-2002461201a7",
+  "prevId": "41c758de-baa8-4028-a127-823111e77b5e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "invitation_organizationId_idx": {
+          "name": "invitation_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_email_idx": {
+          "name": "invitation_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "member_organizationId_idx": {
+          "name": "member_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_userId_idx": {
+          "name": "member_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'user'"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_organization_id": {
+          "name": "last_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "pg_catalog.gen_random_uuid()"
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_config_versions": {
+      "name": "agent_config_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "trigger_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_config": {
+          "name": "trigger_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "report_config": {
+          "name": "report_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context_account_ids": {
+          "name": "context_account_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "context_resource_ids": {
+          "name": "context_resource_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "pr_mode": {
+          "name": "pr_mode",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pr_mode_policy": {
+          "name": "pr_mode_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'disabled'"
+        },
+        "create_linear_tickets": {
+          "name": "create_linear_tickets",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "linear_issue_template": {
+          "name": "linear_issue_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'## Responder issue\n[{{issue_id}}]({{issue_url}})\n\n## Description\n{{description}}\n\n## Evidence\n{{evidence}}\n\n## Recommended remediation\n{{remediation}}'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_config_versions_agent_version_idx": {
+          "name": "agent_config_versions_agent_version_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_config_versions_agent_idx": {
+          "name": "agent_config_versions_agent_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_config_versions_agent_id_agents_id_fk": {
+          "name": "agent_config_versions_agent_id_agents_id_fk",
+          "tableFrom": "agent_config_versions",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_config_versions_created_by_user_id_fk": {
+          "name": "agent_config_versions_created_by_user_id_fk",
+          "tableFrom": "agent_config_versions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_version_repositories": {
+      "name": "agent_version_repositories",
+      "schema": "",
+      "columns": {
+        "agent_config_version_id": {
+          "name": "agent_config_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_version_repositories_agent_config_version_id_agent_config_versions_id_fk": {
+          "name": "agent_version_repositories_agent_config_version_id_agent_config_versions_id_fk",
+          "tableFrom": "agent_version_repositories",
+          "tableTo": "agent_config_versions",
+          "columnsFrom": [
+            "agent_config_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_version_repositories_repository_id_repositories_id_fk": {
+          "name": "agent_version_repositories_repository_id_repositories_id_fk",
+          "tableFrom": "agent_version_repositories",
+          "tableTo": "repositories",
+          "columnsFrom": [
+            "repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_version_repositories_agent_config_version_id_repository_id_pk": {
+          "name": "agent_version_repositories_agent_config_version_id_repository_id_pk",
+          "columns": [
+            "agent_config_version_id",
+            "repository_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_version_secrets": {
+      "name": "agent_version_secrets",
+      "schema": "",
+      "columns": {
+        "agent_config_version_id": {
+          "name": "agent_config_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_secret_id": {
+          "name": "workspace_secret_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_version_secrets_agent_config_version_id_agent_config_versions_id_fk": {
+          "name": "agent_version_secrets_agent_config_version_id_agent_config_versions_id_fk",
+          "tableFrom": "agent_version_secrets",
+          "tableTo": "agent_config_versions",
+          "columnsFrom": [
+            "agent_config_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_version_secrets_workspace_secret_id_workspace_secrets_id_fk": {
+          "name": "agent_version_secrets_workspace_secret_id_workspace_secrets_id_fk",
+          "tableFrom": "agent_version_secrets",
+          "tableTo": "workspace_secrets",
+          "columnsFrom": [
+            "workspace_secret_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_version_secrets_agent_config_version_id_workspace_secret_id_pk": {
+          "name": "agent_version_secrets_agent_config_version_id_workspace_secret_id_pk",
+          "columns": [
+            "agent_config_version_id",
+            "workspace_secret_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'standard'"
+        },
+        "active_version_id": {
+          "name": "active_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agents_organization_idx": {
+          "name": "agents_organization_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agents_organization_slack_thread_idx": {
+          "name": "agents_organization_slack_thread_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"agents\".\"purpose\" = 'slack_thread'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agents_organization_id_organization_id_fk": {
+          "name": "agents_organization_id_organization_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.billing_notification_deliveries": {
+      "name": "billing_notification_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integration_account_id": {
+          "name": "integration_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_key": {
+          "name": "period_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination": {
+          "name": "destination",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "billing_notification_delivery_target_idx": {
+          "name": "billing_notification_delivery_target_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "integration_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "destination",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "billing_notification_delivery_status_idx": {
+          "name": "billing_notification_delivery_status_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "billing_notification_deliveries_organization_id_organization_id_fk": {
+          "name": "billing_notification_deliveries_organization_id_organization_id_fk",
+          "tableFrom": "billing_notification_deliveries",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "billing_notification_deliveries_integration_account_id_integration_accounts_id_fk": {
+          "name": "billing_notification_deliveries_integration_account_id_integration_accounts_id_fk",
+          "tableFrom": "billing_notification_deliveries",
+          "tableTo": "integration_accounts",
+          "columnsFrom": [
+            "integration_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.delivery_attempts": {
+      "name": "delivery_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "investigation_id": {
+          "name": "investigation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination": {
+          "name": "destination",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "delivery_attempts_idempotency_idx": {
+          "name": "delivery_attempts_idempotency_idx",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_attempts_investigation_idx": {
+          "name": "delivery_attempts_investigation_idx",
+          "columns": [
+            {
+              "expression": "investigation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "delivery_attempts_investigation_id_investigations_id_fk": {
+          "name": "delivery_attempts_investigation_id_investigations_id_fk",
+          "tableFrom": "delivery_attempts",
+          "tableTo": "investigations",
+          "columnsFrom": [
+            "investigation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instance_configuration": {
+      "name": "instance_configuration",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "active_runtime_profile_id": {
+          "name": "active_runtime_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "instance_configuration_active_runtime_profile_id_runtime_profiles_id_fk": {
+          "name": "instance_configuration_active_runtime_profile_id_runtime_profiles_id_fk",
+          "tableFrom": "instance_configuration",
+          "tableTo": "runtime_profiles",
+          "columnsFrom": [
+            "active_runtime_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_accounts": {
+      "name": "integration_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "integration_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_account_id": {
+          "name": "external_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'connected'"
+        },
+        "encrypted_credentials": {
+          "name": "encrypted_credentials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_key_version": {
+          "name": "credential_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "integration_accounts_organization_provider_external_idx": {
+          "name": "integration_accounts_organization_provider_external_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_accounts_organization_idx": {
+          "name": "integration_accounts_organization_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_accounts_organization_id_organization_id_fk": {
+          "name": "integration_accounts_organization_id_organization_id_fk",
+          "tableFrom": "integration_accounts",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_connection_states": {
+      "name": "integration_connection_states",
+      "schema": "",
+      "columns": {
+        "state_hash": {
+          "name": "state_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "integration_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_verifier": {
+          "name": "code_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "return_to": {
+          "name": "return_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'/settings'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "integration_connection_states_expires_idx": {
+          "name": "integration_connection_states_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_connection_states_organization_idx": {
+          "name": "integration_connection_states_organization_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_connection_states_owner_provider_idx": {
+          "name": "integration_connection_states_owner_provider_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_connection_states_organization_id_organization_id_fk": {
+          "name": "integration_connection_states_organization_id_organization_id_fk",
+          "tableFrom": "integration_connection_states",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "integration_connection_states_user_id_user_id_fk": {
+          "name": "integration_connection_states_user_id_user_id_fk",
+          "tableFrom": "integration_connection_states",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_resources": {
+      "name": "integration_resources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "integration_account_id": {
+          "name": "integration_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "integration_resource_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "available": {
+          "name": "available",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "integration_resources_account_kind_external_idx": {
+          "name": "integration_resources_account_kind_external_idx",
+          "columns": [
+            {
+              "expression": "integration_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_resources_account_idx": {
+          "name": "integration_resources_account_idx",
+          "columns": [
+            {
+              "expression": "integration_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_resources_integration_account_id_integration_accounts_id_fk": {
+          "name": "integration_resources_integration_account_id_integration_accounts_id_fk",
+          "tableFrom": "integration_resources",
+          "tableTo": "integration_accounts",
+          "columnsFrom": [
+            "integration_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.investigation_issues": {
+      "name": "investigation_issues",
+      "schema": "",
+      "columns": {
+        "investigation_id": {
+          "name": "investigation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relationship": {
+          "name": "relationship",
+          "type": "issue_relationship",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "investigation_issues_issue_idx": {
+          "name": "investigation_issues_issue_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "investigation_issues_investigation_id_investigations_id_fk": {
+          "name": "investigation_issues_investigation_id_investigations_id_fk",
+          "tableFrom": "investigation_issues",
+          "tableTo": "investigations",
+          "columnsFrom": [
+            "investigation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "investigation_issues_issue_id_issues_id_fk": {
+          "name": "investigation_issues_issue_id_issues_id_fk",
+          "tableFrom": "investigation_issues",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "investigation_issues_investigation_id_issue_id_pk": {
+          "name": "investigation_issues_investigation_id_issue_id_pk",
+          "columns": [
+            "investigation_id",
+            "issue_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.investigation_replay_requests": {
+      "name": "investigation_replay_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source_investigation_id": {
+          "name": "source_investigation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "replay_investigation_id": {
+          "name": "replay_investigation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_by": {
+          "name": "requested_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "investigation_replay_request_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "processing_started_at": {
+          "name": "processing_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "queued_at": {
+          "name": "queued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "investigation_replay_requests_replay_idx": {
+          "name": "investigation_replay_requests_replay_idx",
+          "columns": [
+            {
+              "expression": "replay_investigation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "investigation_replay_requests_claim_idx": {
+          "name": "investigation_replay_requests_claim_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "investigation_replay_requests_source_idx": {
+          "name": "investigation_replay_requests_source_idx",
+          "columns": [
+            {
+              "expression": "source_investigation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "investigation_replay_requests_source_investigation_id_investigations_id_fk": {
+          "name": "investigation_replay_requests_source_investigation_id_investigations_id_fk",
+          "tableFrom": "investigation_replay_requests",
+          "tableTo": "investigations",
+          "columnsFrom": [
+            "source_investigation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.investigation_trace_events": {
+      "name": "investigation_trace_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "investigation_id": {
+          "name": "investigation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event": {
+          "name": "event",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "investigation_trace_events_investigation_id_idx": {
+          "name": "investigation_trace_events_investigation_id_idx",
+          "columns": [
+            {
+              "expression": "investigation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "investigation_trace_events_investigation_id_investigations_id_fk": {
+          "name": "investigation_trace_events_investigation_id_investigations_id_fk",
+          "tableFrom": "investigation_trace_events",
+          "tableTo": "investigations",
+          "columnsFrom": [
+            "investigation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.investigations": {
+      "name": "investigations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_config_version_id": {
+          "name": "agent_config_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime_profile_id": {
+          "name": "runtime_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_mode": {
+          "name": "execution_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'standard'"
+        },
+        "slack_investigation_session_id": {
+          "name": "slack_investigation_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "investigation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finding": {
+          "name": "finding",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "structured_report": {
+          "name": "structured_report",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replay_report": {
+          "name": "replay_report",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "report_markdown": {
+          "name": "report_markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_replay": {
+          "name": "is_replay",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "replay_of_investigation_id": {
+          "name": "replay_of_investigation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eve_session_id": {
+          "name": "eve_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_message_timestamp": {
+          "name": "slack_message_timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_trace_items": {
+          "name": "slack_trace_items",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "slack_thread_snapshot": {
+          "name": "slack_thread_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "investigations_organization_created_idx": {
+          "name": "investigations_organization_created_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "investigations_agent_created_idx": {
+          "name": "investigations_agent_created_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "investigations_replay_source_idx": {
+          "name": "investigations_replay_source_idx",
+          "columns": [
+            {
+              "expression": "replay_of_investigation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "investigations_organization_id_organization_id_fk": {
+          "name": "investigations_organization_id_organization_id_fk",
+          "tableFrom": "investigations",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "investigations_agent_id_agents_id_fk": {
+          "name": "investigations_agent_id_agents_id_fk",
+          "tableFrom": "investigations",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "investigations_agent_config_version_id_agent_config_versions_id_fk": {
+          "name": "investigations_agent_config_version_id_agent_config_versions_id_fk",
+          "tableFrom": "investigations",
+          "tableTo": "agent_config_versions",
+          "columnsFrom": [
+            "agent_config_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "investigations_runtime_profile_id_runtime_profiles_id_fk": {
+          "name": "investigations_runtime_profile_id_runtime_profiles_id_fk",
+          "tableFrom": "investigations",
+          "tableTo": "runtime_profiles",
+          "columnsFrom": [
+            "runtime_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "investigations_slack_investigation_session_id_slack_investigation_sessions_id_fk": {
+          "name": "investigations_slack_investigation_session_id_slack_investigation_sessions_id_fk",
+          "tableFrom": "investigations",
+          "tableTo": "slack_investigation_sessions",
+          "columnsFrom": [
+            "slack_investigation_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "investigations_replay_source_fk": {
+          "name": "investigations_replay_source_fk",
+          "tableFrom": "investigations",
+          "tableTo": "investigations",
+          "columnsFrom": [
+            "replay_of_investigation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_linear_tickets": {
+      "name": "issue_linear_tickets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "investigation_id": {
+          "name": "investigation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_config_version_id": {
+          "name": "agent_config_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integration_account_id": {
+          "name": "integration_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linear_issue_id": {
+          "name": "linear_issue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linear_identifier": {
+          "name": "linear_identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linear_issue_url": {
+          "name": "linear_issue_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "issue_linear_tickets_issue_idx": {
+          "name": "issue_linear_tickets_issue_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_linear_tickets_investigation_idx": {
+          "name": "issue_linear_tickets_investigation_idx",
+          "columns": [
+            {
+              "expression": "investigation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_linear_tickets_status_created_idx": {
+          "name": "issue_linear_tickets_status_created_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_linear_tickets_issue_id_issues_id_fk": {
+          "name": "issue_linear_tickets_issue_id_issues_id_fk",
+          "tableFrom": "issue_linear_tickets",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_linear_tickets_investigation_id_investigations_id_fk": {
+          "name": "issue_linear_tickets_investigation_id_investigations_id_fk",
+          "tableFrom": "issue_linear_tickets",
+          "tableTo": "investigations",
+          "columnsFrom": [
+            "investigation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_linear_tickets_agent_config_version_id_agent_config_versions_id_fk": {
+          "name": "issue_linear_tickets_agent_config_version_id_agent_config_versions_id_fk",
+          "tableFrom": "issue_linear_tickets",
+          "tableTo": "agent_config_versions",
+          "columnsFrom": [
+            "agent_config_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "issue_linear_tickets_integration_account_id_integration_accounts_id_fk": {
+          "name": "issue_linear_tickets_integration_account_id_integration_accounts_id_fk",
+          "tableFrom": "issue_linear_tickets",
+          "tableTo": "integration_accounts",
+          "columnsFrom": [
+            "integration_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_pull_request_activities": {
+      "name": "issue_pull_request_activities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_key": {
+          "name": "external_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event": {
+          "name": "event",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_pull_request_activities_request_idx": {
+          "name": "issue_pull_request_activities_request_idx",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_pull_request_activities_external_key_idx": {
+          "name": "issue_pull_request_activities_external_key_idx",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"issue_pull_request_activities\".\"external_key\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_pull_request_activities_request_id_issue_pull_requests_id_fk": {
+          "name": "issue_pull_request_activities_request_id_issue_pull_requests_id_fk",
+          "tableFrom": "issue_pull_request_activities",
+          "tableTo": "issue_pull_requests",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_pull_request_slack_messages": {
+      "name": "issue_pull_request_slack_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integration_account_id": {
+          "name": "integration_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_timestamp": {
+          "name": "message_timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_pull_request_slack_messages_message_idx": {
+          "name": "issue_pull_request_slack_messages_message_idx",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "integration_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "message_timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_pull_request_slack_messages_request_idx": {
+          "name": "issue_pull_request_slack_messages_request_idx",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_pull_request_slack_messages_request_id_issue_pull_requests_id_fk": {
+          "name": "issue_pull_request_slack_messages_request_id_issue_pull_requests_id_fk",
+          "tableFrom": "issue_pull_request_slack_messages",
+          "tableTo": "issue_pull_requests",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_pull_request_slack_messages_integration_account_id_integration_accounts_id_fk": {
+          "name": "issue_pull_request_slack_messages_integration_account_id_integration_accounts_id_fk",
+          "tableFrom": "issue_pull_request_slack_messages",
+          "tableTo": "integration_accounts",
+          "columnsFrom": [
+            "integration_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_pull_requests": {
+      "name": "issue_pull_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "investigation_id": {
+          "name": "investigation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_config_version_id": {
+          "name": "agent_config_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "remediation_id": {
+          "name": "remediation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_full_name": {
+          "name": "repository_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pull_request_number": {
+          "name": "pull_request_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pull_request_url": {
+          "name": "pull_request_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eve_session_id": {
+          "name": "eve_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "issue_pull_requests_active_issue_idx": {
+          "name": "issue_pull_requests_active_issue_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"status\" in ('queued', 'creating', 'created') and \"repository_full_name\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_pull_requests_active_issue_repository_idx": {
+          "name": "issue_pull_requests_active_issue_repository_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repository_full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"status\" in ('queued', 'creating', 'created') and \"repository_full_name\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_pull_requests_issue_created_idx": {
+          "name": "issue_pull_requests_issue_created_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_pull_requests_investigation_idx": {
+          "name": "issue_pull_requests_investigation_idx",
+          "columns": [
+            {
+              "expression": "investigation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_pull_requests_issue_id_issues_id_fk": {
+          "name": "issue_pull_requests_issue_id_issues_id_fk",
+          "tableFrom": "issue_pull_requests",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_pull_requests_investigation_id_investigations_id_fk": {
+          "name": "issue_pull_requests_investigation_id_investigations_id_fk",
+          "tableFrom": "issue_pull_requests",
+          "tableTo": "investigations",
+          "columnsFrom": [
+            "investigation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_pull_requests_agent_config_version_id_agent_config_versions_id_fk": {
+          "name": "issue_pull_requests_agent_config_version_id_agent_config_versions_id_fk",
+          "tableFrom": "issue_pull_requests",
+          "tableTo": "agent_config_versions",
+          "columnsFrom": [
+            "agent_config_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issues": {
+      "name": "issues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root_cause": {
+          "name": "root_cause",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "timeline": {
+          "name": "timeline",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "severity": {
+          "name": "severity",
+          "type": "severity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "remediation": {
+          "name": "remediation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "remediations": {
+          "name": "remediations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_model": {
+          "name": "embedding_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issues_organization_created_idx": {
+          "name": "issues_organization_created_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issues_organization_id_organization_id_fk": {
+          "name": "issues_organization_id_organization_id_fk",
+          "tableFrom": "issues",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.legacy_account_redirect": {
+      "name": "legacy_account_redirect",
+      "schema": "",
+      "columns": {
+        "email_normalized": {
+          "name": "email_normalized",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "old_user_id": {
+          "name": "old_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_enabled": {
+          "name": "redirect_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "source_snapshot": {
+          "name": "source_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "legacy_account_redirect_enabled_idx": {
+          "name": "legacy_account_redirect_enabled_idx",
+          "columns": [
+            {
+              "expression": "redirect_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.repositories": {
+      "name": "repositories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "integration_account_id": {
+          "name": "integration_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'main'"
+        },
+        "private": {
+          "name": "private",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "available": {
+          "name": "available",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "repositories_installation_external_idx": {
+          "name": "repositories_installation_external_idx",
+          "columns": [
+            {
+              "expression": "integration_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "repositories_integration_account_id_integration_accounts_id_fk": {
+          "name": "repositories_integration_account_id_integration_accounts_id_fk",
+          "tableFrom": "repositories",
+          "tableTo": "integration_accounts",
+          "columnsFrom": [
+            "integration_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runtime_profiles": {
+      "name": "runtime_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "version": {
+          "name": "version",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_options": {
+          "name": "model_options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "runtime_profiles_version_idx": {
+          "name": "runtime_profiles_version_idx",
+          "columns": [
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_investigation_sessions": {
+      "name": "slack_investigation_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_config_version_id": {
+          "name": "agent_config_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime_profile_id": {
+          "name": "runtime_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_timestamp": {
+          "name": "thread_timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandbox_session_state": {
+          "name": "sandbox_session_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_response_id": {
+          "name": "previous_response_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "slack_investigation_sessions_thread_idx": {
+          "name": "slack_investigation_sessions_thread_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "thread_timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_investigation_sessions_organization_id_organization_id_fk": {
+          "name": "slack_investigation_sessions_organization_id_organization_id_fk",
+          "tableFrom": "slack_investigation_sessions",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "slack_investigation_sessions_agent_id_agents_id_fk": {
+          "name": "slack_investigation_sessions_agent_id_agents_id_fk",
+          "tableFrom": "slack_investigation_sessions",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "slack_investigation_sessions_agent_config_version_id_agent_config_versions_id_fk": {
+          "name": "slack_investigation_sessions_agent_config_version_id_agent_config_versions_id_fk",
+          "tableFrom": "slack_investigation_sessions",
+          "tableTo": "agent_config_versions",
+          "columnsFrom": [
+            "agent_config_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "slack_investigation_sessions_runtime_profile_id_runtime_profiles_id_fk": {
+          "name": "slack_investigation_sessions_runtime_profile_id_runtime_profiles_id_fk",
+          "tableFrom": "slack_investigation_sessions",
+          "tableTo": "runtime_profiles",
+          "columnsFrom": [
+            "runtime_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_investigation_thread_links": {
+      "name": "slack_investigation_thread_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "investigation_id": {
+          "name": "investigation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integration_account_id": {
+          "name": "integration_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_timestamp": {
+          "name": "thread_timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_timestamp": {
+          "name": "message_timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "slack_investigation_thread_links_message_idx": {
+          "name": "slack_investigation_thread_links_message_idx",
+          "columns": [
+            {
+              "expression": "integration_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "message_timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "slack_investigation_thread_links_thread_idx": {
+          "name": "slack_investigation_thread_links_thread_idx",
+          "columns": [
+            {
+              "expression": "integration_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "thread_timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "slack_investigation_thread_links_investigation_idx": {
+          "name": "slack_investigation_thread_links_investigation_idx",
+          "columns": [
+            {
+              "expression": "investigation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_investigation_thread_links_organization_id_organization_id_fk": {
+          "name": "slack_investigation_thread_links_organization_id_organization_id_fk",
+          "tableFrom": "slack_investigation_thread_links",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "slack_investigation_thread_links_investigation_id_investigations_id_fk": {
+          "name": "slack_investigation_thread_links_investigation_id_investigations_id_fk",
+          "tableFrom": "slack_investigation_thread_links",
+          "tableTo": "investigations",
+          "columnsFrom": [
+            "investigation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "slack_investigation_thread_links_issue_id_issues_id_fk": {
+          "name": "slack_investigation_thread_links_issue_id_issues_id_fk",
+          "tableFrom": "slack_investigation_thread_links",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "slack_investigation_thread_links_integration_account_id_integration_accounts_id_fk": {
+          "name": "slack_investigation_thread_links_integration_account_id_integration_accounts_id_fk",
+          "tableFrom": "slack_investigation_thread_links",
+          "tableTo": "integration_accounts",
+          "columnsFrom": [
+            "integration_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_receipts": {
+      "name": "webhook_receipts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_event_id": {
+          "name": "external_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "investigation_id": {
+          "name": "investigation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_hash": {
+          "name": "payload_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_receipts_provider_event_idx": {
+          "name": "webhook_receipts_provider_event_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_receipts_organization_id_organization_id_fk": {
+          "name": "webhook_receipts_organization_id_organization_id_fk",
+          "tableFrom": "webhook_receipts",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_secrets": {
+      "name": "workspace_secrets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "daytona_secret_id": {
+          "name": "daytona_secret_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "daytona_secret_name": {
+          "name": "daytona_secret_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allowed_hosts": {
+          "name": "allowed_hosts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workspace_secrets_organization_name_idx": {
+          "name": "workspace_secrets_organization_name_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_secrets_daytona_id_idx": {
+          "name": "workspace_secrets_daytona_id_idx",
+          "columns": [
+            {
+              "expression": "daytona_secret_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_secrets_daytona_name_idx": {
+          "name": "workspace_secrets_daytona_name_idx",
+          "columns": [
+            {
+              "expression": "daytona_secret_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_secrets_organization_id_organization_id_fk": {
+          "name": "workspace_secrets_organization_id_organization_id_fk",
+          "tableFrom": "workspace_secrets",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "workspace_secrets_created_by_user_id_fk": {
+          "name": "workspace_secrets_created_by_user_id_fk",
+          "tableFrom": "workspace_secrets",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.integration_provider": {
+      "name": "integration_provider",
+      "schema": "public",
+      "values": [
+        "aws",
+        "gcp",
+        "github",
+        "slack",
+        "sentry",
+        "datadog",
+        "axiom",
+        "clickstack",
+        "upstash",
+        "langfuse",
+        "vercel",
+        "custom_mcp",
+        "linear"
+      ]
+    },
+    "public.integration_resource_kind": {
+      "name": "integration_resource_kind",
+      "schema": "public",
+      "values": [
+        "slack_channel",
+        "sentry_project",
+        "datadog_monitor",
+        "vercel_project"
+      ]
+    },
+    "public.investigation_replay_request_status": {
+      "name": "investigation_replay_request_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "queued",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.investigation_status": {
+      "name": "investigation_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "investigating",
+        "resolved",
+        "failed"
+      ]
+    },
+    "public.issue_relationship": {
+      "name": "issue_relationship",
+      "schema": "public",
+      "values": [
+        "new",
+        "recurrence"
+      ]
+    },
+    "public.severity": {
+      "name": "severity",
+      "schema": "public",
+      "values": [
+        "SEV-1",
+        "SEV-2",
+        "SEV-3"
+      ]
+    },
+    "public.trigger_kind": {
+      "name": "trigger_kind",
+      "schema": "public",
+      "values": [
+        "sentry_issue",
+        "datadog_monitor",
+        "slack_channel",
+        "slack_mention"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -253,6 +253,13 @@
       "when": 1788283103101,
       "tag": "0035_add_gcp_context",
       "breakpoints": true
+    },
+    {
+      "idx": 36,
+      "version": "7",
+      "when": 1788283879030,
+      "tag": "0036_slack_issue_followups",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/src/db/agents.ts
+++ b/packages/core/src/db/agents.ts
@@ -49,7 +49,8 @@ export async function findAgentsForSlackEvent(input: {
     trigger: "slack_channel" | "slack_mention" | "slack_thread";
   }>
 > {
-  const rows = await getDatabase()
+  const db = getDatabase();
+  const rows = await db
     .select({
       agentId: agents.id,
       organizationId: agents.organizationId,

--- a/packages/core/src/db/investigations.ts
+++ b/packages/core/src/db/investigations.ts
@@ -46,9 +46,11 @@ import {
   investigationReplayRequests,
   investigationTraceEvents,
   investigations,
+  issues,
   repositories,
   runtimeProfiles,
   slackInvestigationSessions,
+  slackInvestigationThreadLinks,
   webhookReceipts,
   type InvestigationInput,
   type InvestigationSlackMessageSnapshot,
@@ -337,6 +339,125 @@ export async function recordInvestigationSlackSource(
     ...snapshot,
     source,
   }));
+}
+
+export async function recordSlackInvestigationThreadLink(input: {
+  channelId: string;
+  integrationAccountId: string;
+  investigationId: string;
+  issueId: string;
+  messageTimestamp: string;
+  organizationId: string;
+  teamId: string;
+  threadTimestamp: string;
+}): Promise<void> {
+  await getDatabase()
+    .insert(slackInvestigationThreadLinks)
+    .values(input)
+    .onConflictDoNothing({
+      target: [
+        slackInvestigationThreadLinks.integrationAccountId,
+        slackInvestigationThreadLinks.channelId,
+        slackInvestigationThreadLinks.messageTimestamp,
+      ],
+    });
+}
+
+export async function findSlackIssueThread(input: {
+  channelId: string;
+  teamId: string;
+  threadTimestamp: string;
+}) {
+  const rows = await getDatabase()
+    .select({
+      agentId: investigations.agentId,
+      agentConfigVersionId: investigations.agentConfigVersionId,
+      agentModel: agentConfigVersions.model,
+      agentPrompt: agentConfigVersions.prompt,
+      agentPrMode: agentConfigVersions.prMode,
+      channelId: slackInvestigationThreadLinks.channelId,
+      encryptedCredentials: integrationAccounts.encryptedCredentials,
+      id: investigations.id,
+      issueId: slackInvestigationThreadLinks.issueId,
+      issueTitle: issues.title,
+      issueDescription: issues.description,
+      issueRootCause: issues.rootCause,
+      issueRemediation: issues.remediation,
+      issueRemediations: issues.remediations,
+      investigationInput: investigations.input,
+      organizationId: investigations.organizationId,
+      reportMarkdown: investigations.reportMarkdown,
+      teamId: slackInvestigationThreadLinks.teamId,
+      threadTimestamp: slackInvestigationThreadLinks.threadTimestamp,
+      integrationAccountId: slackInvestigationThreadLinks.integrationAccountId,
+    })
+    .from(slackInvestigationThreadLinks)
+    .innerJoin(
+      investigations,
+      eq(investigations.id, slackInvestigationThreadLinks.investigationId),
+    )
+    .innerJoin(issues, eq(issues.id, slackInvestigationThreadLinks.issueId))
+    .innerJoin(
+      agentConfigVersions,
+      eq(agentConfigVersions.id, investigations.agentConfigVersionId),
+    )
+    .innerJoin(
+      integrationAccounts,
+      and(
+        eq(
+          integrationAccounts.id,
+          slackInvestigationThreadLinks.integrationAccountId,
+        ),
+        eq(integrationAccounts.organizationId, investigations.organizationId),
+        eq(integrationAccounts.externalAccountId, input.teamId),
+        eq(integrationAccounts.provider, "slack"),
+        eq(integrationAccounts.status, "connected"),
+      ),
+    )
+    .where(
+      and(
+        eq(slackInvestigationThreadLinks.teamId, input.teamId),
+        eq(slackInvestigationThreadLinks.channelId, input.channelId),
+        eq(
+          slackInvestigationThreadLinks.threadTimestamp,
+          input.threadTimestamp,
+        ),
+      ),
+    )
+    .orderBy(desc(investigations.createdAt));
+  if (rows.length === 0) return null;
+  const first = rows[0]!;
+  return {
+    ...first,
+    issueIds: [...new Set(rows.map((row) => row.issueId))],
+    issues: rows.map((row) => ({
+      id: row.issueId,
+      title: row.issueTitle,
+      description: row.issueDescription,
+      rootCause: row.issueRootCause,
+      remediation: row.issueRemediation,
+      remediations: row.issueRemediations,
+    })),
+  };
+}
+
+export async function getSlackInvestigationThreadLinks(investigationId: string) {
+  return getDatabase()
+    .select({
+      issueId: slackInvestigationThreadLinks.issueId,
+      channelId: slackInvestigationThreadLinks.channelId,
+      integrationAccountId: slackInvestigationThreadLinks.integrationAccountId,
+      teamId: slackInvestigationThreadLinks.teamId,
+      threadTimestamp: slackInvestigationThreadLinks.threadTimestamp,
+      messageTimestamp: slackInvestigationThreadLinks.messageTimestamp,
+      encryptedCredentials: integrationAccounts.encryptedCredentials,
+    })
+    .from(slackInvestigationThreadLinks)
+    .innerJoin(
+      integrationAccounts,
+      eq(integrationAccounts.id, slackInvestigationThreadLinks.integrationAccountId),
+    )
+    .where(eq(slackInvestigationThreadLinks.investigationId, investigationId));
 }
 
 export async function recordInvestigationSlackReply(

--- a/packages/core/src/db/issues.ts
+++ b/packages/core/src/db/issues.ts
@@ -13,6 +13,7 @@ import type {
   InvestigationReportSubmission,
   IssueEvidence,
   IssueRemediation,
+  IssueRemediationSubmission,
   StructuredInvestigationReport,
 } from "../investigations/report.js";
 import {
@@ -570,6 +571,52 @@ export async function getIssueForSlackAction(input: {
   return rows[0] ?? null;
 }
 
+export async function updateIssueRemediations(input: {
+  issueId: string;
+  organizationId: string;
+  remediations: IssueRemediationSubmission[];
+}) {
+  const remediations: IssueRemediation[] = input.remediations.map(
+    (remediation) => ({ ...remediation, id: randomUUID() }),
+  );
+  const rows = await getDatabase()
+    .update(issues)
+    .set({
+      remediation: remediationSummary(remediations),
+      remediations,
+      updatedAt: new Date(),
+    })
+    .where(
+      and(
+        eq(issues.id, input.issueId),
+        eq(issues.organizationId, input.organizationId),
+        isNull(issues.archivedAt),
+      ),
+    )
+    .returning({
+      id: issues.id,
+      remediations: issues.remediations,
+      title: issues.title,
+      remediation: issues.remediation,
+    });
+  const updated = rows[0];
+  if (updated) {
+    const preferred = remediations.find((remediation) => remediation.type === "code_change") ?? remediations[0];
+    if (preferred) {
+      await getDatabase()
+        .update(issuePullRequests)
+        .set({ remediationId: preferred.id, updatedAt: new Date() })
+        .where(
+          and(
+            eq(issuePullRequests.issueId, input.issueId),
+            inArray(issuePullRequests.status, ["queued", "creating", "created"]),
+          ),
+        );
+    }
+  }
+  return updated ?? null;
+}
+
 export async function getInvestigationIssueDetails(investigationId: string) {
   return getDatabase()
     .select({
@@ -665,6 +712,7 @@ export interface SlackInvestigationDeliveryContext {
     integrationAccountId: string;
     messageTimestamp: string | null;
     reactionTimestamp: string;
+    teamId?: string;
     threadTimestamp: string;
   } | null;
   output: {
@@ -672,6 +720,7 @@ export interface SlackInvestigationDeliveryContext {
     encryptedCredentials: string;
     integrationAccountId: string;
     severities: Array<"SEV-1" | "SEV-2" | "SEV-3"> | null;
+    teamId?: string;
   } | null;
 }
 
@@ -836,10 +885,11 @@ export async function getSlackInvestigationDeliveryContext(
   ];
   const accountRows = accountIds.length
     ? await db
-        .select({
-          id: integrationAccounts.id,
-          encryptedCredentials: integrationAccounts.encryptedCredentials,
-        })
+      .select({
+        id: integrationAccounts.id,
+        encryptedCredentials: integrationAccounts.encryptedCredentials,
+        teamId: integrationAccounts.externalAccountId,
+      })
         .from(integrationAccounts)
         .where(
           and(
@@ -864,6 +914,8 @@ export async function getSlackInvestigationDeliveryContext(
   const outputCredentials = outputConfig
     ? credentialsByAccount.get(outputConfig.integrationAccountId)
     : null;
+  const teamIdForAccount = (accountId: string): string | null =>
+    accountRows.find((account) => account.id === accountId)?.teamId ?? null;
   const issueDetails = await getInvestigationIssueDetails(investigation.id);
   const pullRequestRows = await db
     .select({
@@ -911,17 +963,22 @@ export async function getSlackInvestigationDeliveryContext(
             integrationAccountId: sourceAccountId,
             messageTimestamp: investigation.messageTimestamp,
             reactionTimestamp: sourceReactionTimestamp,
+            teamId:
+              typeof investigation.input.attributes?.teamId === "string"
+                ? investigation.input.attributes.teamId
+                : teamIdForAccount(sourceAccountId) ?? "",
             threadTimestamp: sourceTimestamp,
           }
         : null,
     output:
       outputConfig && outputCredentials
         ? {
-            channelId: outputConfig.outputChannelId,
-            encryptedCredentials: outputCredentials,
-            integrationAccountId: outputConfig.integrationAccountId,
-            severities: outputConfig.severities ?? null,
-          }
+          channelId: outputConfig.outputChannelId,
+          encryptedCredentials: outputCredentials,
+          integrationAccountId: outputConfig.integrationAccountId,
+          severities: outputConfig.severities ?? null,
+          teamId: teamIdForAccount(outputConfig.integrationAccountId) ?? "",
+        }
         : null,
   };
 }

--- a/packages/core/src/db/schema.ts
+++ b/packages/core/src/db/schema.ts
@@ -495,6 +495,51 @@ export const slackInvestigationSessions = pgTable(
   ],
 );
 
+/**
+ * Durable bindings between Slack issue cards and their originating
+ * investigation. These cover both Slack-sourced alert threads and issue
+ * cards posted directly to an output channel.
+ */
+export const slackInvestigationThreadLinks = pgTable(
+  "slack_investigation_thread_links",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    organizationId: uuid("organization_id")
+      .notNull()
+      .references(() => organization.id, { onDelete: "cascade" }),
+    investigationId: uuid("investigation_id")
+      .notNull()
+      .references(() => investigations.id, { onDelete: "cascade" }),
+    issueId: uuid("issue_id")
+      .notNull()
+      .references(() => issues.id, { onDelete: "cascade" }),
+    teamId: text("team_id").notNull(),
+    channelId: text("channel_id").notNull(),
+    integrationAccountId: uuid("integration_account_id")
+      .notNull()
+      .references(() => integrationAccounts.id, { onDelete: "cascade" }),
+    threadTimestamp: text("thread_timestamp").notNull(),
+    messageTimestamp: text("message_timestamp").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    uniqueIndex("slack_investigation_thread_links_message_idx").on(
+      table.integrationAccountId,
+      table.channelId,
+      table.messageTimestamp,
+    ),
+    index("slack_investigation_thread_links_thread_idx").on(
+      table.integrationAccountId,
+      table.channelId,
+      table.threadTimestamp,
+    ),
+    index("slack_investigation_thread_links_investigation_idx").on(
+      table.investigationId,
+    ),
+  ],
+);
+
 export const investigations = pgTable(
   "investigations",
   {

--- a/packages/core/src/integrations/slack-delivery.test.ts
+++ b/packages/core/src/integrations/slack-delivery.test.ts
@@ -6,6 +6,7 @@ import {
   slackDeliveryClientMessageId,
   slackDeliveryErrorMessage,
   slackInvestigationSummaryMessage,
+  slackIssueFollowupMessage,
   slackIssueMessage,
 } from "./slack-delivery.js";
 
@@ -331,5 +332,71 @@ describe("Slack issue delivery", () => {
         }),
       ]),
     );
+  });
+
+  it("renders updated remediations with the same actionable carousel", () => {
+    const issueId = "07070707-0707-4707-8707-070707070707";
+    const codeRemediationId = "24242424-2424-4424-8424-242424242424";
+    const externalRemediationId = "26262626-2626-4626-8626-262626262626";
+    const message = slackIssueFollowupMessage({
+      context: {
+        investigationId: "16161616-1616-4616-8616-161616161616",
+        issues: [{
+          id: issueId,
+          title: "Malformed cart payload",
+          description: "Malformed payloads fail during parsing.",
+          rootCause: "Input is parsed before it is validated.",
+          timeline: [],
+          severity: "SEV-2",
+          remediation: "Validate the payload, warn, and return 400.",
+          remediations: [{
+            id: codeRemediationId,
+            type: "code_change",
+            title: "Validate before parsing",
+            description: "Return a structured 400 for malformed input.",
+            changes: [{ repository: null, diff: "diff --git a/a b/a\n--- a/a\n+++ b/a\n@@ -1 +1 @@\n-a\n+b" }],
+          }, {
+            id: externalRemediationId,
+            type: "external_action",
+            title: "Adjust the monitor",
+            description: "Exclude expected validation warnings.",
+            agentPrompt: "Exclude warning-level validation logs from the monitor.",
+          }],
+          pullRequest: null,
+          relationship: "new",
+          evidence: [],
+        }],
+        prMode: "manual",
+        source: null,
+        output: null,
+        organizationId: "17171717-1717-4717-8717-171717171717",
+      } as never,
+      response: "I revised the proposal to retain a warning.",
+      updatedIssueIds: [issueId],
+    });
+
+    expect(message.blocks).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        type: "carousel",
+        elements: [
+          expect.objectContaining({
+            actions: expect.arrayContaining([
+              expect.objectContaining({
+                action_id: "create_issue_pull_request",
+                text: expect.objectContaining({ text: "Open PR" }),
+              }),
+            ]),
+          }),
+          expect.objectContaining({
+            actions: expect.arrayContaining([
+              expect.objectContaining({
+                action_id: "copy_issue_prompt",
+                text: expect.objectContaining({ text: "Copy prompt" }),
+              }),
+            ]),
+          }),
+        ],
+      }),
+    ]));
   });
 });

--- a/packages/core/src/integrations/slack-delivery.ts
+++ b/packages/core/src/integrations/slack-delivery.ts
@@ -10,6 +10,8 @@ import {
 } from "../db/issues.js";
 import {
   recordInvestigationSlackReply,
+  getSlackInvestigationThreadLinks,
+  recordSlackInvestigationThreadLink,
   setInvestigationSlackReaction,
 } from "../db/investigations.js";
 import { registerIssuePullRequestSlackMessage } from "../db/pull-requests.js";
@@ -204,11 +206,65 @@ function issueSlackMessage(
     : slackIssueMessage(
         issue,
         context.investigationId,
-        context.prMode === "manual" &&
-          issue.remediations.some(
-            (remediation) => remediation.type === "code_change",
-          ),
+        canCreateIssuePullRequest(context, issue),
       );
+}
+
+function canCreateIssuePullRequest(
+  context: SlackInvestigationDeliveryContext,
+  issue: DeliveryIssue,
+): boolean {
+  return context.prMode === "manual" &&
+    issue.remediations.some((remediation) => remediation.type === "code_change");
+}
+
+export function slackIssueFollowupMessage(input: {
+  context: SlackInvestigationDeliveryContext | null;
+  response: string;
+  updatedIssueIds: string[];
+}): { blocks: unknown[]; text: string } {
+  const issues = input.context?.issues.filter((issue) =>
+    input.updatedIssueIds.includes(issue.id)
+  ) ?? [];
+  const remediationText = issues.length > 0
+    ? issues.map((issue) =>
+      `Updated remediation — ${issue.title}\n${issue.remediation}`
+    ).join("\n\n")
+    : "No issue remediation was changed; the investigation needs clarification before making a safe update.";
+  const text = `${input.response}\n\n${remediationText}`.slice(0, 100_000);
+  const blocks: unknown[] = [{
+    type: "section",
+    text: {
+      type: "mrkdwn",
+      text: truncateSlackBlock(input.response),
+    },
+  }];
+
+  if (issues.length === 0) {
+    blocks.push({
+      type: "section",
+      text: { type: "mrkdwn", text: remediationText },
+    });
+  } else {
+    for (const issue of issues) {
+      blocks.push({
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: `*Updated remediation — ${escapeSlack(issue.title)}*`,
+        },
+      });
+      blocks.push(...slackRemediationCarousel({
+        canCreatePullRequest: input.context
+          ? canCreateIssuePullRequest(input.context, issue)
+          : false,
+        issueId: issue.id,
+        remediations: issue.remediations,
+      }));
+    }
+  }
+
+  return { blocks, text };
 }
 
 async function registerPullRequestMessage(input: {
@@ -622,6 +678,18 @@ async function deliverSourceThread(
         slackTimestamp: messageTimestamp,
         text: message.text,
       });
+      if (context.source.teamId && context.organizationId) {
+        await recordSlackInvestigationThreadLink({
+          channelId: context.source.channelId,
+          integrationAccountId: context.source.integrationAccountId,
+          investigationId: context.investigationId,
+          issueId: issue.id,
+          messageTimestamp,
+          organizationId: context.organizationId,
+          teamId: context.source.teamId,
+          threadTimestamp: context.source.threadTimestamp,
+        });
+      }
       await registerPullRequestMessage({
         channelId: context.source.channelId,
         integrationAccountId: context.source.integrationAccountId,
@@ -722,6 +790,18 @@ async function deliverOutputChannel(
       issue,
       messageTimestamp,
     });
+    if (messageTimestamp && context.output.teamId && context.organizationId) {
+      await recordSlackInvestigationThreadLink({
+        channelId: context.output.channelId,
+        integrationAccountId: context.output.integrationAccountId,
+        investigationId: context.investigationId,
+        issueId: issue.id,
+        messageTimestamp,
+        organizationId: context.organizationId,
+        teamId: context.output.teamId,
+        threadTimestamp: messageTimestamp,
+      });
+    }
   }
 }
 
@@ -740,4 +820,48 @@ export async function deliverInvestigationToSlack(
       ? [slackDeliveryErrorMessage(result.reason)]
       : [],
   );
+}
+
+/** Post follow-up feedback and the revised remediation back into the original issue thread. */
+export async function deliverSlackIssueFollowupResponse(input: {
+  channelId: string;
+  deliveryRunId: string;
+  originalInvestigationId: string;
+  response: string;
+  threadTimestamp: string;
+  updatedIssueIds: string[];
+}): Promise<void> {
+  const links = await getSlackInvestigationThreadLinks(input.originalInvestigationId);
+  if (links.length === 0) return;
+  const context = await getSlackInvestigationDeliveryContext(input.originalInvestigationId);
+  const link = links.find(
+    (candidate) =>
+      candidate.channelId === input.channelId &&
+      candidate.threadTimestamp === input.threadTimestamp,
+  ) ?? links[0]!;
+  if (!link.encryptedCredentials) return;
+  const credentials = accessToken(link.encryptedCredentials);
+  const message = slackIssueFollowupMessage({
+    context,
+    response: input.response,
+    updatedIssueIds: input.updatedIssueIds,
+  });
+  const timestamp = await postSlackMessage({
+    accessToken: credentials,
+    blocks: message.blocks,
+    channelId: link.channelId,
+    clientMessageId: slackDeliveryClientMessageId(input.deliveryRunId, "issue-followup"),
+    text: message.text,
+    threadTimestamp: link.threadTimestamp,
+  });
+  if (timestamp) {
+    await recordInvestigationSlackReply(input.originalInvestigationId, {
+      attachments: [],
+      authorName: "Responder",
+      blocks: message.blocks,
+      key: `issue-followup:${input.deliveryRunId}`,
+      slackTimestamp: timestamp,
+      text: message.text,
+    });
+  }
 }

--- a/packages/core/src/jobs.ts
+++ b/packages/core/src/jobs.ts
@@ -57,6 +57,12 @@ export const investigationJobSchema = z.object({
   request: investigationRequestSchema,
   replay: z.boolean().default(false),
   runtimeProfileId: z.uuid(),
+  slackIssueFollowup: z.object({
+    originalInvestigationId: z.uuid(),
+    issueIds: z.array(z.uuid()).min(1),
+    channelId: z.string().min(1),
+    threadTimestamp: z.string().min(1),
+  }).optional(),
 });
 
 export type InvestigationJob = z.infer<typeof investigationJobSchema>;


### PR DESCRIPTION
## Summary
- continue Sentry and Datadog issue investigations when a teammate explicitly mentions Responder in the issue thread
- reuse the original investigation context while allowing only bound issue remediations to change
- post revised remediation carousels with Copy prompt and Open PR actions
- keep active pull-request requests pointed at the revised remediation
- install unzip in investigation sandboxes so Bun bootstrap succeeds

## Validation
- pnpm typecheck
- pnpm lint
- pnpm test (913 tests)
- pnpm build:app
- manual Slack follow-up investigation through the public tunnel

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lets teammates continue an existing Sentry or Datadog issue investigation by replying with @Responder in the issue thread. Follow-ups reuse the original investigation context, update only the remediations of the issues bound to that thread, and post a revised remediation carousel with Copy prompt and Open PR actions; the investigation sandbox also installs `unzip` so Bun bootstrap succeeds.

**New Features**
- Queued and in-progress pull-request requests stay pointed at the revised remediation.

**Migration**
- Adds the `slack_investigation_thread_links` table to bind issue cards to the investigation and its original Slack thread.

<sup>Written for commit c55885ec4a5dcb8486a818f5b7b1eaff8122bd12. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/responder-oss/pull/111?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

