### PR TITLE
Resolve base tree before publishing pull requests

### DIFF
--- a/apps/worker/src/github-pull-request.test.ts
+++ b/apps/worker/src/github-pull-request.test.ts
@@ -19,6 +19,7 @@ describe("GitHub pull requests from Daytona", () => {
     } as unknown as DaytonaSandboxSession;
     const fetchMock = vi
       .fn<typeof fetch>()
+      .mockResolvedValueOnce(Response.json({ tree: { sha: "base-tree-sha" } }))
       .mockResolvedValueOnce(Response.json({ sha: "blob-sha" }))
       .mockResolvedValueOnce(Response.json({ sha: "tree-sha" }))
       .mockResolvedValueOnce(Response.json({ sha: "commit-sha" }))
@@ -53,6 +54,10 @@ describe("GitHub pull requests from Daytona", () => {
       url: "https://github.com/acme/app/pull/42",
     });
     expect(JSON.stringify(execCommand.mock.calls)).not.toContain("github-secret");
+    expect(fetchMock).toHaveBeenCalledWith(
+      `https://api.github.com/repos/acme/app/git/commits/${"a".repeat(40)}`,
+      expect.objectContaining({ method: "GET" }),
+    );
     expect(fetchMock).toHaveBeenCalledWith(
       "https://api.github.com/repos/acme/app/git/blobs",
       expect.objectContaining({
@@ -114,6 +119,7 @@ describe("GitHub pull requests from Daytona", () => {
     } as unknown as DaytonaSandboxSession;
     const fetchMock = vi
       .fn<typeof fetch>()
+      .mockResolvedValueOnce(Response.json({ tree: { sha: "base-tree-sha" } }))
       .mockResolvedValueOnce(Response.json({ sha: "blob-sha" }))
       .mockResolvedValueOnce(Response.json({ sha: "tree-sha" }))
       .mockResolvedValueOnce(Response.json({ sha: "commit-sha" }))
@@ -143,7 +149,13 @@ describe("GitHub pull requests from Daytona", () => {
         },
       ),
     ).resolves.toMatchObject({ number: 42 });
-    expect(fetchMock).toHaveBeenCalledTimes(5);
+    expect(fetchMock).toHaveBeenCalledTimes(6);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.github.com/repos/acme/app/git/trees",
+      expect.objectContaining({
+        body: expect.stringContaining('"base_tree":"base-tree-sha"'),
+      }),
+    );
   });
 
   it("rejects a pull request title containing a workspace secret placeholder", async () => {

--- a/apps/worker/src/github-pull-request.ts
+++ b/apps/worker/src/github-pull-request.ts
@@ -9,6 +9,9 @@ import { assertNoDaytonaSecretPlaceholders } from "./secret-safety.js";
 const githubBlobSchema = z.object({ sha: z.string().min(1) });
 const githubTreeSchema = z.object({ sha: z.string().min(1) });
 const githubCommitSchema = z.object({ sha: z.string().min(1) });
+const githubCommitDetailsSchema = z.object({
+  tree: z.object({ sha: z.string().min(1) }),
+});
 const githubPullRequestSchema = z.object({
   number: z.number().int().positive(),
   html_url: z.string().url(),
@@ -213,6 +216,14 @@ export async function createPullRequestFromSandbox(
   const token = await dependencies.createInstallationToken(input.installationId);
   const apiRepository = repositoryApiPath(input.repository);
   const apiBase = `https://api.github.com/repos/${apiRepository}`;
+  const baseCommit = githubCommitDetailsSchema.parse(
+    await githubJson(
+      dependencies.fetch,
+      token,
+      `${apiBase}/git/commits/${encodeURIComponent(input.baseSha)}`,
+      { method: "GET" },
+    ),
+  );
   const treeEntries: Array<{
     path: string;
     mode: "100644" | "100755";
@@ -240,7 +251,7 @@ export async function createPullRequestFromSandbox(
   const tree = githubTreeSchema.parse(
     await githubJson(dependencies.fetch, token, `${apiBase}/git/trees`, {
       method: "POST",
-      body: JSON.stringify({ base_tree: input.baseSha, tree: treeEntries }),
+      body: JSON.stringify({ base_tree: baseCommit.tree.sha, tree: treeEntries }),
     }),
   );
   const commit = githubCommitSchema.parse(


### PR DESCRIPTION
## Summary

Resolve the base commit to its Git tree before constructing pull request commits through the Git database API. This prevents publication from failing with an invalid object-state response.

## Checks

- `pnpm test`
- `pnpm typecheck`
- `pnpm lint`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolves the base commit to its Git tree before building pull request commits, preventing publication failures caused by passing a commit SHA as the base tree.

<sup>Written for commit 3e6bdf3f5bf83b94ac95dbcd50a52e9f8d0941a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/responder-oss/pull/118?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

