### PR TITLE
Allow existing placeholder fixtures in PR files

### DIFF
--- a/apps/worker/src/github-pull-request.test.ts
+++ b/apps/worker/src/github-pull-request.test.ts
@@ -99,6 +99,53 @@ describe("GitHub pull requests from Daytona", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it("allows an existing placeholder fixture when the stored diff was scanned", async () => {
+    const session = {
+      execCommand: vi
+        .fn()
+        .mockResolvedValueOnce(commandResult(0, "src/config.ts\0"))
+        .mockResolvedValueOnce(commandResult(0, "present"))
+        .mockResolvedValueOnce(commandResult(1)),
+      readFile: vi
+        .fn()
+        .mockResolvedValue(
+          new TextEncoder().encode('export const fixture = "dtn_secret_1234-abcd";'),
+        ),
+    } as unknown as DaytonaSandboxSession;
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(Response.json({ sha: "blob-sha" }))
+      .mockResolvedValueOnce(Response.json({ sha: "tree-sha" }))
+      .mockResolvedValueOnce(Response.json({ sha: "commit-sha" }))
+      .mockResolvedValueOnce(Response.json({ ref: "refs/heads/fix" }))
+      .mockResolvedValueOnce(
+        Response.json({ number: 42, html_url: "https://github.com/acme/app/pull/42" }),
+      );
+
+    await expect(
+      createPullRequestFromSandbox(
+        {
+          baseBranch: "main",
+          baseSha: "a".repeat(40),
+          body: "Pull request body",
+          installationId: 123,
+          repository: "acme/app",
+          repositoryPath: "/home/daytona/workspace/repositories/acme/app",
+          requestId: "12345678-1234-1234-1234-123456789012",
+          scanChangedFileContents: false,
+          title: "Fix: Broken route",
+          workspaceBaseSha: "b".repeat(40),
+        },
+        session,
+        {
+          createInstallationToken: vi.fn().mockResolvedValue("github-secret"),
+          fetch: fetchMock,
+        },
+      ),
+    ).resolves.toMatchObject({ number: 42 });
+    expect(fetchMock).toHaveBeenCalledTimes(5);
+  });
+
   it("rejects a pull request title containing a workspace secret placeholder", async () => {
     const session = {
       execCommand: vi

--- a/apps/worker/src/github-pull-request.ts
+++ b/apps/worker/src/github-pull-request.ts
@@ -187,6 +187,7 @@ export async function createPullRequestFromSandbox(
     repository: string;
     repositoryPath: string;
     requestId: string;
+    scanChangedFileContents?: boolean;
     title: string;
     workspaceBaseSha: string;
   },
@@ -202,7 +203,7 @@ export async function createPullRequestFromSandbox(
   assertNoDaytonaSecretPlaceholders(input.title, "Pull request title");
   for (const file of files) {
     assertNoDaytonaSecretPlaceholders(file.path, "Changed file path");
-    if (file.content) {
+    if (input.scanChangedFileContents !== false && file.content) {
       assertNoDaytonaSecretPlaceholders(
         file.content,
         `Changed file ${file.path}`,

--- a/apps/worker/src/remediate.test.ts
+++ b/apps/worker/src/remediate.test.ts
@@ -174,4 +174,21 @@ describe("proposed diff remediation", () => {
       applyProposedDiff(session, "/workspace/acme/api", "invalid diff"),
     ).rejects.toThrow("The proposed diff no longer applies cleanly");
   });
+
+  it("rejects a proposed diff containing a workspace secret placeholder", async () => {
+    const session = {
+      execCommand: vi.fn(),
+      materializeEntry: vi.fn(),
+    } as unknown as DaytonaSandboxSession;
+
+    await expect(
+      applyProposedDiff(
+        session,
+        "/workspace/acme/api",
+        "diff --git a/key.ts b/key.ts\n+dtn_secret_1234-abcd",
+      ),
+    ).rejects.toThrow("Proposed diff cannot contain a workspace secret placeholder");
+    expect(session.materializeEntry).not.toHaveBeenCalled();
+    expect(session.execCommand).not.toHaveBeenCalled();
+  });
 });

--- a/apps/worker/src/remediate.ts
+++ b/apps/worker/src/remediate.ts
@@ -19,9 +19,7 @@ import {
 import type { RemediationJob } from "@responder/core/jobs";
 import type { IssueRemediationSubmission } from "@responder/core/investigations/report";
 import { refreshIssuePullRequestSlackMessages } from "@responder/core/integrations/slack-remediations";
-import {
-  createPullRequestFromSandbox,
-} from "./github-pull-request.js";
+import { createPullRequestFromSandbox } from "./github-pull-request.js";
 import { checkoutRuntimeRepository } from "./repositories.js";
 import {
   closeDaytonaSandbox,
@@ -29,6 +27,7 @@ import {
   createDaytonaSandboxSession,
   prepareDaytonaPatchSandbox,
 } from "./sandbox.js";
+import { assertNoDaytonaSecretPlaceholders } from "./secret-safety.js";
 
 type CodeChangeRemediation = Extract<
   IssueRemediationSubmission,
@@ -104,6 +103,7 @@ export async function applyProposedDiff(
   repositoryPath: string,
   diff: string,
 ): Promise<void> {
+  assertNoDaytonaSecretPlaceholders(diff, "Proposed diff");
   const patchPath = "/home/daytona/workspace/.responder/proposed.patch";
   await session.materializeEntry({
     entry: { type: "file", content: `${diff.trim()}\n` },
@@ -174,6 +174,10 @@ export async function runProposedRemediation(
         repository: selected.repository.fullName,
         repositoryPath: checkout.path,
         requestId: request.requestId,
+        // This sandbox receives no workspace secrets. The exact stored diff is
+        // scanned before application, so an unchanged placeholder fixture in a
+        // touched file is safe and must not block publication.
+        scanChangedFileContents: false,
         title: pullRequest.title,
         workspaceBaseSha: checkout.workspaceBaseSha,
       },


### PR DESCRIPTION
## Summary

- scan the exact stored diff before applying it in the isolated pull request sandbox
- allow touched files to retain placeholder fixtures that already existed outside the proposed diff
- continue rejecting placeholders introduced by the diff, title, body, or changed path

## Production failure

Fixes the pull request publication failure for issue `4ac7d193-b5cc-40ff-9ac9-d02a65299647`.

## Testing

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test` (125 files, 935 tests)

## Companion change

- https://github.com/superloglabs/responder/pull/214

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the PR publication failure for `4ac7d193-b5cc-40ff-9ac9-d02a65299647`. Previously, a placeholder fixture already present in a touched file blocked the PR; now the exact stored diff is scanned before it is applied, and only placeholders introduced by the diff, title, body, or changed path are rejected.

<sup>Written for commit 48302f8aea256a4d5b693e9790cbdff2676bdd18. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/responder-oss/pull/117?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

