### PR TITLE
Streamline pull request creation

### DIFF
--- a/apps/worker/src/github-pull-request.test.ts
+++ b/apps/worker/src/github-pull-request.test.ts
@@ -1,42 +1,12 @@
 import type { DaytonaSandboxSession } from "@openai/agents-extensions/sandbox/daytona";
 import { describe, expect, it, vi } from "vitest";
-import {
-  buildPullRequestBody,
-  createPullRequestFromSandbox,
-} from "./github-pull-request.js";
+import { createPullRequestFromSandbox } from "./github-pull-request.js";
 
 function commandResult(exitCode: number, output = "") {
   return `Chunk ID: abc123\nWall time: 0.0100 seconds\nProcess exited with code ${exitCode}\nOutput:\n${output}`;
 }
 
 describe("GitHub pull requests from Daytona", () => {
-  it("builds a simple failure explanation with deterministic issue links", () => {
-    expect(
-      buildPullRequestBody({
-        failureMechanism:
-          "The page expected a value that was missing, so it stopped loading.",
-        responderIssueUrl: "https://responder.example/issues/issue-1",
-        sentryIssueUrl: "https://example.sentry.io/issues/42/",
-        summary: "## Summary\nHandle the missing value.",
-        testing: "## Testing\nUnit tests pass.",
-      }),
-    ).toBe(
-      "## Summary\nHandle the missing value.\n\n## Issue\nThe page expected a value that was missing, so it stopped loading.\n\n[Responder issue](<https://responder.example/issues/issue-1>) · [Sentry issue](<https://example.sentry.io/issues/42/>)\n\n## Testing\nUnit tests pass.",
-    );
-  });
-
-  it("omits issue links when they are unavailable", () => {
-    expect(
-      buildPullRequestBody({
-        failureMechanism: "A missing value made the page stop loading.",
-        summary: "Handle the missing value.",
-        testing: "Unit tests pass.",
-      }),
-    ).toContain(
-      "## Issue\nA missing value made the page stop loading.\n\n## Testing",
-    );
-  });
-
   it("publishes changed sandbox files without putting the GitHub token in Daytona", async () => {
     const execCommand = vi
       .fn()

--- a/apps/worker/src/github-pull-request.ts
+++ b/apps/worker/src/github-pull-request.ts
@@ -48,45 +48,6 @@ function branchSlug(title: string): string {
   return slug || "issue";
 }
 
-function pullRequestSection(heading: string, content: string): string {
-  const escapedHeading = heading.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const withoutLeadingHeading = content
-    .trim()
-    .replace(
-      new RegExp(
-        `^#{1,6}[ \\t]+${escapedHeading}(?:[ \\t]+[^\\n]*)?\\r?\\n+`,
-        "i",
-      ),
-      "",
-    )
-    .trim();
-  return `## ${heading}\n${withoutLeadingHeading}`;
-}
-
-export function buildPullRequestBody(input: {
-  failureMechanism: string;
-  responderIssueUrl?: string;
-  sentryIssueUrl?: string;
-  summary: string;
-  testing: string;
-}): string {
-  const issueLinks = [
-    input.responderIssueUrl
-      ? `[Responder issue](<${input.responderIssueUrl}>)`
-      : null,
-    input.sentryIssueUrl ? `[Sentry issue](<${input.sentryIssueUrl}>)` : null,
-  ].filter((link): link is string => Boolean(link));
-  return [
-    pullRequestSection("Summary", input.summary),
-    "",
-    "## Issue",
-    input.failureMechanism.trim(),
-    ...(issueLinks.length > 0 ? ["", issueLinks.join(" · ")] : []),
-    "",
-    pullRequestSection("Testing", input.testing),
-  ].join("\n");
-}
-
 function execResult(output: string): { exitCode: number; stdout: string } {
   const match = /(?:^|\n)Process exited with code (\d+)(?:\n|$)/u.exec(output);
   return {

--- a/apps/worker/src/investigate.test.ts
+++ b/apps/worker/src/investigate.test.ts
@@ -151,7 +151,7 @@ describe("sandbox agent configuration", () => {
     ]);
   });
 
-  it("keeps investigation instructions read-only in every PR mode", () => {
+  it("lets investigations prepare and validate code without publishing it", () => {
     const instructions = investigationInstructions({
       agentPrompt: "Inspect the reported failure.",
       clickStackConnected: false,
@@ -168,9 +168,10 @@ describe("sandbox agent configuration", () => {
       sentryConnected: true,
     });
 
-    expect(instructions).toContain("read-only repository inspection tools");
-    expect(instructions).toContain("only for investigation and reporting");
-    expect(instructions).toContain("remediation, when enabled, runs separately");
+    expect(instructions).toContain("sandbox filesystem and shell tools");
+    expect(instructions).toContain("modify repository files");
+    expect(instructions).toContain("checks you judge useful");
+    expect(instructions).toContain("do not push branches");
     expect(instructions).not.toContain("call create_pull_request");
     expect(instructions).toContain("posts the report to Slack");
     expect(instructions).toContain(
@@ -179,6 +180,8 @@ describe("sandbox agent configuration", () => {
     expect(instructions).toContain(
       "Keep each remediation description to at most one sentence.",
     );
+    expect(instructions).toContain("ready-for-review pull request title");
+    expect(instructions).toContain("published later without another model pass");
   });
 
   it("keeps Slack thread turns sandbox-only without issue or PR workflows", () => {

--- a/apps/worker/src/investigate.ts
+++ b/apps/worker/src/investigate.ts
@@ -394,21 +394,21 @@ export function investigationInstructions(input: {
       : null,
     input.threadMode
       ? "Use the sandbox tools and attached code to investigate the request."
-      : "Use the read-only repository inspection tools to list, search, and read attached repository files.",
+      : "Use the sandbox filesystem and shell tools to inspect and work in attached repository checkouts.",
     input.threadMode
       ? null
-      : "This run is only for investigation and reporting. Do not modify repository code or create pull requests. Pull request remediation, when enabled, runs separately after the report is saved.",
+      : "This run may prepare code remediation locally. You may modify repository files and run the checks you judge useful, but do not push branches, create pull requests, or make any other external code change. A later job publishes the exact saved diff.",
     "Do not expose credentials or secret values.",
     workspaceSecretUsageInstructions(workspaceSecrets),
     input.threadMode
       ? "This is an ad-hoc Slack thread investigation. Never create or update issues, tickets, branches, commits, or pull requests. You may use the sandbox for notes, experiments, and local code changes, but nothing in it is published."
       : "For every distinct problem you find, call search_existing_issues before deciding whether it is a new issue or a recurrence. Use an existing issue ID when the evidence matches; this attaches the investigation to that issue instead of creating a duplicate.",
     input.issueFollowup
-      ? "This is a follow-up to an existing Slack issue investigation. Use the supplied prior investigation context and the latest Slack feedback to decide which bound issue remediations need to change. Do not create new issues, tickets, or pull requests. Call update_issue_remediation for each affected issue, and do not update unrelated issues. If the feedback is ambiguous, ask for clarification instead of guessing."
+      ? "This is a follow-up to an existing Slack issue investigation. Use the supplied prior investigation context and the latest Slack feedback to decide which bound issue remediations need to change. For an updated code remediation, make the change locally, run the checks you judge useful, and save the exact final diff plus your ready-for-review pull request title and body. Do not create new issues, tickets, or pull requests. Call update_issue_remediation for each affected issue, and do not update unrelated issues. If the feedback is ambiguous, ask for clarification instead of guessing."
       : null,
     input.threadMode || input.issueFollowup
       ? null
-      : "For every new issue, submit one or more concrete remediation options with the report. Keep each remediation description to at most one sentence. A code_change must contain a changes array with one complete unified diff per attached repository; use one element for a single-repository fix, and combine changes for the same repository. Use external_action for work outside the attached repositories, describe the action for a human, and include a self-contained prompt they can pass to an agent with access to that system. Do not claim that a proposed diff has been applied.",
+      : "For every new issue, submit one or more concrete remediation options with the report. Keep each remediation description to at most one sentence. For a code_change, first make the smallest safe change in the attached checkout, choose and run the checks appropriate for that change, and inspect the final git diff. Its changes array must contain one complete unified diff per attached repository; use one element for a single-repository fix, and combine changes for the same repository. Author the ready-for-review pull request title and complete Markdown body in each change's pullRequest field, including only the context and check results you decide belong there. The saved diff and pull request content are published later without another model pass or project checks. Use external_action for work outside the attached repositories, describe the action for a human, and include a self-contained prompt they can pass to an agent with access to that system.",
     input.threadMode
       ? null
       : "Do not include actions performed by Responder during the investigation in an issue timeline; include only events in the incident's causal sequence.",

--- a/apps/worker/src/issue-followup.ts
+++ b/apps/worker/src/issue-followup.ts
@@ -3,7 +3,7 @@ import {
   updateIssueRemediations,
 } from "@responder/core/db/issues";
 import {
-  issueRemediationSubmissionSchema,
+  authoredIssueRemediationsSchema,
 } from "@responder/core/investigations/report";
 import { z } from "zod";
 
@@ -18,7 +18,7 @@ export function createIssueRemediationUpdateTool(input: {
       "Replace the proposed remediation options for an existing issue after follow-up feedback. Only update an issue when the new evidence changes its remediation; do not create issues or pull requests.",
     parameters: z.object({
       issueId: z.uuid(),
-      remediations: z.array(issueRemediationSubmissionSchema).min(1).max(10),
+      remediations: authoredIssueRemediationsSchema,
     }),
     async execute(request) {
       if (!input.allowedIssueIds.has(request.issueId)) {

--- a/apps/worker/src/remediate.test.ts
+++ b/apps/worker/src/remediate.test.ts
@@ -1,125 +1,177 @@
-import { MaxTurnsExceededError } from "@openai/agents";
-import { describe, expect, it } from "vitest";
+import type { DaytonaSandboxSession } from "@openai/agents-extensions/sandbox/daytona";
+import type { RuntimeRepository } from "@responder/core/db/investigations";
+import type { IssueRemediationSubmission } from "@responder/core/investigations/report";
+import { describe, expect, it, vi } from "vitest";
 import {
-  remediationApplyPatchPathInstruction,
-  remediationFailureMechanismInstruction,
-  remediationMaxTurns,
-  remediationRunDiagnostics,
+  applyProposedDiff,
+  proposedPullRequestContent,
+  selectProposedChange,
 } from "./remediate.js";
 
-function maxTurnsError(
-  patchOutput = "Invalid Context 0:\nworkspace-secret-value",
-) {
-  return new MaxTurnsExceededError(
-    "Max turns (40) exceeded",
-    {
-      toJSON: () => ({
-        currentTurn: 41,
-        generatedItems: [
-          {
-            agent: { name: "Responder issue fixer" },
-            rawItem: {
-              callId: "patch-1",
-              operation: {
-                diff: "@@\n-old\n+new",
-                path: "/home/daytona/workspace/repositories/example/app/src/app.ts",
-                type: "update_file",
-              },
-              type: "apply_patch_call",
-            },
-            type: "tool_call_item",
-          },
-          {
-            agent: { name: "Responder issue fixer" },
-            output: patchOutput,
-            rawItem: {
-              callId: "patch-1",
-              output: patchOutput,
-              status: "failed",
-              type: "apply_patch_call_output",
-            },
-            type: "tool_call_output_item",
-          },
-        ],
-        maxTurns: 40,
-      }),
-    } as never,
-  );
+const repositories: RuntimeRepository[] = [
+  {
+    defaultBranch: "main",
+    fullName: "acme/api",
+    installationId: 42,
+    private: true,
+  },
+  {
+    defaultBranch: "main",
+    fullName: "acme/web",
+    installationId: 42,
+    private: true,
+  },
+];
+
+function remediation(
+  changes: Array<{
+    diff: string;
+    pullRequest?: { body: string; title: string };
+    repository: string | null;
+  }>,
+): IssueRemediationSubmission {
+  return {
+    type: "code_change",
+    title: "Handle the missing value",
+    description: "Return early when the required value is missing.",
+    changes,
+  };
 }
 
-function unreadableMaxTurnsError() {
-  return new MaxTurnsExceededError(
-    "Max turns (40) exceeded",
-    {
-      toJSON: () => {
-        throw new Error("state serialization failed");
-      },
-    } as never,
-  );
-}
-
-describe("remediation agent", () => {
-  it("allows forty model turns", () => {
-    expect(remediationMaxTurns).toBe(40);
-  });
-
-  it("requires absolute paths for native patches", () => {
-    expect(remediationApplyPatchPathInstruction).toContain(
-      "full absolute checkout path",
-    );
-    expect(remediationApplyPatchPathInstruction).toContain(
-      "Repository-relative paths",
-    );
-  });
-
-  it("requires an extremely simple failure mechanism", () => {
-    expect(remediationFailureMechanismInstruction).toContain(
-      "what failed and why",
-    );
-    expect(remediationFailureMechanismInstruction).toContain(
-      "anyone can understand at a glance",
-    );
-    expect(remediationFailureMechanismInstruction).toContain("no jargon");
-  });
-
-  it("retains a safe apply_patch failure category without raw output", () => {
+describe("proposed diff remediation", () => {
+  it("selects only the assigned repository diff", () => {
     expect(
-      remediationRunDiagnostics(maxTurnsError(), {
-        DAYTONA_API_KEY: "daytona-secret",
-      }),
-    ).toEqual({
-      applyPatchFailures: [
-        {
-          callId: "patch-1",
-          error: "Invalid Context 0",
-          operation: "update_file",
-          path: "/home/daytona/workspace/repositories/example/app/src/app.ts",
-        },
-      ],
-      completedTurns: 40,
-      maxTurns: 40,
+      selectProposedChange(
+        remediation([
+          { diff: "api diff", repository: "acme/api" },
+          { diff: "web diff", repository: "acme/web" },
+        ]),
+        "acme/web",
+        repositories,
+      ),
+    ).toEqual({ diff: "web diff", repository: repositories[1] });
+  });
+
+  it("selects the agent-authored pull request content with the diff", () => {
+    const proposed = remediation([{
+      diff: "api diff",
+      repository: "acme/api",
+      pullRequest: {
+        title: "Handle missing route values",
+        body: "Guard missing values before the route uses them.",
+      },
+    }]);
+
+    expect(selectProposedChange(proposed, "acme/api", repositories)).toEqual({
+      diff: "api diff",
+      pullRequest: {
+        title: "Handle missing route values",
+        body: "Guard missing values before the route uses them.",
+      },
+      repository: repositories[0],
     });
   });
 
-  it("does not retain unclassified apply_patch output", () => {
+  it("publishes the agent-authored title and body without adding testing text", () => {
+    const proposed = remediation([{
+      diff: "api diff",
+      repository: "acme/api",
+      pullRequest: {
+        title: "Handle missing route values",
+        body: "Explain the fix in the format chosen during investigation.",
+      },
+    }]);
+    if (proposed.type !== "code_change") throw new Error("Expected code change");
+    const selected = selectProposedChange(proposed, "acme/api", repositories);
+
+    expect(proposedPullRequestContent(proposed, selected)).toEqual({
+      title: "Handle missing route values",
+      body: "Explain the fix in the format chosen during investigation.",
+    });
+    expect(proposedPullRequestContent(proposed, selected).body).not.toContain(
+      "Testing",
+    );
+  });
+
+  it("uses the remediation title and description for older saved diffs", () => {
+    const proposed = remediation([{ diff: "api diff", repository: "acme/api" }]);
+    if (proposed.type !== "code_change") throw new Error("Expected code change");
+
     expect(
-      remediationRunDiagnostics(maxTurnsError("workspace-secret-value"))
-        ?.applyPatchFailures[0]?.error,
-    ).toBe("Unclassified apply_patch failure");
+      proposedPullRequestContent(
+        proposed,
+        selectProposedChange(proposed, "acme/api", repositories),
+      ),
+    ).toEqual({
+      title: "Handle the missing value",
+      body: "Return early when the required value is missing.",
+    });
   });
 
-  it("categorizes an empty apply_patch failure", () => {
+  it("supports a legacy repository-less diff for one attached repository", () => {
     expect(
-      remediationRunDiagnostics(maxTurnsError(""))?.applyPatchFailures[0]
-        ?.error,
-    ).toBe("apply_patch failed without an error message");
+      selectProposedChange(
+        remediation([{ diff: "legacy diff", repository: null }]),
+        undefined,
+        [repositories[0]!],
+      ),
+    ).toEqual({ diff: "legacy diff", repository: repositories[0] });
   });
 
-  it("ignores errors without resumable run state", () => {
-    expect(remediationRunDiagnostics(new Error("failed"))).toBeUndefined();
+  it("rejects an ambiguous repository-less diff", () => {
+    expect(() =>
+      selectProposedChange(
+        remediation([{ diff: "ambiguous diff", repository: null }]),
+        undefined,
+        repositories,
+      ),
+    ).toThrow("does not identify one attached repository");
   });
 
-  it("does not let unreadable diagnostics mask the remediation failure", () => {
-    expect(remediationRunDiagnostics(unreadableMaxTurnsError())).toBeUndefined();
+  it("applies the stored diff without running project checks", async () => {
+    const session = {
+      execCommand: vi.fn().mockResolvedValue(
+        "Process exited with code 0\nOutput:\n",
+      ),
+      materializeEntry: vi.fn().mockResolvedValue(undefined),
+    } as unknown as DaytonaSandboxSession;
+    const diff = [
+      "diff --git a/src/route.ts b/src/route.ts",
+      "--- a/src/route.ts",
+      "+++ b/src/route.ts",
+      "@@ -1 +1,2 @@",
+      "+if (!value) return;",
+      " use(value);",
+    ].join("\n");
+
+    await expect(
+      applyProposedDiff(session, "/workspace/acme/api", diff),
+    ).resolves.toBeUndefined();
+
+    expect(session.materializeEntry).toHaveBeenCalledWith({
+      entry: { type: "file", content: `${diff}\n` },
+      path: "/home/daytona/workspace/.responder/proposed.patch",
+    });
+    expect(session.execCommand).toHaveBeenCalledWith({
+      cmd: "git apply --whitespace=nowarn /home/daytona/workspace/.responder/proposed.patch",
+      maxOutputTokens: 2_000,
+      workdir: "/workspace/acme/api",
+    });
+    expect(JSON.stringify(vi.mocked(session.execCommand).mock.calls)).not.toMatch(
+      /(?:pnpm|npm|yarn|bun|test|lint|typecheck)/,
+    );
+  });
+
+  it("fails safely when the stored diff no longer applies", async () => {
+    const session = {
+      execCommand: vi.fn().mockResolvedValue(
+        "Process exited with code 1\nOutput:\npatch failed with sensitive context",
+      ),
+      materializeEntry: vi.fn().mockResolvedValue(undefined),
+    } as unknown as DaytonaSandboxSession;
+
+    await expect(
+      applyProposedDiff(session, "/workspace/acme/api", "invalid diff"),
+    ).rejects.toThrow("The proposed diff no longer applies cleanly");
   });
 });

--- a/apps/worker/src/remediate.ts
+++ b/apps/worker/src/remediate.ts
@@ -1,185 +1,146 @@
 import {
-  MaxTurnsExceededError,
-  run,
-  setDefaultOpenAIKey,
-  setTracingDisabled,
-} from "@openai/agents";
-import { Capabilities, SandboxAgent } from "@openai/agents/sandbox";
-import {
   DaytonaSandboxClient,
   type DaytonaSandboxSession,
 } from "@openai/agents-extensions/sandbox/daytona";
-import { getRuntimeProfile } from "@responder/core/db/runtime-profiles";
-import { getRuntimeWorkspaceSecrets } from "@responder/core/db/workspace-secrets";
-import { daytonaClientOptions } from "@responder/core/daytona-config";
-import type { RemediationJob } from "@responder/core/jobs";
-import { renderIssueFixPrompt } from "@responder/core/investigations/report";
+import { captureAnalyticsEvent } from "@responder/core/analytics";
 import {
-  safeInvestigationError,
-  sandboxAgentConfig,
-} from "./investigate.js";
-import { createPullRequestTool } from "./pull-request.js";
-import { checkoutRuntimeRepositories } from "./repositories.js";
+  getRuntimeRepositories,
+  type RuntimeRepository,
+} from "@responder/core/db/investigations";
+import {
+  getExecutableIssuePullRequest,
+  markIssuePullRequestCreated,
+  markIssuePullRequestStarted,
+} from "@responder/core/db/pull-requests";
+import {
+  daytonaClientOptions,
+  requireDaytonaClientConfig,
+} from "@responder/core/daytona-config";
+import type { RemediationJob } from "@responder/core/jobs";
+import type { IssueRemediationSubmission } from "@responder/core/investigations/report";
+import { refreshIssuePullRequestSlackMessages } from "@responder/core/integrations/slack-remediations";
+import {
+  createPullRequestFromSandbox,
+} from "./github-pull-request.js";
+import { checkoutRuntimeRepository } from "./repositories.js";
 import {
   closeDaytonaSandbox,
   configureDaytonaSandboxLifecycle,
   createDaytonaSandboxSession,
-  prepareDaytonaSandbox,
+  prepareDaytonaPatchSandbox,
 } from "./sandbox.js";
-import {
-  redactDaytonaSecretPlaceholders,
-  workspaceSecretUsageInstructions,
-} from "./secret-safety.js";
 
-export const remediationMaxTurns = 40;
-export const remediationApplyPatchPathInstruction =
-  "When using apply_patch, use the full absolute checkout path shown above. Repository-relative paths are resolved from the workspace root and may target the wrong location.";
-export const remediationFailureMechanismInstruction =
-  "For the pull request failure mechanism, explain what failed and why in one or two very short sentences. Use extremely simple language that anyone can understand at a glance. Use no jargon, acronyms, code names, or implementation details.";
+type CodeChangeRemediation = Extract<
+  IssueRemediationSubmission,
+  { type: "code_change" }
+>;
 
-export interface RemediationApplyPatchFailure {
-  callId: string;
-  error: string;
-  operation?: "create_file" | "delete_file" | "update_file";
-  path?: string;
+interface SelectedProposedChange {
+  diff: string;
+  pullRequest?: { body: string; title: string };
+  repository: RuntimeRepository;
 }
 
-export interface RemediationRunDiagnostics {
-  applyPatchFailures: RemediationApplyPatchFailure[];
-  completedTurns: number;
-  maxTurns: number | null;
-}
-
-const maxStoredApplyPatchFailures = 10;
-
-function safeApplyPatchFailure(
-  output: string | undefined,
-  environment: NodeJS.ProcessEnv,
-): string {
-  if (!output?.trim()) {
-    return "apply_patch failed without an error message";
-  }
-  const safeOutput = safeInvestigationError(new Error(output), environment);
-  const invalidEofContext = safeOutput.match(
-    /^Invalid EOF Context(?:\s+(\d+))?(?::|$)/,
-  );
-  if (invalidEofContext) {
-    return `Invalid EOF Context${invalidEofContext[1] ? ` ${invalidEofContext[1]}` : ""}`;
+export function selectProposedChange(
+  remediation: IssueRemediationSubmission | undefined,
+  targetRepository: string | undefined,
+  repositories: RuntimeRepository[],
+): SelectedProposedChange {
+  if (remediation?.type !== "code_change") {
+    throw new Error("The pull request does not have a proposed code diff");
   }
 
-  const invalidContext = safeOutput.match(
-    /^Invalid Context(?:\s+(\d+))?(?::|$)/,
-  );
-  if (invalidContext) {
-    return `Invalid Context${invalidContext[1] ? ` ${invalidContext[1]}` : ""}`;
-  }
-
-  if (/^Invalid Add File Line:/.test(safeOutput)) {
-    return "Invalid add-file patch line";
-  }
-  if (/^Invalid Line:/.test(safeOutput)) {
-    return "Invalid patch line";
-  }
-  if (/^Cannot create file because it already exists:/.test(safeOutput)) {
-    return "File already exists";
-  }
-  if (/^Nothing in this section/.test(safeOutput)) {
-    return "Patch section did not match";
-  }
-  if (/^applyDiff: chunk\.origIndex/.test(safeOutput)) {
-    return "Invalid patch chunk position";
-  }
-  if (/overlapping (?:patch )?chunks/i.test(safeOutput)) {
-    return "Overlapping patch chunks";
-  }
-  if (/not a regular file/i.test(safeOutput)) {
-    return "Patch target is not a regular file";
-  }
-  if (/workspace escape/i.test(safeOutput)) {
-    return "Patch target is outside the workspace";
-  }
-  if (/directory target/i.test(safeOutput)) {
-    return "Patch target is a directory";
-  }
-  if (/remote editor operation failed/i.test(safeOutput)) {
-    return "Remote editor operation failed";
-  }
-  return "Unclassified apply_patch failure";
-}
-
-export function remediationRunDiagnostics(
-  error: unknown,
-  environment: NodeJS.ProcessEnv = process.env,
-): RemediationRunDiagnostics | undefined {
-  if (!(error instanceof MaxTurnsExceededError) || !error.state) {
-    return undefined;
-  }
-
-  try {
-    const state = error.state.toJSON();
-    const operations = new Map<
-      string,
-      {
-        operation: "create_file" | "delete_file" | "update_file";
-        path: string;
-      }
-    >();
-
-    for (const item of state.generatedItems) {
-      if (
-        item.type !== "tool_call_item" ||
-        item.rawItem.type !== "apply_patch_call"
-      ) {
-        continue;
-      }
-      operations.set(item.rawItem.callId, {
-        operation: item.rawItem.operation.type,
-        path: item.rawItem.operation.path,
-      });
+  let change: CodeChangeRemediation["changes"][number] | undefined;
+  if (targetRepository) {
+    change = remediation.changes.find(
+      (candidate) => candidate.repository === targetRepository,
+    );
+    if (!change && remediation.changes.length === 1) {
+      const onlyChange = remediation.changes[0];
+      if (onlyChange?.repository === null) change = onlyChange;
     }
+  } else if (remediation.changes.length === 1) {
+    change = remediation.changes[0];
+  }
+  if (!change) {
+    throw new Error("The pull request does not have one target repository diff");
+  }
 
-    const applyPatchFailures = state.generatedItems
-      .flatMap((item): RemediationApplyPatchFailure[] => {
-        if (
-          item.type !== "tool_call_output_item" ||
-          item.rawItem.type !== "apply_patch_call_output" ||
-          item.rawItem.status !== "failed"
-        ) {
-          return [];
-        }
-        const operation = operations.get(item.rawItem.callId);
-        const output =
-          item.rawItem.output ||
-          (typeof item.output === "string" ? item.output : undefined);
-        return [
-          {
-            callId: item.rawItem.callId,
-            error: safeApplyPatchFailure(output, environment),
-            ...(operation ?? {}),
-          },
-        ];
-      })
-      .slice(-maxStoredApplyPatchFailures);
+  const repositoryName = targetRepository ?? change.repository;
+  const repository = repositoryName
+    ? repositories.find((candidate) => candidate.fullName === repositoryName)
+    : repositories.length === 1
+      ? repositories[0]
+      : undefined;
+  if (!repository) {
+    throw new Error("The proposed diff does not identify one attached repository");
+  }
+  if (change.repository && change.repository !== repository.fullName) {
+    throw new Error("The proposed diff does not match the target repository");
+  }
+  return {
+    diff: change.diff,
+    ...(change.pullRequest ? { pullRequest: change.pullRequest } : {}),
+    repository,
+  };
+}
 
-    return {
-      applyPatchFailures,
-      completedTurns: Math.max(0, state.currentTurn - 1),
-      maxTurns: state.maxTurns,
-    };
-  } catch {
-    return undefined;
+export function proposedPullRequestContent(
+  remediation: CodeChangeRemediation,
+  selected: SelectedProposedChange,
+): { body: string; title: string } {
+  return selected.pullRequest ?? {
+    body: remediation.description,
+    title: remediation.title,
+  };
+}
+
+function commandSucceeded(output: string): boolean {
+  return /(?:^|\n)Process exited with code 0(?:\n|$)/u.test(output);
+}
+
+export async function applyProposedDiff(
+  session: DaytonaSandboxSession,
+  repositoryPath: string,
+  diff: string,
+): Promise<void> {
+  const patchPath = "/home/daytona/workspace/.responder/proposed.patch";
+  await session.materializeEntry({
+    entry: { type: "file", content: `${diff.trim()}\n` },
+    path: patchPath,
+  });
+  const output = await session.execCommand({
+    cmd: `git apply --whitespace=nowarn ${patchPath}`,
+    maxOutputTokens: 2_000,
+    workdir: repositoryPath,
+  });
+  if (!commandSucceeded(output)) {
+    throw new Error("The proposed diff no longer applies cleanly");
   }
 }
 
-export async function runRemediationAgent(
+export async function runProposedRemediation(
   job: RemediationJob,
   environment: NodeJS.ProcessEnv = process.env,
 ): Promise<string> {
-  const config = sandboxAgentConfig(environment);
-  setDefaultOpenAIKey(config.openAiApiKey);
-  setTracingDisabled(true);
-  const runtimeProfile = await getRuntimeProfile(job.runtimeProfileId);
-  const workspaceSecrets = await getRuntimeWorkspaceSecrets(job.config.id);
+  const request = await getExecutableIssuePullRequest({
+    agentConfigVersionId: job.config.id,
+    investigationId: job.investigationId,
+    issueId: job.issue.id,
+    organizationId: job.config.organizationId,
+    requestId: job.remediationRequestId,
+  });
+  const repositories = await getRuntimeRepositories(job.config.id);
+  const selected = selectProposedChange(
+    request.selectedRemediation ?? job.selectedRemediation,
+    job.targetRepository,
+    repositories,
+  );
+
+  await markIssuePullRequestStarted(request.requestId);
+  await refreshIssuePullRequestSlackMessages(request.requestId);
+
+  const config = requireDaytonaClientConfig(environment);
   const sandboxName = `responder-remediation-${job.remediationRequestId}`;
   const client = new DaytonaSandboxClient({
     ...daytonaClientOptions(config),
@@ -190,71 +151,57 @@ export async function runRemediationAgent(
 
   try {
     session = await createDaytonaSandboxSession(client, config, sandboxName);
-    await configureDaytonaSandboxLifecycle(session, config, workspaceSecrets);
-    await prepareDaytonaSandbox(session);
-    const repositories = await checkoutRuntimeRepositories(
+    await configureDaytonaSandboxLifecycle(session, config);
+    await prepareDaytonaPatchSandbox(session);
+    const checkout = await checkoutRuntimeRepository(
       session,
       job.config.id,
+      selected.repository.fullName,
     );
-    if (repositories.length === 0) {
-      throw new Error("No repositories are attached to this Agent version");
+    await applyProposedDiff(session, checkout.path, selected.diff);
+
+    const remediation = request.selectedRemediation ?? job.selectedRemediation;
+    if (remediation?.type !== "code_change") {
+      throw new Error("The pull request does not have a proposed code diff");
     }
-    const pullRequestTool = createPullRequestTool({
-      agentConfigVersionId: job.config.id,
-      investigationId: job.investigationId,
-      organizationId: job.config.organizationId,
-      pullRequestRequestId: job.remediationRequestId,
-      repositories,
-      session,
-      targetRepository: job.targetRepository,
-    });
-    const agent = new SandboxAgent({
-      name: "Responder issue fixer",
-      model: config.model,
-      instructions: [
-        runtimeProfile?.systemPrompt,
-        job.config.prompt,
-        renderIssueFixPrompt(
-          job.issue,
-          job.selectedRemediation,
-          job.targetRepository,
-        ),
-        "The selected repositories are already checked out:",
-        ...repositories.map(
-          (repository) =>
-            `- ${repository.repository}: ${repository.path} (${repository.branch} at ${repository.sha})`,
-        ),
-        remediationApplyPatchPathInstruction,
-        job.selectedRemediation?.type === "code_change"
-          ? `Use the proposed diff as the starting point. Verify it against the current checkout, adjust it when needed, make the smallest safe fix in ${job.targetRepository ? `the target repository ${job.targetRepository}` : "one selected repository"}, and run the narrowest useful checks.`
-          : `Inspect the relevant code, make the smallest safe fix in ${job.targetRepository ? `the target repository ${job.targetRepository}` : "one selected repository"}, and run the narrowest useful checks.`,
-        remediationFailureMechanismInstruction,
-        `Call create_pull_request for ${job.targetRepository ? `the target repository ${job.targetRepository}` : "exactly one of the selected repository names shown above"}.`,
-        `Then call create_pull_request with issue ID ${job.issue.id}. Do not finish without creating the pull request or clearly explaining why no safe code fix is possible.`,
-        "Do not expose credentials or secret values. The pull request is the only allowed external change.",
-        workspaceSecretUsageInstructions(workspaceSecrets),
-      ]
-        .filter((instruction): instruction is string => Boolean(instruction))
-        .join("\n\n"),
-      capabilities: Capabilities.default(),
-      tools: [pullRequestTool],
-    });
-    const result = await run(
-      agent,
-      renderIssueFixPrompt(
-        job.issue,
-        job.selectedRemediation,
-        job.targetRepository,
-      ),
+    const pullRequest = proposedPullRequestContent(remediation, selected);
+    const result = await createPullRequestFromSandbox(
       {
-        maxTurns: remediationMaxTurns,
-        sandbox: { session },
+        baseBranch: checkout.branch,
+        baseSha: checkout.sha,
+        body: pullRequest.body,
+        installationId: selected.repository.installationId,
+        repository: selected.repository.fullName,
+        repositoryPath: checkout.path,
+        requestId: request.requestId,
+        title: pullRequest.title,
+        workspaceBaseSha: checkout.workspaceBaseSha,
       },
+      session,
     );
-    if (typeof result.finalOutput !== "string" || !result.finalOutput.trim()) {
-      throw new Error("OpenAI agent returned an empty remediation result");
-    }
-    return redactDaytonaSecretPlaceholders(result.finalOutput.trim());
+    await markIssuePullRequestCreated({
+      requestId: request.requestId,
+      repositoryFullName: selected.repository.fullName,
+      branch: result.branch,
+      pullRequestNumber: result.number,
+      pullRequestUrl: result.url,
+    });
+    await refreshIssuePullRequestSlackMessages(request.requestId);
+    await captureAnalyticsEvent({
+      distinctId: `investigation:${job.investigationId}`,
+      event: "pr opened",
+      organizationId: job.config.organizationId,
+      properties: {
+        $process_person_profile: false,
+        agent_config_version_id: job.config.id,
+        investigation_id: job.investigationId,
+        issue_id: job.issue.id,
+        pr_number: result.number,
+        pr_url: result.url,
+        repository: selected.repository.fullName,
+      },
+    });
+    return result.url;
   } finally {
     if (session) {
       await closeDaytonaSandbox(session, config, {

--- a/apps/worker/src/remediation-job.test.ts
+++ b/apps/worker/src/remediation-job.test.ts
@@ -37,19 +37,7 @@ describe("remediation job terminal state", () => {
   });
 
   it("records the terminal failure even when monitoring is unavailable", async () => {
-    const agentError = new Error("agent failed");
-    const diagnostics = {
-      applyPatchFailures: [
-        {
-          callId: "call-1",
-          error: "Invalid Context 12",
-          operation: "update_file" as const,
-          path: "/workspace/repository/src/index.ts",
-        },
-      ],
-      completedTurns: 40,
-      maxTurns: 40,
-    };
+    const remediationError = new Error("diff failed");
     const failRequest = vi.fn().mockResolvedValue(undefined);
     const reportException = vi.fn(() => {
       throw new Error("monitoring unavailable");
@@ -62,27 +50,24 @@ describe("remediation job terminal state", () => {
       processRemediationJob("job-id", payload, {}, {
         failRequest,
         reportException,
-        runDiagnostics: vi.fn(() => diagnostics),
-        runAgent: vi.fn().mockRejectedValue(agentError),
+        runRemediation: vi.fn().mockRejectedValue(remediationError),
       }),
     ).resolves.toEqual({ requestId: payload.remediationRequestId });
 
     expect(failRequest).toHaveBeenCalledWith(
       payload.remediationRequestId,
-      "agent failed",
+      "diff failed",
     );
     expect(reportException).toHaveBeenCalledWith(
-      agentError,
+      remediationError,
       expect.objectContaining({
-        diagnostics,
         jobId: "job-id",
         requestId: payload.remediationRequestId,
       }),
     );
     expect(consoleError).toHaveBeenCalledWith(
       JSON.stringify({
-        diagnostics,
-        error: "agent failed",
+        error: "diff failed",
         event: "remediation_job_failed",
         jobId: "job-id",
         requestId: payload.remediationRequestId,
@@ -109,8 +94,7 @@ describe("remediation job terminal state", () => {
       processRemediationJob("job-id", payload, {}, {
         failRequest: vi.fn().mockRejectedValue(databaseError),
         reportException,
-        runDiagnostics: vi.fn(() => undefined),
-        runAgent: vi.fn().mockRejectedValue(new Error("agent failed")),
+        runRemediation: vi.fn().mockRejectedValue(new Error("diff failed")),
       }),
     ).rejects.toThrow("Unable to record remediation failure");
 
@@ -125,49 +109,27 @@ describe("remediation job terminal state", () => {
     );
   });
 
-  it("records a no-pull-request result without reporting an exception", async () => {
-    const failRequest = vi.fn().mockResolvedValue(undefined);
+  it("completes without a failure write after publishing the pull request", async () => {
+    const failRequest = vi.fn();
     const reportException = vi.fn();
-    vi.spyOn(console, "log").mockImplementation(() => {});
+    const consoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
 
     await expect(
       processRemediationJob("job-id", payload, {}, {
         failRequest,
         reportException,
-        runDiagnostics: vi.fn(() => undefined),
-        runAgent: vi.fn().mockResolvedValue("No safe change was available"),
+        runRemediation: vi.fn().mockResolvedValue("https://example.com/pull/1"),
       }),
     ).resolves.toEqual({ requestId: payload.remediationRequestId });
 
-    expect(failRequest).toHaveBeenCalledWith(
-      payload.remediationRequestId,
-      "Remediation finished without creating a pull request",
-    );
+    expect(failRequest).not.toHaveBeenCalled();
     expect(reportException).not.toHaveBeenCalled();
-  });
-
-  it("does not let unreadable diagnostics mask a remediation failure", async () => {
-    const agentError = new Error("agent failed");
-    const failRequest = vi.fn().mockResolvedValue(undefined);
-    const reportException = vi.fn().mockResolvedValue(undefined);
-    vi.spyOn(console, "error").mockImplementation(() => {});
-
-    await expect(
-      processRemediationJob("job-id", payload, {}, {
-        failRequest,
-        reportException,
-        runDiagnostics: vi.fn(() => {
-          throw new Error("unreadable diagnostics");
-        }),
-        runAgent: vi.fn().mockRejectedValue(agentError),
+    expect(consoleLog).toHaveBeenCalledWith(
+      JSON.stringify({
+        event: "remediation_job_complete",
+        jobId: "job-id",
+        requestId: payload.remediationRequestId,
       }),
-    ).resolves.toEqual({ requestId: payload.remediationRequestId });
-
-    expect(failRequest).toHaveBeenCalledWith(
-      payload.remediationRequestId,
-      "agent failed",
     );
-    expect(reportException).toHaveBeenCalledOnce();
-    expect(reportException.mock.calls[0]?.[1]).not.toHaveProperty("diagnostics");
   });
 });

--- a/apps/worker/src/remediation-job.ts
+++ b/apps/worker/src/remediation-job.ts
@@ -1,10 +1,7 @@
 import { failIssuePullRequest } from "@responder/core/db/pull-requests";
 import type { RemediationJob } from "@responder/core/jobs";
 import { refreshIssuePullRequestSlackMessages } from "@responder/core/integrations/slack-remediations";
-import {
-  remediationRunDiagnostics,
-  runRemediationAgent,
-} from "./remediate.js";
+import { runProposedRemediation } from "./remediate.js";
 import { safeInvestigationError } from "./investigate.js";
 import { reportWorkerException } from "./monitoring.js";
 
@@ -12,16 +9,14 @@ interface RemediationJobDependencies {
   failRequest: typeof failIssuePullRequest;
   reportException: typeof reportWorkerException;
   refreshSlack?: typeof refreshIssuePullRequestSlackMessages;
-  runDiagnostics: typeof remediationRunDiagnostics;
-  runAgent: typeof runRemediationAgent;
+  runRemediation: typeof runProposedRemediation;
 }
 
 const defaultDependencies: RemediationJobDependencies = {
   failRequest: failIssuePullRequest,
   reportException: reportWorkerException,
   refreshSlack: refreshIssuePullRequestSlackMessages,
-  runDiagnostics: remediationRunDiagnostics,
-  runAgent: runRemediationAgent,
+  runRemediation: runProposedRemediation,
 };
 
 export async function processRemediationJob(
@@ -30,104 +25,76 @@ export async function processRemediationJob(
   environment: NodeJS.ProcessEnv = process.env,
   dependencies: RemediationJobDependencies = defaultDependencies,
 ): Promise<{ requestId: string }> {
-  let failure: unknown;
-  let reportFailure = false;
-
   try {
-    await dependencies.runAgent(payload, environment);
-    failure = new Error(
-      "Remediation finished without creating a pull request",
-    );
+    await dependencies.runRemediation(payload, environment);
   } catch (error) {
-    failure = error;
-    reportFailure = true;
-  }
-
-  const message = safeInvestigationError(failure, environment);
-  let diagnostics: ReturnType<typeof remediationRunDiagnostics> = undefined;
-  if (reportFailure) {
-    try {
-      diagnostics = dependencies.runDiagnostics(failure, environment);
-    } catch {
-      diagnostics = undefined;
-    }
-  }
-  if (reportFailure) {
+    const message = safeInvestigationError(error, environment);
     console.error(
       JSON.stringify({
-        ...(diagnostics ? { diagnostics } : {}),
         error: message,
         event: "remediation_job_failed",
         jobId,
         requestId: payload.remediationRequestId,
       }),
     );
+    const [recordingResult, reportingResult] = await Promise.allSettled([
+      Promise.resolve().then(() =>
+        dependencies.failRequest(payload.remediationRequestId, message)
+      ),
+      Promise.resolve().then(() =>
+        dependencies.reportException(error, {
+          investigationId: payload.investigationId,
+          jobId,
+          operation: "remediation",
+          organizationId: payload.config.organizationId,
+          requestId: payload.remediationRequestId,
+        })
+      ),
+    ]);
+
+    if (reportingResult.status === "rejected") {
+      console.error(
+        JSON.stringify({
+          error: safeInvestigationError(reportingResult.reason, environment),
+          event: "remediation_error_reporting_failed",
+          jobId,
+          requestId: payload.remediationRequestId,
+        }),
+      );
+    }
+
+    if (recordingResult.status === "rejected") {
+      console.error(
+        JSON.stringify({
+          error: safeInvestigationError(recordingResult.reason, environment),
+          event: "remediation_failure_recording_failed",
+          jobId,
+          requestId: payload.remediationRequestId,
+        }),
+      );
+      throw new AggregateError(
+        [
+          error,
+          recordingResult.reason,
+          ...(reportingResult.status === "rejected"
+            ? [reportingResult.reason]
+            : []),
+        ],
+        "Unable to record remediation failure",
+      );
+    }
+
+    await dependencies.refreshSlack?.(payload.remediationRequestId);
+    return { requestId: payload.remediationRequestId };
   }
 
-  const recording = Promise.resolve().then(() =>
-    dependencies.failRequest(payload.remediationRequestId, message)
+  console.log(
+    JSON.stringify({
+      event: "remediation_job_complete",
+      jobId,
+      requestId: payload.remediationRequestId,
+    }),
   );
-  const reporting =
-    reportFailure
-      ? Promise.resolve().then(() =>
-          dependencies.reportException(failure, {
-            ...(diagnostics ? { diagnostics: { ...diagnostics } } : {}),
-            investigationId: payload.investigationId,
-            jobId,
-            operation: "remediation",
-            organizationId: payload.config.organizationId,
-            requestId: payload.remediationRequestId,
-          })
-        )
-      : Promise.resolve();
-  const [recordingResult, reportingResult] = await Promise.allSettled([
-    recording,
-    reporting,
-  ]);
-
-  if (reportingResult.status === "rejected") {
-    console.error(
-      JSON.stringify({
-        error: safeInvestigationError(reportingResult.reason, environment),
-        event: "remediation_error_reporting_failed",
-        jobId,
-        requestId: payload.remediationRequestId,
-      }),
-    );
-  }
-
-  if (recordingResult.status === "rejected") {
-    console.error(
-      JSON.stringify({
-        error: safeInvestigationError(recordingResult.reason, environment),
-        event: "remediation_failure_recording_failed",
-        jobId,
-        requestId: payload.remediationRequestId,
-      }),
-    );
-    throw new AggregateError(
-      [
-        failure,
-        recordingResult.reason,
-        ...(reportingResult.status === "rejected"
-          ? [reportingResult.reason]
-          : []),
-      ],
-      "Unable to record remediation failure",
-    );
-  }
-
-  await dependencies.refreshSlack?.(payload.remediationRequestId);
-
-  if (!reportFailure) {
-    console.log(
-      JSON.stringify({
-        event: "remediation_job_complete",
-        jobId,
-        requestId: payload.remediationRequestId,
-      }),
-    );
-  }
 
   return { requestId: payload.remediationRequestId };
 }

--- a/apps/worker/src/repositories.test.ts
+++ b/apps/worker/src/repositories.test.ts
@@ -6,6 +6,7 @@ import { join } from "node:path";
 import { promisify } from "node:util";
 import { describe, expect, it, vi } from "vitest";
 import {
+  checkoutRuntimeRepository,
   checkoutRuntimeRepositories,
   checkoutRuntimeRepositoriesAtRefs,
   refreshRuntimeRepositories,
@@ -133,6 +134,49 @@ describe("Daytona repository checkout", () => {
         }),
       }),
     );
+  });
+
+  it("checks out only the repository assigned to a pull request", async () => {
+    const session = fakeSession();
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ sha }), { status: 200 }),
+      )
+      .mockResolvedValueOnce(missingGitmodules())
+      .mockResolvedValueOnce(
+        new Response(new Uint8Array([31, 139, 8, 0]), { status: 200 }),
+      );
+
+    await expect(
+      checkoutRuntimeRepository(
+        session,
+        "version-id",
+        "example-org/api",
+        {
+          createInstallationToken: vi.fn().mockResolvedValue("github-secret"),
+          fetch: fetchMock,
+          getRepositories: vi.fn().mockResolvedValue([
+            {
+              defaultBranch: "main",
+              fullName: "example-org/web",
+              installationId: 123,
+              private: true,
+            },
+            {
+              defaultBranch: "main",
+              fullName: "example-org/api",
+              installationId: 123,
+              private: true,
+            },
+          ]),
+          uploadArchive: uploadArchive(),
+        },
+      ),
+    ).resolves.toEqual(expect.objectContaining({ repository: "example-org/api" }));
+
+    expect(JSON.stringify(fetchMock.mock.calls)).toContain("example-org/api");
+    expect(JSON.stringify(fetchMock.mock.calls)).not.toContain("example-org/web");
   });
 
   it("uses an exact Git checkout when the parent commit declares submodules", async () => {

--- a/apps/worker/src/repositories.ts
+++ b/apps/worker/src/repositories.ts
@@ -621,6 +621,36 @@ export async function checkoutRuntimeRepositories(
   );
 }
 
+export async function checkoutRuntimeRepository(
+  session: DaytonaSandboxSession,
+  versionId: string,
+  repositoryFullName: string,
+  dependencies: RepositoryCheckoutDependencies = defaultDependencies,
+): Promise<CheckedOutRepository> {
+  const repositories = await dependencies.getRepositories(versionId);
+  const repository = repositories.find(
+    (candidate) => candidate.fullName === repositoryFullName,
+  );
+  if (!repository) {
+    throw new Error(
+      `Repository ${repositoryFullName} is not attached to this Agent version`,
+    );
+  }
+  const checkedOut = await checkoutRuntimeRepositoriesWithRefs(
+    session,
+    versionId,
+    new Map(),
+    {
+      ...dependencies,
+      getRepositories: async () => [repository],
+    },
+  );
+  if (!checkedOut[0]) {
+    throw new Error(`Unable to check out ${repositoryFullName}`);
+  }
+  return checkedOut[0];
+}
+
 export async function refreshRuntimeRepositories(
   session: DaytonaSandboxSession,
   versionId: string,

--- a/apps/worker/src/sandbox.test.ts
+++ b/apps/worker/src/sandbox.test.ts
@@ -5,6 +5,7 @@ import {
   configureDaytonaSandboxLifecycle,
   createDaytonaSandboxSession,
   type DaytonaCleanupDependencies,
+  prepareDaytonaPatchSandbox,
   prepareDaytonaSandbox,
 } from "./sandbox.js";
 
@@ -53,6 +54,20 @@ function cleanupHarness(options?: {
 }
 
 describe("Daytona sandbox preparation", () => {
+  it("prepares only git and tar for direct diff publication", async () => {
+    const session = {
+      execCommand: vi.fn().mockResolvedValue(
+        "Chunk ID: abc123\nProcess exited with code 0\nOutput:\n",
+      ),
+    } as unknown as DaytonaSandboxSession;
+
+    await expect(prepareDaytonaPatchSandbox(session)).resolves.toBeUndefined();
+    const command = vi.mocked(session.execCommand).mock.calls[0]?.[0].cmd;
+    expect(command).toContain("command -v git");
+    expect(command).toContain("command -v tar");
+    expect(command).not.toMatch(/(?:node|python|bun|ripgrep|unzip)/i);
+  });
+
   it("ensures investigation tools are installed before the agent starts", async () => {
     const session = {
       execCommand: vi.fn().mockResolvedValue(

--- a/apps/worker/src/sandbox.ts
+++ b/apps/worker/src/sandbox.ts
@@ -310,3 +310,36 @@ export async function prepareDaytonaSandbox(
     );
   }
 }
+
+/** Prepare only the tools needed to apply and publish a proposed diff. */
+export async function prepareDaytonaPatchSandbox(
+  session: DaytonaSandboxSession,
+): Promise<void> {
+  const output = await session.execCommand({
+    cmd: [
+      "set -eu",
+      "if command -v git >/dev/null 2>&1 && command -v tar >/dev/null 2>&1; then exit 0; fi",
+      "if ! command -v apt-get >/dev/null 2>&1; then echo 'git or tar is unavailable and apt-get is missing' >&2; exit 1; fi",
+      "if [ \"$(id -u)\" -eq 0 ]; then",
+      "  apt-get update -qq",
+      "  DEBIAN_FRONTEND=noninteractive apt-get install -y -qq git tar",
+      "elif command -v sudo >/dev/null 2>&1; then",
+      "  sudo apt-get update -qq",
+      "  sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq git tar",
+      "else",
+      "  echo 'git and tar installation require root access' >&2",
+      "  exit 1",
+      "fi",
+      "command -v git >/dev/null",
+      "command -v tar >/dev/null",
+    ].join("\n"),
+    maxOutputTokens: 2_000,
+    workdir: "/home/daytona/workspace",
+  });
+  if (!execSucceeded(output)) {
+    const detail = output.split("\nOutput:\n", 2)[1]?.trim();
+    throw new Error(
+      `Unable to install git and tar in Daytona${detail ? `: ${detail}` : ""}`,
+    );
+  }
+}

--- a/packages/core/src/investigations/report.test.ts
+++ b/packages/core/src/investigations/report.test.ts
@@ -85,6 +85,10 @@ describe("investigation report", () => {
             changes: [{
               repository: null,
               diff: "diff --git a/src/route.ts b/src/route.ts\n--- a/src/route.ts\n+++ b/src/route.ts\n@@ -1 +1,2 @@\n+if (!value) return;\n use(value);",
+              pullRequest: {
+                title: "Restore the missing route guard",
+                body: "Guard the optional value before the route uses it.\n\nThe focused route test passes.",
+              },
             }],
           },
           {
@@ -99,6 +103,18 @@ describe("investigation report", () => {
     });
 
     expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      const issue = parsed.data.issues[0];
+      const remediation = issue?.resolution === "new"
+        ? issue.remediations[0]
+        : undefined;
+      expect(remediation?.type === "code_change"
+        ? remediation.changes[0]?.pullRequest
+        : undefined).toEqual({
+        title: "Restore the missing route guard",
+        body: "Guard the optional value before the route uses it.\n\nThe focused route test passes.",
+      });
+    }
   });
 
   it("accepts one code remediation containing changes for several repositories", () => {
@@ -124,10 +140,18 @@ describe("investigation report", () => {
             {
               repository: "acme/app",
               diff: "diff --git a/src/config.ts b/src/config.ts\n--- a/src/config.ts\n+++ b/src/config.ts\n@@ -1 +1,2 @@\n+export const channelId = \"chan\";",
+              pullRequest: {
+                title: "Propagate the channel from the app",
+                body: "Forward the resolved channel to the SDK.",
+              },
             },
             {
               repository: "acme/sdk",
               diff: "diff --git a/src/events.ts b/src/events.ts\n--- a/src/events.ts\n+++ b/src/events.ts\n@@ -1 +1,2 @@\n+export const channelId = \"chan\";",
+              pullRequest: {
+                title: "Accept the resolved channel in the SDK",
+                body: "Carry the app's resolved channel into produced events.",
+              },
             },
           ],
         }],
@@ -136,6 +160,48 @@ describe("investigation report", () => {
     });
 
     expect(parsed.success).toBe(true);
+  });
+
+  it("requires pull request content for newly authored code changes", () => {
+    const parsed = investigationReportSubmissionSchema.safeParse({
+      schemaVersion: 1,
+      headline: "Route needs a guard",
+      summary: "The missing guard causes the route to fail.",
+      issues: [{
+        resolution: "new",
+        title: "Missing route guard",
+        description: "The route uses an optional value without checking it.",
+        rootCause: "A route change removed the optional-value guard.",
+        timeline: [{
+          title: "Request reached the route",
+          description: "The request reached the route without the optional value.",
+        }],
+        severity: "SEV-2",
+        remediations: [{
+          type: "code_change",
+          title: "Restore the route guard",
+          description: "Return early when the optional value is absent.",
+          changes: [{
+            repository: "acme/app",
+            diff: "diff --git a/src/route.ts b/src/route.ts\n--- a/src/route.ts\n+++ b/src/route.ts\n@@ -1 +1,2 @@\n+if (!value) return;\n use(value);",
+          }],
+        }],
+        evidence: [evidence],
+      }],
+    });
+
+    expect(parsed.success).toBe(false);
+    if (!parsed.success) {
+      expect(parsed.error.issues[0]?.path).toEqual([
+        "issues",
+        0,
+        "remediations",
+        0,
+        "changes",
+        0,
+        "pullRequest",
+      ]);
+    }
   });
 
   it("renders only the targeted repository change for a remediation job", () => {

--- a/packages/core/src/investigations/report.ts
+++ b/packages/core/src/investigations/report.ts
@@ -97,6 +97,27 @@ const codeChangePartSchema = z.object({
     .describe(
       "Complete unified git diff for this repository, including diff --git, ---/+++, and hunk headers.",
     ),
+  pullRequest: z
+    .object({
+      title: z
+        .string()
+        .trim()
+        .min(1)
+        .max(240)
+        .describe("Ready-for-review pull request title."),
+      body: z
+        .string()
+        .trim()
+        .min(1)
+        .max(12_000)
+        .describe(
+          "Complete Markdown pull request body. Decide what context and validation results belong here.",
+        ),
+    })
+    .optional()
+    .describe(
+      "Agent-authored pull request content. Required for newly proposed changes; optional only for remediations saved by older versions.",
+    ),
 });
 
 const codeChangeRemediationSchema = z
@@ -150,6 +171,27 @@ export type IssueRemediation = IssueRemediationSubmission & { id: string };
 
 export type CodeChangePart = z.infer<typeof codeChangePartSchema>;
 
+export const authoredIssueRemediationsSchema = z
+  .array(issueRemediationSubmissionSchema)
+  .min(1)
+  .max(10)
+  .superRefine((remediations, context) => {
+    remediations.forEach((remediation, remediationIndex) => {
+      if (remediation.type !== "code_change") return;
+      remediation.changes.forEach((change, changeIndex) => {
+        if (change.pullRequest) return;
+        context.addIssue({
+          code: "custom",
+          message: "New code changes require agent-authored pull request content",
+          path: [remediationIndex, "changes", changeIndex, "pullRequest"],
+        });
+      });
+    });
+  })
+  .describe(
+    "Concrete remediation options with complete pull request content for every new code change.",
+  );
+
 export function codeChangeParts(
   remediation: Extract<IssueRemediationSubmission, { type: "code_change" }>,
 ): CodeChangePart[] {
@@ -180,13 +222,9 @@ const newIssueSubmissionSchema = z.object({
     .max(30)
     .describe("Ordered events that explain how the issue unfolded."),
   severity: issueSeveritySchema,
-  remediations: z
-    .array(issueRemediationSubmissionSchema)
-    .min(1)
-    .max(10)
-    .describe(
-      "Concrete remediation options. Use code_change only after inspecting the relevant files; use external_action for configuration, deployment, data, or other work outside the attached repositories.",
-    ),
+  remediations: authoredIssueRemediationsSchema.describe(
+    "Concrete remediation options. Use code_change only after inspecting and editing the relevant files and running the checks you choose; use external_action for configuration, deployment, data, or other work outside the attached repositories.",
+  ),
   evidence: z.array(issueEvidenceSchema).min(1).max(30),
 });
 


### PR DESCRIPTION
## Summary

- prepare proposed code changes and focused validation during investigation
- store ready-for-review title and body alongside each repository diff
- apply the stored diff in a minimal sandbox and publish it without a second generation or project-check pass
- keep compatibility with previously saved remediations

## Testing

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test` (122 files, 915 tests)

## Companion change

- https://github.com/superloglabs/responder/pull/210