### PR TITLE
Make Slack channel selection searchable

### DIFF
--- a/apps/control-plane/src/agent-context-defaults.test.ts
+++ b/apps/control-plane/src/agent-context-defaults.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { AgentOptions } from "./agents-api";
 import {
   defaultAgentContext,
+  filterSlackSearchChannels,
   resolveSlackSearchContext,
 } from "./agent-context-defaults";
 
@@ -157,5 +158,21 @@ describe("resolveSlackSearchContext", () => {
       searchableChannels: [],
       reconnectRequired: true,
     });
+  });
+});
+
+describe("filterSlackSearchChannels", () => {
+  const channels = OPTIONS.resources.filter(
+    (resource) => resource.kind === "slack_channel",
+  );
+
+  it("matches channel names case-insensitively with an optional hash prefix", () => {
+    expect(filterSlackSearchChannels(channels, " #PLAT ")).toEqual([
+      expect.objectContaining({ id: "slack-channel-2" }),
+    ]);
+  });
+
+  it("returns every channel for an empty query", () => {
+    expect(filterSlackSearchChannels(channels, "   ")).toEqual(channels);
   });
 });

--- a/apps/control-plane/src/agent-context-defaults.ts
+++ b/apps/control-plane/src/agent-context-defaults.ts
@@ -52,6 +52,21 @@ export function resolveSlackSearchContext(options: AgentOptions): SlackSearchCon
   };
 }
 
+export function filterSlackSearchChannels(
+  channels: AgentOptions["resources"],
+  query: string,
+): AgentOptions["resources"] {
+  const normalizedQuery = query.trim().toLocaleLowerCase().replace(/^#/, "");
+  if (!normalizedQuery) return channels;
+
+  return channels.filter((channel) =>
+    channel.displayName
+      .toLocaleLowerCase()
+      .replace(/^#/, "")
+      .includes(normalizedQuery),
+  );
+}
+
 export function defaultAgentContext(options: AgentOptions): DefaultAgentContext {
   const firstSlackChannel = resolveSlackSearchContext(options).searchableChannels[0];
   const firstVercelProject = options.resources.find(

--- a/apps/control-plane/src/pages/agent-create.tsx
+++ b/apps/control-plane/src/pages/agent-create.tsx
@@ -24,6 +24,7 @@ import {
 } from "../agents-api";
 import {
   defaultAgentContext,
+  filterSlackSearchChannels,
   resolveSlackSearchContext,
 } from "../agent-context-defaults";
 import { AppShell } from "../components/app-shell";
@@ -515,6 +516,7 @@ export function AgentCreatePage() {
     linearJustConnected ? returnedIntegrationAccountId ?? "" : "",
   );
   const [repositoryQuery, setRepositoryQuery] = useState("");
+  const [slackContextQuery, setSlackContextQuery] = useState("");
   const [integrationQuery, setIntegrationQuery] = useState("");
   const [connectionSettingsOpen, setConnectionSettingsOpen] = useState<
     AgentOptions["accounts"][number] | null
@@ -932,6 +934,10 @@ export function AgentCreatePage() {
   const slackAccounts = slackSearchContext.connectedAccounts;
   const searchableSlackAccounts = slackSearchContext.searchableAccounts;
   const searchableSlackChannels = slackSearchContext.searchableChannels;
+  const filteredSlackContextChannels = filterSlackSearchChannels(
+    searchableSlackChannels,
+    slackContextQuery,
+  );
   const slackSearchReconnectRequired = slackSearchContext.reconnectRequired;
   const sentryProjects = useMemo(
     () => resourcesOfKind(options, "sentry_project"),
@@ -2120,7 +2126,6 @@ export function AgentCreatePage() {
                           </span>
                           <IconButton
                             aria-label="Close Slack context configuration"
-                            autoFocus
                             onClick={() => setSlackContextDialogOpen(false)}
                             size="small"
                             variant="ghost"
@@ -2129,80 +2134,161 @@ export function AgentCreatePage() {
                           </IconButton>
                         </header>
                         <div className="configurationDialog__body">
-                          <div className="projectPicker slackContextPicker">
-                            <span>Channels</span>
-                            <div>
-                              {searchableSlackChannels.map((channel) => {
-                                  const account = slackAccounts.find(
-                                    (item) => item.id === channel.integrationAccountId,
-                                  );
-                                  return (
-                                    <Checkbox
-                                      checked={draft.contextResourceIds.includes(channel.id)}
-                                      description={
-                                        slackAccounts.length > 1
-                                          ? account?.displayName
-                                          : undefined
-                                      }
-                                      key={channel.id}
-                                      label={slackChannelLabel(channel.displayName)}
-                                      onChange={() =>
-                                        toggleSlackContextResource(channel.id)
-                                      }
-                                    />
-                                  );
-                                })}
-                              {slackSearchReconnectRequired ? (
-                                <div className="slackContextPicker__empty">
-                                  <span>
-                                    <strong>Reconnect Slack to search messages</strong>
-                                    <small>
-                                      Your existing connection needs permission to search
-                                      the channels you select.
-                                    </small>
-                                  </span>
-                                  <Button
-                                    disabled={connectingProvider === "slack"}
-                                    loading={connectingProvider === "slack"}
-                                    onClick={() => connect("slack")}
-                                    size="small"
-                                    type="button"
-                                    variant="primary"
+                          <div className="slackContextPicker">
+                            {!slackSearchReconnectRequired &&
+                            searchableSlackChannels.length > 0 ? (
+                              <>
+                                <div className="slackContextSearch">
+                                  <SearchIcon />
+                                  <label
+                                    className="srOnly"
+                                    htmlFor="slack-context-channel-search"
                                   >
-                                    {connectingProvider === "slack"
-                                      ? "Reconnecting…"
-                                      : "Reconnect Slack"}
-                                  </Button>
-                                </div>
-                              ) : null}
-                              {!slackSearchReconnectRequired &&
-                              searchableSlackChannels.length === 0 ? (
-                                <div className="slackContextPicker__empty">
-                                  <span>
-                                    <strong>
-                                      {refreshingSlackChannels
-                                        ? "Refreshing Slack channels…"
-                                        : "No Slack channels are available"}
-                                    </strong>
-                                    <small>
-                                      {refreshingSlackChannels
-                                        ? "This should only take a moment."
-                                        : "Invite Responder to a channel, then refresh the list."}
-                                    </small>
-                                  </span>
-                                  {!refreshingSlackChannels ? (
-                                    <Button
-                                      onClick={() => void refreshSlackChannels()}
-                                      size="small"
+                                    Search Slack channels
+                                  </label>
+                                  <input
+                                    aria-describedby="slack-context-result-count"
+                                    autoComplete="off"
+                                    autoFocus
+                                    id="slack-context-channel-search"
+                                    onChange={(event) =>
+                                      setSlackContextQuery(event.target.value)
+                                    }
+                                    placeholder="Search channels…"
+                                    type="search"
+                                    value={slackContextQuery}
+                                  />
+                                  {slackContextQuery ? (
+                                    <button
+                                      aria-label="Clear Slack channel search"
+                                      onClick={() => setSlackContextQuery("")}
                                       type="button"
-                                      variant="secondary"
                                     >
-                                      Refresh
-                                    </Button>
+                                      ×
+                                    </button>
                                   ) : null}
                                 </div>
-                              ) : null}
-                            </div>
+                                <div className="slackContextPicker__meta">
+                                  <span>All channels</span>
+                                  <span
+                                    aria-live="polite"
+                                    id="slack-context-result-count"
+                                    role="status"
+                                  >
+                                    {refreshingSlackChannels
+                                      ? "Refreshing channels…"
+                                      : slackContextQuery.trim()
+                                        ? `${filteredSlackContextChannels.length} ${
+                                            filteredSlackContextChannels.length === 1
+                                              ? "result"
+                                              : "results"
+                                          }`
+                                        : `${searchableSlackChannels.length} ${
+                                            searchableSlackChannels.length === 1
+                                              ? "channel"
+                                              : "channels"
+                                          }`}
+                                  </span>
+                                </div>
+                                <fieldset className="slackContextChannelList">
+                                  <legend className="srOnly">Slack channels</legend>
+                                  {filteredSlackContextChannels.map((channel) => {
+                                    const account = slackAccounts.find(
+                                      (item) =>
+                                        item.id === channel.integrationAccountId,
+                                    );
+                                    return (
+                                      <Checkbox
+                                        checked={draft.contextResourceIds.includes(
+                                          channel.id,
+                                        )}
+                                        className="slackContextChannelRow"
+                                        description={
+                                          slackAccounts.length > 1
+                                            ? account?.displayName
+                                            : undefined
+                                        }
+                                        key={channel.id}
+                                        label={slackChannelLabel(channel.displayName)}
+                                        onChange={() =>
+                                          toggleSlackContextResource(channel.id)
+                                        }
+                                      />
+                                    );
+                                  })}
+                                  {filteredSlackContextChannels.length === 0 ? (
+                                    <div className="slackContextPicker__noResults">
+                                      <span>
+                                        <strong>
+                                          No channels match “{slackContextQuery.trim()}”
+                                        </strong>
+                                        <small>
+                                          Try another channel name or clear the search.
+                                        </small>
+                                      </span>
+                                      <Button
+                                        onClick={() => setSlackContextQuery("")}
+                                        size="small"
+                                        type="button"
+                                        variant="secondary"
+                                      >
+                                        Clear search
+                                      </Button>
+                                    </div>
+                                  ) : null}
+                                </fieldset>
+                              </>
+                            ) : null}
+                            {slackSearchReconnectRequired ? (
+                              <div className="slackContextPicker__empty">
+                                <span>
+                                  <strong>Reconnect Slack to search messages</strong>
+                                  <small>
+                                    Your existing connection needs permission to search
+                                    the channels you select.
+                                  </small>
+                                </span>
+                                <Button
+                                  disabled={connectingProvider === "slack"}
+                                  loading={connectingProvider === "slack"}
+                                  onClick={() => connect("slack")}
+                                  size="small"
+                                  type="button"
+                                  variant="primary"
+                                >
+                                  {connectingProvider === "slack"
+                                    ? "Reconnecting…"
+                                    : "Reconnect Slack"}
+                                </Button>
+                              </div>
+                            ) : null}
+                            {!slackSearchReconnectRequired &&
+                            searchableSlackChannels.length === 0 ? (
+                              <div className="slackContextPicker__empty">
+                                <span>
+                                  <strong>
+                                    {refreshingSlackChannels
+                                      ? "Refreshing Slack channels…"
+                                      : "No Slack channels are available"}
+                                  </strong>
+                                  <small>
+                                    {refreshingSlackChannels
+                                      ? "This should only take a moment."
+                                      : "Invite Responder to a channel, then refresh the list."}
+                                  </small>
+                                </span>
+                                {!refreshingSlackChannels ? (
+                                  <Button
+                                    onClick={() => void refreshSlackChannels()}
+                                    size="small"
+                                    type="button"
+                                    variant="secondary"
+                                  >
+                                    Refresh
+                                  </Button>
+                                ) : null}
+                              </div>
+                            ) : null}
                           </div>
                           {slackRefreshError ? (
                             <Alert role="alert" title={slackRefreshError} tone="danger" />

--- a/apps/control-plane/src/styles.css
+++ b/apps/control-plane/src/styles.css
@@ -7765,37 +7765,171 @@ body:has(.appShell--create) {
   color: var(--ds-text-secondary);
 }
 
-.appShell--create .slackContextPicker__empty {
-  width: 100%;
-  min-height: 72px;
+.appShell--create .slackContextPicker {
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.appShell--create .slackContextSearch {
+  min-height: 44px;
+  padding-inline: 12px;
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  border: 1px solid var(--ds-border-strong);
+  border-radius: var(--ds-radius-small);
+  background: var(--ds-canvas);
+  color: var(--ds-text-muted);
+}
+
+.appShell--create .slackContextSearch:focus-within {
+  outline: 2px solid var(--ds-text-primary);
+  outline-offset: 2px;
+}
+
+.appShell--create .slackContextSearch > svg {
+  width: 16px;
+  height: 16px;
+  flex: 0 0 auto;
+}
+
+.appShell--create .slackContextSearch > input {
+  min-width: 0;
+  height: 42px;
+  flex: 1 1 auto;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: var(--ds-text-primary);
+  font: inherit;
+  font-size: 13px;
+}
+
+.appShell--create .slackContextSearch > input::placeholder {
+  color: var(--ds-text-muted);
+}
+
+.appShell--create .slackContextSearch > button {
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  display: grid;
+  place-items: center;
+  flex: 0 0 auto;
+  border: 0;
+  border-radius: var(--ds-radius-pill);
+  background: var(--ds-surface-hover);
+  color: var(--ds-text-secondary);
+  cursor: pointer;
+  font-size: 17px;
+}
+
+.appShell--create .slackContextSearch > button:focus-visible {
+  outline: 2px solid var(--ds-text-primary);
+  outline-offset: 2px;
+}
+
+.appShell--create .slackContextPicker__meta {
+  min-height: 20px;
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 16px;
+  color: var(--ds-text-muted);
+  font-size: 11px;
+  line-height: 15px;
 }
 
-.appShell--create .slackContextPicker__empty > span {
+.appShell--create .slackContextPicker__meta span:last-child {
+  font-variant-numeric: tabular-nums;
+}
+
+.appShell--create .slackContextChannelList {
+  min-height: 184px;
+  max-height: min(440px, calc(100vh - 310px));
+  margin: 0;
+  padding: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  border: 1px solid var(--ds-border-default);
+  border-radius: var(--ds-radius-small);
+  background: var(--ds-canvas);
+}
+
+.appShell--create .slackContextChannelRow {
+  min-height: 44px;
+  padding: 10px 12px;
+  align-items: center;
+  border-bottom: 1px solid var(--ds-border-default);
+}
+
+.appShell--create .slackContextChannelRow:last-of-type {
+  border-bottom: 0;
+}
+
+.appShell--create .slackContextChannelRow:has(.dsChoice__input:checked) {
+  background: var(--ds-surface-raised);
+}
+
+.appShell--create .slackContextChannelRow .dsChoice__mark {
+  margin-top: 0;
+}
+
+.appShell--create .slackContextChannelRow .dsChoice__copy strong {
+  color: var(--ds-text-secondary);
+  font-size: 13px;
+  line-height: 18px;
+  overflow-wrap: anywhere;
+}
+
+.appShell--create .slackContextPicker__empty,
+.appShell--create .slackContextPicker__noResults {
+  width: 100%;
+  min-height: 96px;
+  padding: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  border: 1px solid var(--ds-border-default);
+  border-radius: var(--ds-radius-small);
+  background: var(--ds-canvas);
+}
+
+.appShell--create .slackContextPicker__empty > span,
+.appShell--create .slackContextPicker__noResults > span {
   min-width: 0;
   display: flex;
   flex-direction: column;
   gap: 3px;
 }
 
-.appShell--create .slackContextPicker__empty strong {
+.appShell--create .slackContextPicker__empty strong,
+.appShell--create .slackContextPicker__noResults strong {
   color: var(--ds-text-primary);
   font-size: 13px;
   font-weight: 500;
   line-height: 18px;
 }
 
-.appShell--create .slackContextPicker__empty small {
+.appShell--create .slackContextPicker__empty small,
+.appShell--create .slackContextPicker__noResults small {
   color: var(--ds-text-muted);
   font-size: 12px;
   line-height: 17px;
 }
 
-.appShell--create .slackContextPicker__empty > .dsButton {
+.appShell--create .slackContextPicker__empty > .dsButton,
+.appShell--create .slackContextPicker__noResults > .dsButton {
   flex: 0 0 auto;
+}
+
+@media (hover: hover) {
+  .appShell--create .slackContextChannelRow:hover {
+    background: var(--ds-surface-hover);
+  }
 }
 
 .appShell--create .requiredOutput__label small,
@@ -9976,6 +10110,21 @@ a.issueLine:focus-visible {
 }
 
 @media (max-width: 620px) {
+  .appShell--create .slackContextSearch > input {
+    font-size: 16px;
+  }
+
+  .appShell--create .slackContextPicker__empty,
+  .appShell--create .slackContextPicker__noResults {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .appShell--create .slackContextPicker__empty > .dsButton,
+  .appShell--create .slackContextPicker__noResults > .dsButton {
+    width: 100%;
+  }
+
   .authThemeToggle {
     top: 18px;
     right: 18px;


### PR DESCRIPTION
## Summary
- replace the Slack channel cloud with a searchable full-width checkbox list
- preserve selected channels while filtering and show an accessible live result count
- add responsive empty and no-results states
- cover channel-name filtering, including case and optional # prefixes

## Validation
- pnpm typecheck
- pnpm lint
- pnpm test (914 tests)
- pnpm build

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the Slack channel picker searchable so users can find and select channels in long lists without scrolling.

- Adds a search box that filters channels by name, case-insensitively and ignoring a leading `#`.
- Preserves the selected channels while filtering and announces the live result count for screen readers.
- Adds responsive empty and no-results states with a clear-search action.

<sup>Written for commit f6d39bf83eeda3f4fcce578461b4143408e09bf4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/responder-oss/pull/112?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

