### PR TITLE
Group remediation files by repository

### DIFF
--- a/apps/control-plane/src/components/remediation-diff-files.test.ts
+++ b/apps/control-plane/src/components/remediation-diff-files.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import type { IssueRemediation } from "../agents-api";
+import { remediationFileGroups } from "./remediation-diff-files";
+
+const firstDiff = `diff --git a/src/first.ts b/src/first.ts
+--- a/src/first.ts
++++ b/src/first.ts
+@@ -1 +1 @@
+-export const value = "old";
++export const value = "new";`;
+
+const secondDiff = `diff --git a/src/second.ts b/src/second.ts
+--- a/src/second.ts
++++ b/src/second.ts
+@@ -1 +1 @@
+-export const enabled = false;
++export const enabled = true;`;
+
+function remediation(
+  changes: Array<{ repository: string | null; diff: string }>,
+): IssueRemediation & { type: "code_change" } {
+  return {
+    id: "remediation-1",
+    type: "code_change",
+    title: "Update the behavior",
+    description: "Apply the required code changes.",
+    changes,
+  };
+}
+
+describe("remediation file groups", () => {
+  it("groups every file in a repository diff under one repository entry", () => {
+    const groups = remediationFileGroups(remediation([
+      { repository: "acme/app", diff: `${firstDiff}\n${secondDiff}` },
+    ]));
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0]?.repository).toBe("acme/app");
+    expect(groups[0]?.files.map((file) => file.name)).toEqual([
+      "src/first.ts",
+      "src/second.ts",
+    ]);
+  });
+
+  it("keeps files from different repositories in separate entries", () => {
+    const groups = remediationFileGroups(remediation([
+      { repository: "acme/api", diff: firstDiff },
+      { repository: "acme/web", diff: secondDiff },
+    ]));
+
+    expect(groups.map((group) => group.repository)).toEqual([
+      "acme/api",
+      "acme/web",
+    ]);
+  });
+});

--- a/apps/control-plane/src/components/remediation-diff-files.ts
+++ b/apps/control-plane/src/components/remediation-diff-files.ts
@@ -1,0 +1,40 @@
+import { parsePatchFiles, type FileDiffMetadata } from "@pierre/diffs";
+import type { IssueRemediation } from "../agents-api";
+
+type CodeChangeRemediation = IssueRemediation & { type: "code_change" };
+
+export interface RemediationFileGroup {
+  repository: string | null;
+  files: FileDiffMetadata[];
+}
+
+export function remediationFileGroups(
+  remediation: CodeChangeRemediation,
+): RemediationFileGroup[] {
+  const groups = new Map<string | null, RemediationFileGroup>();
+
+  remediation.changes.forEach((change, changeIndex) => {
+    try {
+      const files = parsePatchFiles(
+        change.diff,
+        `remediation-${remediation.id}-${changeIndex}`,
+        true,
+      ).flatMap((patch) => patch.files);
+      if (files.length === 0) return;
+
+      const existing = groups.get(change.repository);
+      if (existing) {
+        existing.files.push(...files);
+      } else {
+        groups.set(change.repository, {
+          repository: change.repository,
+          files,
+        });
+      }
+    } catch {
+      // The raw unified diff is rendered by the caller when nothing can be parsed.
+    }
+  });
+
+  return [...groups.values()];
+}

--- a/apps/control-plane/src/components/remediation-diff.tsx
+++ b/apps/control-plane/src/components/remediation-diff.tsx
@@ -1,8 +1,8 @@
-import { parsePatchFiles } from "@pierre/diffs";
 import { FileDiff } from "@pierre/diffs/react";
 import { useMemo } from "react";
 import type { IssueRemediation } from "../agents-api";
 import { useColorTheme } from "../color-theme";
+import { remediationFileGroups } from "./remediation-diff-files";
 
 export function RemediationDiff({
   remediation,
@@ -10,28 +10,15 @@ export function RemediationDiff({
   remediation: IssueRemediation & { type: "code_change" };
 }) {
   const { theme } = useColorTheme();
-  const changes = useMemo(() => remediation.changes, [remediation.changes]);
-  const files = useMemo(
-    () => changes.flatMap((change, changeIndex) => {
-      try {
-        return parsePatchFiles(
-          change.diff,
-          `remediation-${remediation.id}-${changeIndex}`,
-          true,
-        ).flatMap((patch) =>
-          patch.files.map((file) => ({ file, repository: change.repository })),
-        );
-      } catch {
-        return [];
-      }
-    }),
-    [changes, remediation.id],
+  const fileGroups = useMemo(
+    () => remediationFileGroups(remediation),
+    [remediation],
   );
 
-  if (files.length === 0) {
+  if (fileGroups.length === 0) {
     return (
       <pre className="remediationDiff__fallback">
-        {changes.map((change) =>
+        {remediation.changes.map((change) =>
           `${change.repository ? `# ${change.repository}\n` : ""}${change.diff}`,
         ).join("\n\n")}
       </pre>
@@ -40,19 +27,27 @@ export function RemediationDiff({
 
   return (
     <div className="remediationDiff">
-      {files.map(({ file, repository }, index) => (
-        <div key={`${remediation.id}-${index}`}>
-          {repository ? <h4>{repository}</h4> : null}
-          <FileDiff
-            className="remediationDiff__file"
-            fileDiff={file}
-            options={{
-              diffIndicators: "bars",
-              diffStyle: "unified",
-              overflow: "scroll",
-              themeType: theme,
-            }}
-          />
+      {fileGroups.map((group, groupIndex) => (
+        <div
+          className="remediationDiff__repository"
+          key={`${remediation.id}-${group.repository ?? "unknown"}-${groupIndex}`}
+        >
+          {group.repository ? <h4>{group.repository}</h4> : null}
+          <div className="remediationDiff__files">
+            {group.files.map((file, fileIndex) => (
+              <FileDiff
+                className="remediationDiff__file"
+                fileDiff={file}
+                key={`${remediation.id}-${groupIndex}-${fileIndex}`}
+                options={{
+                  diffIndicators: "bars",
+                  diffStyle: "unified",
+                  overflow: "scroll",
+                  themeType: theme,
+                }}
+              />
+            ))}
+          </div>
         </div>
       ))}
     </div>

--- a/apps/control-plane/src/styles.css
+++ b/apps/control-plane/src/styles.css
@@ -8709,7 +8709,24 @@ body:has(.appShell--create) {
   min-width: 0;
   display: flex;
   flex-direction: column;
+  gap: 16px;
+}
+
+.remediationDiff__repository,
+.remediationDiff__files {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
   gap: 8px;
+}
+
+.remediationDiff__repository > h4 {
+  margin: 0;
+  color: var(--issueMuted);
+  font-family: var(--ds-font-mono);
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 16px;
 }
 
 .remediationDiff__file {


### PR DESCRIPTION
## What changed

- group all parsed file diffs beneath one repository heading
- preserve separate groups for multi-repository remediation plans
- add focused coverage for both layouts

## Validation

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated focused tests
- [x] Checked migrations when the schema changed (not applicable; no schema changes)

## Risk and rollout

Presentation-only change to remediation diffs. No data model or operational changes.

## Assistance disclosure

Implementation was reviewed and validated locally.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Groups remediation file diffs under a single repository heading so a repository with multiple changed files shows its name once instead of once per file. Multi-repository remediation plans keep separate groups per repository; this is a presentation-only change with no data model or operational impact.

<sup>Written for commit 8a77faa73ed957e2c91578ceeeb5590fa8fce150. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/responder-oss/pull/121?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

