### PR TITLE
Increase investigation worker concurrency

### DIFF
--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -1,5 +1,6 @@
 import {
   createJobBoss,
+  investigationLocalConcurrency,
   investigationQueue,
   linearTicketJobSchema,
   linearTicketQueue,
@@ -428,7 +429,7 @@ await boss.work(
 await migrateLegacyInvestigationHeartbeats(boss, {
   handoffWaitMs: legacyHeartbeatHandoffWaitMs(),
 });
-await boss.work(investigationQueue, { localConcurrency: 1 }, async ([job]) => {
+await boss.work(investigationQueue, { localConcurrency: investigationLocalConcurrency }, async ([job]) => {
   const payload = responderJobSchema.parse(job.data);
   if (payload.kind === "remediation") {
     // Drain jobs queued by older workers while all new remediations use the

--- a/packages/core/src/jobs.test.ts
+++ b/packages/core/src/jobs.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   createJobBoss,
   investigationJobSchema,
+  investigationLocalConcurrency,
   investigationQueue,
   linearTicketQueue,
   migrateLegacyInvestigationHeartbeats,
@@ -15,6 +16,10 @@ import {
 } from "./jobs.js";
 
 describe("background jobs", () => {
+  it("allows two investigations to run concurrently on each worker", () => {
+    expect(investigationLocalConcurrency).toBe(2);
+  });
+
   it("migrates queued legacy investigations without reclassifying active work", async () => {
     const executeSql = vi
       .fn()

--- a/packages/core/src/jobs.ts
+++ b/packages/core/src/jobs.ts
@@ -21,6 +21,7 @@ export const remediationQueue = "responder-remediations-v2";
 export const pullRequestReviewQueue = "responder-pull-request-reviews-v1";
 
 export const investigationHeartbeatSeconds = 60;
+export const investigationLocalConcurrency = 2;
 
 export const workerHealthJobSchema = z.object({
   marker: z.string().min(1),


### PR DESCRIPTION
## Summary
- allow two standard investigations to run concurrently per worker
- keep the concurrency value next to the queue policy
- cover the production concurrency setting with a focused test

## Motivation
A long-running investigation can currently occupy the only standard investigation slot. If that job retries, newer investigations remain queued even though the worker is healthy. Two slots prevent one pathological run from blocking all other investigations.

## Validation
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allows two standard investigations to run concurrently per worker instead of one, so a long-running or retrying investigation no longer blocks newer investigations from being processed.

The concurrency value now lives as a named constant next to the queue policy, and a test locks in the production setting.

<sup>Written for commit 630cafd0555a7e266be1516492f68953292806de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/responder-oss/pull/115?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

