### PR TITLE
Accept legacy Sentry callback URL

### DIFF
--- a/apps/control-plane/server/app.ts
+++ b/apps/control-plane/server/app.ts
@@ -320,6 +320,11 @@ export const app = instrumentedApp
     callbackUrl.pathname = "/api/integrations/github/callback";
     return context.redirect(callbackUrl.toString());
   })
+  .get("/sentry/oauth/callback", (context) => {
+    const callbackUrl = new URL(context.req.url);
+    callbackUrl.pathname = "/api/integrations/sentry/callback";
+    return context.redirect(callbackUrl.toString());
+  })
   .get("/api/superuser/users", async (context) => {
     const auth = getAuth();
     const session = await auth.api

--- a/apps/control-plane/server/index.test.ts
+++ b/apps/control-plane/server/index.test.ts
@@ -245,6 +245,25 @@ describe("control-plane API", () => {
     );
   });
 
+  it("routes the legacy Sentry callback to the integration flow", async () => {
+    const response = await app.request(
+      "https://responder.example/sentry/oauth/callback" +
+        "?code=sentry-code" +
+        "&installationId=00000000-0000-4000-8000-000000000000" +
+        "&orgSlug=customer" +
+        "&state=responder-v1.callback.nonce",
+    );
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe(
+      "https://responder.example/api/integrations/sentry/callback" +
+        "?code=sentry-code" +
+        "&installationId=00000000-0000-4000-8000-000000000000" +
+        "&orgSlug=customer" +
+        "&state=responder-v1.callback.nonce",
+    );
+  });
+
   it("rejects unauthenticated investigation requests", async () => {
     const response = await app.request("/api/investigations", {
       method: "POST",

--- a/apps/control-plane/server/integrations/providers.test.ts
+++ b/apps/control-plane/server/integrations/providers.test.ts
@@ -545,6 +545,7 @@ describe("integration providers", () => {
         exp: expect.any(Number),
         iat: expect.any(Number),
         iss: "sentry-client",
+        sub: "sentry-client",
         jti: expect.any(String),
       }),
     );

--- a/apps/control-plane/server/integrations/sentry.ts
+++ b/apps/control-plane/server/integrations/sentry.ts
@@ -71,6 +71,7 @@ function sentryClientSecretJwt(clientId: string, clientSecret: string): string {
       exp: issuedAt + 60,
       iat: issuedAt,
       iss: clientId,
+      sub: clientId,
       jti: randomUUID(),
     }),
   );


### PR DESCRIPTION
## Summary

- redirect the configured legacy Sentry callback path to the canonical integration handler
- preserve the authorization code, installation ID, organization slug, and state query parameters
- include Sentry’s required `sub` claim in client-secret JWT refreshes
- cover both compatibility and JWT behavior with focused tests

## Testing

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
