### PR TITLE
Add Sentry disconnect and reconnect recovery

### DIFF
--- a/apps/control-plane/server/integrations/providers.test.ts
+++ b/apps/control-plane/server/integrations/providers.test.ts
@@ -29,8 +29,11 @@ import {
   githubInstallUrl,
 } from "./github.js";
 import {
+  deleteSentryInstallation,
   listSentryProjects,
   refreshSentryGrant,
+  SentryApiError,
+  sentryIntegrationSettingsUrl,
   sentryInstallUrl,
 } from "./sentry.js";
 import {
@@ -558,6 +561,71 @@ describe("integration providers", () => {
     expect(JSON.parse(manualRequest[1].body as string)).toEqual({
       grant_type: "urn:sentry:params:oauth:grant-type:jwt-bearer",
     });
+  });
+
+  it("uninstalls a Sentry App with its installation token", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(null, { status: 204 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      deleteSentryInstallation(
+        "installation-token",
+        "40000000-0000-4000-8000-000000000000",
+      ),
+    ).resolves.toBe("deleted");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://sentry.io/api/0/sentry-app-installations/40000000-0000-4000-8000-000000000000/",
+      expect.objectContaining({
+        method: "DELETE",
+        headers: expect.objectContaining({
+          authorization: "Bearer installation-token",
+        }),
+      }),
+    );
+  });
+
+  it("treats an already removed Sentry App as uninstalled", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(new Response(null, { status: 404 })),
+    );
+
+    await expect(
+      deleteSentryInstallation(
+        "installation-token",
+        "40000000-0000-4000-8000-000000000000",
+      ),
+    ).resolves.toBe("already_deleted");
+  });
+
+  it("preserves Sentry uninstall authorization failures for guided recovery", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(new Response(null, { status: 403 })),
+    );
+
+    await expect(
+      deleteSentryInstallation(
+        "installation-token",
+        "40000000-0000-4000-8000-000000000000",
+      ),
+    ).rejects.toEqual(
+      expect.objectContaining<Partial<SentryApiError>>({
+        httpStatus: 403,
+        operation: "installation",
+      }),
+    );
+  });
+
+  it("builds a safe Sentry organization integration settings URL", () => {
+    expect(sentryIntegrationSettingsUrl("example-team")).toBe(
+      "https://example-team.sentry.io/settings/integrations/",
+    );
+    expect(sentryIntegrationSettingsUrl("example.invalid/path")).toBe(
+      "https://sentry.io/settings/",
+    );
   });
 
   it("follows trusted regional Sentry project pagination", async () => {

--- a/apps/control-plane/server/integrations/routes.test.ts
+++ b/apps/control-plane/server/integrations/routes.test.ts
@@ -288,7 +288,7 @@ describe("integration callback routing", () => {
     );
   });
 
-  it("falls back to fresh Sentry authorization when an old retry fails", async () => {
+  it("guides stale Sentry installations through uninstall before reconnect", async () => {
     vi.stubEnv("BETTER_AUTH_URL", "https://responder.example");
     vi.stubEnv("SENTRY_APP_SLUG", "responder-test");
     vi.stubEnv("SENTRY_CLIENT_ID", "sentry-client");
@@ -302,20 +302,123 @@ describe("integration callback routing", () => {
     vi.mocked(decryptCredentials).mockImplementation(() => {
       throw new Error("cannot decrypt");
     });
-    vi.mocked(createIntegrationConnectionState).mockResolvedValue("fresh-state");
     vi.spyOn(console, "error").mockImplementation(() => {});
 
     const response = await app.request("/api/integrations/sentry/start");
 
     expect(response.status).toBe(302);
-    expect(new URL(response.headers.get("location")!).searchParams.get("state"))
-      .toBe("fresh-state");
+    const location = new URL(response.headers.get("location")!);
+    expect(location.searchParams.get("status")).toBe("error");
+    expect(location.searchParams.get("reason")).toBe(
+      "manual_uninstall_required",
+    );
+    expect(createIntegrationConnectionState).not.toHaveBeenCalled();
     expect(setIntegrationAccountStatusIfCredentialsMatch).toHaveBeenCalledWith({
       encryptedCredentials: "broken-credentials",
       integrationAccountId: "30000000-0000-4000-8000-000000000000",
       organizationId: tenant.organizationId,
       provider: "sentry",
       status: "error",
+    });
+  });
+
+  it("uninstalls Sentry before removing the tenant-owned connection", async () => {
+    vi.mocked(getOrganizationIntegrationAccount).mockResolvedValue({
+      encryptedCredentials: "encrypted-credentials",
+      id: "30000000-0000-4000-8000-000000000000",
+      metadata: {
+        installationId: "40000000-0000-4000-8000-000000000000",
+        organizationSlug: "example-team",
+      },
+      status: "connected",
+    });
+    vi.mocked(decryptCredentials).mockReturnValue({
+      accessToken: "installation-token",
+      expiresAt: "2099-01-01T00:00:00.000Z",
+      installationId: "40000000-0000-4000-8000-000000000000",
+      refreshToken: "refresh-token",
+    });
+    vi.mocked(deleteIntegrationAccount).mockResolvedValue(true);
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(null, { status: 204 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await app.request(
+      "/api/integrations/sentry/30000000-0000-4000-8000-000000000000",
+      { method: "DELETE" },
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ removed: true });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://sentry.io/api/0/sentry-app-installations/40000000-0000-4000-8000-000000000000/",
+      expect.objectContaining({ method: "DELETE" }),
+    );
+    expect(deleteIntegrationAccount).toHaveBeenCalledWith({
+      integrationAccountId: "30000000-0000-4000-8000-000000000000",
+      organizationId: tenant.organizationId,
+      provider: "sentry",
+    });
+  });
+
+  it("requires manual Sentry uninstall when its token lacks permission", async () => {
+    vi.mocked(getOrganizationIntegrationAccount).mockResolvedValue({
+      encryptedCredentials: "encrypted-credentials",
+      id: "30000000-0000-4000-8000-000000000000",
+      metadata: { organizationSlug: "example-team" },
+      status: "error",
+    });
+    vi.mocked(decryptCredentials).mockReturnValue({
+      accessToken: "installation-token",
+      expiresAt: "2099-01-01T00:00:00.000Z",
+      installationId: "40000000-0000-4000-8000-000000000000",
+      refreshToken: "refresh-token",
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(new Response(null, { status: 403 })),
+    );
+
+    const response = await app.request(
+      "/api/integrations/sentry/30000000-0000-4000-8000-000000000000",
+      { method: "DELETE" },
+    );
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({
+      action: "manual_uninstall_required",
+      error:
+        "Sentry requires an organization admin to uninstall this connection before it can be reconnected.",
+      manualUninstallUrl:
+        "https://example-team.sentry.io/settings/integrations/",
+    });
+    expect(deleteIntegrationAccount).not.toHaveBeenCalled();
+  });
+
+  it("removes a stale local Sentry connection after manual uninstall", async () => {
+    vi.mocked(getOrganizationIntegrationAccount).mockResolvedValue({
+      encryptedCredentials: null,
+      id: "30000000-0000-4000-8000-000000000000",
+      metadata: { organizationSlug: "example-team" },
+      status: "error",
+    });
+    vi.mocked(deleteIntegrationAccount).mockResolvedValue(true);
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await app.request(
+      "/api/integrations/sentry/30000000-0000-4000-8000-000000000000?localOnly=true",
+      { method: "DELETE" },
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ removed: true });
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(deleteIntegrationAccount).toHaveBeenCalledWith({
+      integrationAccountId: "30000000-0000-4000-8000-000000000000",
+      organizationId: tenant.organizationId,
+      provider: "sentry",
     });
   });
 
@@ -593,6 +696,7 @@ describe("integration callback routing", () => {
     vi.mocked(upsertIntegrationAccount).mockResolvedValue(
       "30000000-0000-4000-8000-000000000000",
     );
+    vi.mocked(setIntegrationAccountStatus).mockResolvedValue(undefined);
     vi.stubGlobal(
       "fetch",
       vi
@@ -784,6 +888,57 @@ describe("integration callback routing", () => {
       "https://responder.example/settings?integration=sentry&status=finishing",
     );
     expect(consumeIntegrationConnectionState).not.toHaveBeenCalled();
+  });
+
+  it("keeps a failed Sentry installation visible so it can be disconnected", async () => {
+    vi.stubEnv("BETTER_AUTH_URL", "https://responder.example");
+    vi.stubEnv("SENTRY_APP_SLUG", "responder-test");
+    vi.stubEnv("SENTRY_CLIENT_ID", "sentry-client");
+    vi.stubEnv("SENTRY_CLIENT_SECRET", "sentry-secret");
+    vi.mocked(consumeIntegrationConnectionState).mockResolvedValue({
+      organizationId: tenant.organizationId,
+      userId: tenant.user.id,
+      returnTo: "/settings",
+      codeVerifier: null,
+      metadata: {},
+    });
+    vi.mocked(upsertIntegrationAccount).mockResolvedValue(
+      "30000000-0000-4000-8000-000000000000",
+    );
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(new Response(null, { status: 401 })),
+    );
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const response = await app.request(
+      "/api/integrations/sentry/callback" +
+        "?state=oauth-state&code=oauth-code" +
+        "&installationId=40000000-0000-4000-8000-000000000000" +
+        "&orgSlug=example-team",
+    );
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe(
+      "https://responder.example/settings" +
+        "?integration=sentry&status=error&reason=connection_failed",
+    );
+    expect(upsertIntegrationAccount).toHaveBeenCalledWith({
+      organizationId: tenant.organizationId,
+      provider: "sentry",
+      externalAccountId: "40000000-0000-4000-8000-000000000000",
+      displayName: "example-team",
+      status: "pending",
+      encryptedCredentials: null,
+      credentialKeyVersion: null,
+      metadata: {
+        installationId: "40000000-0000-4000-8000-000000000000",
+        organizationSlug: "example-team",
+      },
+    });
+    expect(setIntegrationAccountStatus).toHaveBeenCalledWith(
+      "30000000-0000-4000-8000-000000000000",
+      "error",
+    );
   });
 
   it("offers GitHub App installation as the first connection flow", async () => {

--- a/apps/control-plane/server/integrations/routes.test.ts
+++ b/apps/control-plane/server/integrations/routes.test.ts
@@ -350,6 +350,7 @@ describe("integration callback routing", () => {
 
     expect(response.status).toBe(302);
     const location = new URL(response.headers.get("location")!);
+    expect(location.searchParams.get("status")).toBe("error");
     expect(location.searchParams.get("reason")).toBe(
       "manual_uninstall_required",
     );

--- a/apps/control-plane/server/integrations/routes.test.ts
+++ b/apps/control-plane/server/integrations/routes.test.ts
@@ -234,6 +234,7 @@ describe("integration callback routing", () => {
       .toBe("fresh-state");
     expect(getRecoverableSentryIntegrationAccount).toHaveBeenCalledWith(
       tenant.organizationId,
+      undefined,
     );
   });
 
@@ -274,12 +275,19 @@ describe("integration callback routing", () => {
         .mockResolvedValueOnce(new Response(null, { status: 200 })),
     );
 
-    const response = await app.request("/api/integrations/sentry/start");
+    const response = await app.request(
+      "/api/integrations/sentry/start" +
+        "?integrationAccountId=30000000-0000-4000-8000-000000000000",
+    );
 
     expect(response.status).toBe(302);
     expect(new URL(response.headers.get("location")!).searchParams.get("status"))
       .toBe("connected");
     expect(createIntegrationConnectionState).not.toHaveBeenCalled();
+    expect(getRecoverableSentryIntegrationAccount).toHaveBeenCalledWith(
+      tenant.organizationId,
+      "30000000-0000-4000-8000-000000000000",
+    );
     expect(replaceIntegrationResourcesIfCredentialsMatch).toHaveBeenCalledWith(
       expect.objectContaining({
         encryptedCredentials: "refreshed-credentials",
@@ -322,6 +330,49 @@ describe("integration callback routing", () => {
     });
   });
 
+  it("guides a selected tokenless Sentry installation to disconnect", async () => {
+    vi.stubEnv("BETTER_AUTH_URL", "https://responder.example");
+    vi.stubEnv("SENTRY_APP_SLUG", "responder-test");
+    vi.stubEnv("SENTRY_CLIENT_ID", "sentry-client");
+    vi.stubEnv("SENTRY_CLIENT_SECRET", "sentry-secret");
+    vi.mocked(getRecoverableSentryIntegrationAccount).mockResolvedValue({
+      id: "30000000-0000-4000-8000-000000000000",
+      encryptedCredentials: null,
+      externalAccountId: "40000000-0000-4000-8000-000000000000",
+      metadata: { organizationSlug: "example" },
+    });
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const response = await app.request(
+      "/api/integrations/sentry/start" +
+        "?integrationAccountId=30000000-0000-4000-8000-000000000000",
+    );
+
+    expect(response.status).toBe(302);
+    const location = new URL(response.headers.get("location")!);
+    expect(location.searchParams.get("reason")).toBe(
+      "manual_uninstall_required",
+    );
+    expect(createIntegrationConnectionState).not.toHaveBeenCalled();
+  });
+
+  it("starts a fresh Sentry install without retrying another organization", async () => {
+    vi.stubEnv("BETTER_AUTH_URL", "https://responder.example");
+    vi.stubEnv("SENTRY_APP_SLUG", "responder-test");
+    vi.stubEnv("SENTRY_CLIENT_ID", "sentry-client");
+    vi.stubEnv("SENTRY_CLIENT_SECRET", "sentry-secret");
+    vi.mocked(createIntegrationConnectionState).mockResolvedValue("fresh-state");
+
+    const response = await app.request(
+      "/api/integrations/sentry/start?mode=install&returnTo=/settings",
+    );
+
+    expect(response.status).toBe(302);
+    expect(new URL(response.headers.get("location")!).searchParams.get("state"))
+      .toBe("fresh-state");
+    expect(getRecoverableSentryIntegrationAccount).not.toHaveBeenCalled();
+  });
+
   it("uninstalls Sentry before removing the tenant-owned connection", async () => {
     vi.mocked(getOrganizationIntegrationAccount).mockResolvedValue({
       encryptedCredentials: "encrypted-credentials",
@@ -354,6 +405,9 @@ describe("integration callback routing", () => {
     expect(fetchMock).toHaveBeenCalledWith(
       "https://sentry.io/api/0/sentry-app-installations/40000000-0000-4000-8000-000000000000/",
       expect.objectContaining({ method: "DELETE" }),
+    );
+    expect(fetchMock.mock.invocationCallOrder[0]).toBeLessThan(
+      vi.mocked(deleteIntegrationAccount).mock.invocationCallOrder[0]!,
     );
     expect(deleteIntegrationAccount).toHaveBeenCalledWith({
       integrationAccountId: "30000000-0000-4000-8000-000000000000",
@@ -905,6 +959,9 @@ describe("integration callback routing", () => {
     vi.mocked(upsertIntegrationAccount).mockResolvedValue(
       "30000000-0000-4000-8000-000000000000",
     );
+    vi.mocked(getOrganizationIntegrationAccountByExternalId).mockResolvedValue(
+      null as never,
+    );
     vi.stubGlobal(
       "fetch",
       vi.fn().mockResolvedValue(new Response(null, { status: 401 })),
@@ -939,6 +996,42 @@ describe("integration callback routing", () => {
       "30000000-0000-4000-8000-000000000000",
       "error",
     );
+  });
+
+  it("preserves an existing Sentry connection when a new grant fails", async () => {
+    vi.stubEnv("BETTER_AUTH_URL", "https://responder.example");
+    vi.stubEnv("SENTRY_APP_SLUG", "responder-test");
+    vi.stubEnv("SENTRY_CLIENT_ID", "sentry-client");
+    vi.stubEnv("SENTRY_CLIENT_SECRET", "sentry-secret");
+    vi.mocked(consumeIntegrationConnectionState).mockResolvedValue({
+      organizationId: tenant.organizationId,
+      userId: tenant.user.id,
+      returnTo: "/settings",
+      codeVerifier: null,
+      metadata: {},
+    });
+    vi.mocked(getOrganizationIntegrationAccountByExternalId).mockResolvedValue({
+      encryptedCredentials: "working-credentials",
+      id: "30000000-0000-4000-8000-000000000000",
+      metadata: { organizationSlug: "example-team" },
+      status: "connected",
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(new Response(null, { status: 401 })),
+    );
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const response = await app.request(
+      "/api/integrations/sentry/callback" +
+        "?state=oauth-state&code=oauth-code" +
+        "&installationId=40000000-0000-4000-8000-000000000000" +
+        "&orgSlug=example-team",
+    );
+
+    expect(response.status).toBe(302);
+    expect(upsertIntegrationAccount).not.toHaveBeenCalled();
+    expect(setIntegrationAccountStatus).not.toHaveBeenCalled();
   });
 
   it("offers GitHub App installation as the first connection flow", async () => {

--- a/apps/control-plane/server/integrations/routes.ts
+++ b/apps/control-plane/server/integrations/routes.ts
@@ -477,12 +477,22 @@ async function completeSentrySetup(input: {
   return projects.length;
 }
 
-async function retrySentrySetup(organizationId: string): Promise<{
+async function retrySentrySetup(
+  organizationId: string,
+  integrationAccountId?: string,
+): Promise<{
   accountId: string;
   resourceCount: number;
 } | null> {
-  const account = await getRecoverableSentryIntegrationAccount(organizationId);
-  if (!account?.encryptedCredentials) return null;
+  const account = await getRecoverableSentryIntegrationAccount(
+    organizationId,
+    integrationAccountId,
+  );
+  if (!account) return null;
+  if (!account.encryptedCredentials) {
+    if (integrationAccountId) throw new StoredSentryConnectionError();
+    return null;
+  }
   let expectedEncryptedCredentials = account.encryptedCredentials;
   try {
     const fresh = await getFreshSentryCredentials({
@@ -883,8 +893,22 @@ export const integrationRoutes = new Hono()
       );
     }
     if (parsedProvider.data === "sentry") {
+      const requestedAccountId = context.req.query("integrationAccountId");
+      const parsedAccountId = requestedAccountId
+        ? z.uuid().safeParse(requestedAccountId)
+        : null;
+      if (parsedAccountId && !parsedAccountId.success) {
+        return context.json({ error: "The Sentry account is invalid" }, 400);
+      }
       try {
-        const retriedAccount = await retrySentrySetup(tenant.organizationId);
+        const retriedAccount = context.req.query("mode") === "install"
+          ? null
+          : parsedAccountId?.data
+            ? await retrySentrySetup(
+                tenant.organizationId,
+                parsedAccountId.data,
+              )
+            : await retrySentrySetup(tenant.organizationId);
         if (retriedAccount) {
           await captureAnalyticsEvent({
             distinctId: tenant.user.id,
@@ -2815,20 +2839,30 @@ export const integrationRoutes = new Hono()
     }
 
     let accountId: string | null = null;
+    let accountChanged = false;
     try {
-      accountId = await upsertIntegrationAccount({
+      const existing = await getOrganizationIntegrationAccountByExternalId({
+        externalAccountId: parsedCallback.data.installationId,
         organizationId: connectionState.organizationId,
         provider: "sentry",
-        externalAccountId: parsedCallback.data.installationId,
-        displayName: parsedCallback.data.orgSlug,
-        status: "pending",
-        encryptedCredentials: null,
-        credentialKeyVersion: null,
-        metadata: {
-          installationId: parsedCallback.data.installationId,
-          organizationSlug: parsedCallback.data.orgSlug,
-        },
       });
+      accountId = existing?.id ?? null;
+      if (!accountId) {
+        accountChanged = true;
+        accountId = await upsertIntegrationAccount({
+          organizationId: connectionState.organizationId,
+          provider: "sentry",
+          externalAccountId: parsedCallback.data.installationId,
+          displayName: parsedCallback.data.orgSlug,
+          status: "pending",
+          encryptedCredentials: null,
+          credentialKeyVersion: null,
+          metadata: {
+            installationId: parsedCallback.data.installationId,
+            organizationSlug: parsedCallback.data.orgSlug,
+          },
+        });
+      }
       const authorization = await exchangeSentryGrant(parsedCallback.data);
       accountId = await upsertIntegrationAccount({
         organizationId: connectionState.organizationId,
@@ -2848,6 +2882,7 @@ export const integrationRoutes = new Hono()
           organizationSlug: parsedCallback.data.orgSlug,
         },
       });
+      accountChanged = true;
       const resourceCount = await completeSentrySetup({
         accessToken: authorization.token,
         accountId,
@@ -2869,7 +2904,7 @@ export const integrationRoutes = new Hono()
         settingsRedirect(connectionState.returnTo, "sentry", "connected"),
       );
     } catch (error) {
-      if (accountId) {
+      if (accountId && accountChanged) {
         await setIntegrationAccountStatus(accountId, "error").catch(
           (statusError: unknown) => {
             logCallbackError("Sentry status update", statusError);

--- a/apps/control-plane/server/integrations/routes.ts
+++ b/apps/control-plane/server/integrations/routes.ts
@@ -92,11 +92,13 @@ import {
   registerClickStackCloudClient,
 } from "./clickstack.js";
 import {
+  deleteSentryInstallation,
   exchangeSentryGrant,
   listSentryProjects,
   refreshSentryGrant,
   SentryApiError,
   sentryErrorNeedsReconnect,
+  sentryIntegrationSettingsUrl,
   sentryInstallUrl,
   verifySentryInstallation,
 } from "./sentry.js";
@@ -767,6 +769,81 @@ export const integrationRoutes = new Hono()
 
     return context.json({ accounts: checkedAccounts });
   })
+  .delete("/sentry/:integrationAccountId", async (context) => {
+    const tenant = await getActiveTenant(context.req.raw.headers);
+    if (tenant.ok === false) {
+      return context.json({ error: tenant.error }, tenant.status);
+    }
+    const accountId = z.uuid().safeParse(context.req.param("integrationAccountId"));
+    if (!accountId.success) {
+      return context.json({ error: "The Sentry account is invalid" }, 400);
+    }
+    const localOnly = context.req.query("localOnly") === "true";
+    const account = await getOrganizationIntegrationAccount({
+      integrationAccountId: accountId.data,
+      organizationId: tenant.organizationId,
+      provider: "sentry",
+    });
+    if (!account) {
+      if (localOnly) return context.json({ removed: true });
+      return context.json({ error: "Sentry connection not found" }, 404);
+    }
+
+    const manualUninstallUrl = sentryIntegrationSettingsUrl(
+      typeof account.metadata.organizationSlug === "string"
+        ? account.metadata.organizationSlug
+        : "",
+    );
+    if (localOnly) {
+      await deleteIntegrationAccount({
+        integrationAccountId: account.id,
+        organizationId: tenant.organizationId,
+        provider: "sentry",
+      });
+      return context.json({ removed: true });
+    }
+
+    try {
+      if (!account.encryptedCredentials) {
+        throw new StoredSentryConnectionError();
+      }
+      const fresh = await getFreshSentryCredentials({
+        accountId: account.id,
+        allowedStatuses: ["connected", "error", "pending"],
+        organizationId: tenant.organizationId,
+      });
+      await deleteSentryInstallation(
+        fresh.credentials.accessToken,
+        fresh.credentials.installationId,
+      );
+      await deleteIntegrationAccount({
+        integrationAccountId: account.id,
+        organizationId: tenant.organizationId,
+        provider: "sentry",
+      });
+      return context.json({ removed: true });
+    } catch (error) {
+      if (
+        error instanceof StoredSentryConnectionError ||
+        sentryErrorNeedsReconnect(error)
+      ) {
+        return context.json(
+          {
+            action: "manual_uninstall_required" as const,
+            error:
+              "Sentry requires an organization admin to uninstall this connection before it can be reconnected.",
+            manualUninstallUrl,
+          },
+          409,
+        );
+      }
+      logCallbackError("Sentry uninstall", error, {
+        integrationAccountId: account.id,
+        organizationId: tenant.organizationId,
+      });
+      return context.json({ error: "Unable to disconnect Sentry" }, 502);
+    }
+  })
   .get("/:provider/start", async (context) => {
     const parsedProvider = providerSchema.safeParse(context.req.param("provider"));
     if (!parsedProvider.success) {
@@ -829,6 +906,19 @@ export const integrationRoutes = new Hono()
         }
       } catch (error) {
         logCallbackError("Sentry retry", error);
+        if (
+          error instanceof StoredSentryConnectionError ||
+          sentryErrorNeedsReconnect(error)
+        ) {
+          return context.redirect(
+            settingsRedirect(
+              context.req.query("returnTo") ?? "/settings",
+              "sentry",
+              "error",
+              "manual_uninstall_required",
+            ),
+          );
+        }
       }
     }
     if (parsedProvider.data === "linear") {
@@ -2726,6 +2816,19 @@ export const integrationRoutes = new Hono()
 
     let accountId: string | null = null;
     try {
+      accountId = await upsertIntegrationAccount({
+        organizationId: connectionState.organizationId,
+        provider: "sentry",
+        externalAccountId: parsedCallback.data.installationId,
+        displayName: parsedCallback.data.orgSlug,
+        status: "pending",
+        encryptedCredentials: null,
+        credentialKeyVersion: null,
+        metadata: {
+          installationId: parsedCallback.data.installationId,
+          organizationSlug: parsedCallback.data.orgSlug,
+        },
+      });
       const authorization = await exchangeSentryGrant(parsedCallback.data);
       accountId = await upsertIntegrationAccount({
         organizationId: connectionState.organizationId,

--- a/apps/control-plane/server/integrations/sentry.ts
+++ b/apps/control-plane/server/integrations/sentry.ts
@@ -253,3 +253,36 @@ export async function verifySentryInstallation(
     );
   }
 }
+
+export async function deleteSentryInstallation(
+  accessToken: string,
+  installationId: string,
+): Promise<"deleted" | "already_deleted"> {
+  const response = await fetch(
+    `https://sentry.io/api/0/sentry-app-installations/${encodeURIComponent(installationId)}/`,
+    {
+      method: "DELETE",
+      signal: AbortSignal.timeout(SENTRY_REQUEST_TIMEOUT_MS),
+      headers: {
+        accept: "application/json",
+        authorization: `Bearer ${accessToken}`,
+      },
+    },
+  );
+  if (response.status === 404) return "already_deleted";
+  if (!response.ok) {
+    throw new SentryApiError(
+      "Unable to uninstall Sentry integration",
+      response.status,
+      "installation",
+    );
+  }
+  return "deleted";
+}
+
+export function sentryIntegrationSettingsUrl(organizationSlug: string): string {
+  if (!/^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/i.test(organizationSlug)) {
+    return "https://sentry.io/settings/";
+  }
+  return `https://${organizationSlug}.sentry.io/settings/integrations/`;
+}

--- a/apps/control-plane/server/webhooks/sentry.test.ts
+++ b/apps/control-plane/server/webhooks/sentry.test.ts
@@ -2,11 +2,16 @@ import { createHash, createHmac } from "node:crypto";
 import { Hono } from "hono";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { findAgentsForSentryIssue } from "../../../../packages/core/src/db/agents.js";
+import { deleteIntegrationAccountsByExternalId } from "../../../../packages/core/src/db/integrations.js";
 import { queueInvestigation } from "../investigations/queue.js";
 import { sentryWebhookRoutes, verifySentrySignature } from "./sentry.js";
 
 vi.mock("../../../../packages/core/src/db/agents.js", () => ({
   findAgentsForSentryIssue: vi.fn(),
+}));
+
+vi.mock("../../../../packages/core/src/db/integrations.js", () => ({
+  deleteIntegrationAccountsByExternalId: vi.fn(),
 }));
 
 vi.mock("../investigations/queue.js", () => ({
@@ -198,9 +203,44 @@ describe("Sentry issue webhooks", () => {
     expect(findAgentsForSentryIssue).not.toHaveBeenCalled();
   });
 
-  it("ignores signed non-issue resources without querying agents", async () => {
+  it("removes local connections after a signed Sentry uninstall", async () => {
     vi.stubEnv("SENTRY_CLIENT_SECRET", "sentry-secret");
-    const body = JSON.stringify({ action: "created" });
+    vi.mocked(deleteIntegrationAccountsByExternalId).mockResolvedValue(1);
+    const body = JSON.stringify({
+      action: "deleted",
+      installation: { uuid: "60000000-0000-4000-8000-000000000000" },
+    });
+    const signature = createHmac("sha256", "sentry-secret")
+      .update(body, "utf8")
+      .digest("hex");
+
+    const response = await app.request("/api/webhooks/sentry", {
+      method: "POST",
+      body,
+      headers: {
+        "sentry-hook-resource": "installation",
+        "sentry-hook-signature": signature,
+      },
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      ok: true,
+      removedAccounts: 1,
+    });
+    expect(deleteIntegrationAccountsByExternalId).toHaveBeenCalledWith({
+      externalAccountId: "60000000-0000-4000-8000-000000000000",
+      provider: "sentry",
+    });
+    expect(findAgentsForSentryIssue).not.toHaveBeenCalled();
+  });
+
+  it("ignores other signed Sentry installation events", async () => {
+    vi.stubEnv("SENTRY_CLIENT_SECRET", "sentry-secret");
+    const body = JSON.stringify({
+      action: "created",
+      installation: { uuid: "60000000-0000-4000-8000-000000000000" },
+    });
     const signature = createHmac("sha256", "sentry-secret")
       .update(body, "utf8")
       .digest("hex");
@@ -216,7 +256,7 @@ describe("Sentry issue webhooks", () => {
 
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({ ok: true, ignored: true });
-    expect(findAgentsForSentryIssue).not.toHaveBeenCalled();
+    expect(deleteIntegrationAccountsByExternalId).not.toHaveBeenCalled();
   });
 
   it("returns a retryable failure when an agent handoff fails", async () => {

--- a/apps/control-plane/server/webhooks/sentry.ts
+++ b/apps/control-plane/server/webhooks/sentry.ts
@@ -2,6 +2,7 @@ import { createHash, createHmac, timingSafeEqual } from "node:crypto";
 import { Hono } from "hono";
 import { z } from "zod";
 import { findAgentsForSentryIssue } from "../../../../packages/core/src/db/agents.js";
+import { deleteIntegrationAccountsByExternalId } from "../../../../packages/core/src/db/integrations.js";
 import { queueInvestigation } from "../investigations/queue.js";
 
 const sentryIssueSchema = z
@@ -39,6 +40,11 @@ const sentryIssueWebhookSchema = z.object({
   installation: z.object({ uuid: z.uuid() }),
   data: z.object({ issue: sentryIssueSchema }),
   actor: z.unknown().optional(),
+});
+
+const sentryInstallationDeletedWebhookSchema = z.object({
+  action: z.literal("deleted"),
+  installation: z.object({ uuid: z.uuid() }),
 });
 
 const investigationStartResponseSchema = z.object({
@@ -169,7 +175,22 @@ export const sentryWebhookRoutes = new Hono().post("/", async (context) => {
     return context.json({ error: "Invalid Sentry signature" }, 401);
   }
 
-  if (context.req.header("sentry-hook-resource") !== "issue") {
+  const resource = context.req.header("sentry-hook-resource");
+  if (resource === "installation") {
+    const parsed = sentryInstallationDeletedWebhookSchema.safeParse(
+      parseJson(rawBody),
+    );
+    if (!parsed.success) {
+      return context.json({ ok: true, ignored: true });
+    }
+    const removedAccounts = await deleteIntegrationAccountsByExternalId({
+      externalAccountId: parsed.data.installation.uuid,
+      provider: "sentry",
+    });
+    return context.json({ ok: true, removedAccounts });
+  }
+
+  if (resource !== "issue") {
     return context.json({ ok: true, ignored: true });
   }
 

--- a/apps/control-plane/src/pages/settings-presentation.ts
+++ b/apps/control-plane/src/pages/settings-presentation.ts
@@ -7,3 +7,16 @@ export function integrationActionUrl(integration: {
     ? integration.configurationUrl ?? integration.connectUrl
     : integration.connectUrl;
 }
+
+export function sentryConnectionUrl(
+  connectUrl: string,
+  options: { accountId?: string; freshInstall?: boolean } = {},
+): string {
+  const url = new URL(connectUrl, "https://responder.local");
+  url.searchParams.set("returnTo", "/settings");
+  if (options.accountId) {
+    url.searchParams.set("integrationAccountId", options.accountId);
+  }
+  if (options.freshInstall) url.searchParams.set("mode", "install");
+  return `${url.pathname}${url.search}`;
+}

--- a/apps/control-plane/src/pages/settings.test.ts
+++ b/apps/control-plane/src/pages/settings.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { integrationActionUrl } from "./settings-presentation";
+import {
+  integrationActionUrl,
+  sentryConnectionUrl,
+} from "./settings-presentation";
 
 describe("settings integration actions", () => {
   it("opens GitHub installation configuration for a connected account", () => {
@@ -20,5 +23,26 @@ describe("settings integration actions", () => {
         state: "available",
       }),
     ).toBe("/api/integrations/github/start?mode=install");
+  });
+
+  it("targets one Sentry account for reconnect", () => {
+    expect(
+      sentryConnectionUrl("/api/integrations/sentry/start", {
+        accountId: "30000000-0000-4000-8000-000000000000",
+      }),
+    ).toBe(
+      "/api/integrations/sentry/start?returnTo=%2Fsettings" +
+        "&integrationAccountId=30000000-0000-4000-8000-000000000000",
+    );
+  });
+
+  it("starts a fresh Sentry installation without retrying another account", () => {
+    expect(
+      sentryConnectionUrl("/api/integrations/sentry/start", {
+        freshInstall: true,
+      }),
+    ).toBe(
+      "/api/integrations/sentry/start?returnTo=%2Fsettings&mode=install",
+    );
   });
 });

--- a/apps/control-plane/src/pages/settings.tsx
+++ b/apps/control-plane/src/pages/settings.tsx
@@ -117,6 +117,8 @@ function connectionNotice(): {
       ? "That account is already connected to another workspace."
       : reason === "cancelled"
         ? "The connection was cancelled."
+        : reason === "manual_uninstall_required"
+          ? "This installation must be disconnected before Sentry will allow it to reconnect."
         : "The connection could not be completed.";
   return { tone: "error", message: `${name}: ${detail}` };
 }
@@ -356,6 +358,14 @@ function IntegrationCard({
 }) {
   if (integration.id === "gcp") {
     return <GcpIntegrationCard integration={integration} />;
+  }
+  if (integration.id === "sentry") {
+    return (
+      <SentryIntegrationCard
+        integration={integration}
+        sentryHealth={sentryHealth}
+      />
+    );
   }
   return <DefaultIntegrationCard integration={integration} sentryHealth={sentryHealth} />;
 }
@@ -652,6 +662,194 @@ function GcpIntegrationCard({
         open={dialogOpen}
         returnTo="/settings"
       />
+    </article>
+  );
+}
+
+function SentryIntegrationCard({
+  integration,
+  sentryHealth,
+}: {
+  integration: IntegrationSummary;
+  sentryHealth: SentryHealth | null;
+}) {
+  const [isConnecting, setIsConnecting] = useState(false);
+  const [removingAccountId, setRemovingAccountId] = useState<string | null>(null);
+  const [removeError, setRemoveError] = useState<string | null>(null);
+  const [manualRemoval, setManualRemoval] = useState<{
+    accountId: string;
+    manualUninstallUrl: string;
+    message: string;
+  } | null>(null);
+  const canConnect = Boolean(integration.connectUrl);
+  const health = displayedSentryHealth(integration, sentryHealth);
+
+  function startConnection() {
+    if (!integration.connectUrl || isConnecting) return;
+    setIsConnecting(true);
+    const url = new URL(integration.connectUrl, window.location.origin);
+    url.searchParams.set("returnTo", "/settings");
+    window.location.assign(`${url.pathname}${url.search}`);
+  }
+
+  async function removeConnection(accountId: string, localOnly = false) {
+    setRemoveError(null);
+    setRemovingAccountId(accountId);
+    try {
+      const suffix = localOnly ? "?localOnly=true" : "";
+      const response = await fetch(
+        `/api/integrations/sentry/${accountId}${suffix}`,
+        { method: "DELETE" },
+      );
+      const body = (await response.json().catch(() => null)) as {
+        action?: string;
+        error?: string;
+        manualUninstallUrl?: string;
+      } | null;
+      if (
+        response.status === 409 &&
+        body?.action === "manual_uninstall_required" &&
+        body.manualUninstallUrl
+      ) {
+        setManualRemoval({
+          accountId,
+          manualUninstallUrl: body.manualUninstallUrl,
+          message: body.error ?? "Uninstall Responder in Sentry to continue.",
+        });
+        return;
+      }
+      if (!response.ok) {
+        throw new Error(body?.error ?? "Unable to disconnect Sentry");
+      }
+      if (localOnly) {
+        window.location.assign(
+          "/api/integrations/sentry/start?returnTo=/settings",
+        );
+      } else {
+        window.location.reload();
+      }
+    } catch (cause) {
+      setRemoveError(
+        cause instanceof Error ? cause.message : "Unable to disconnect Sentry",
+      );
+    } finally {
+      setRemovingAccountId(null);
+    }
+  }
+
+  return (
+    <article className="integrationCard integrationCard--managed">
+      <div className="integrationCard__top">
+        <ProviderGlyph
+          className="integrationLogo integrationLogo--sentry"
+          decorative
+          provider="sentry"
+        />
+        {health === "needs_reconnect" ? (
+          <span className="connectedBadge connectedBadge--warning">Action needed</span>
+        ) : health === "unavailable" ? (
+          <span className="connectedBadge connectedBadge--muted">Not verified</span>
+        ) : health === "checking" ? (
+          <span className="connectedBadge connectedBadge--muted">Checking</span>
+        ) : health === "working" ? (
+          <span className="connectedBadge">Working</span>
+        ) : integration.accountCount > 0 ? (
+          <span className="connectedBadge">Connected</span>
+        ) : null}
+      </div>
+      <div className="integrationCard__body">
+        <strong>Sentry</strong>
+        <small>{integrationDetail(integration, sentryHealth)}</small>
+        {integration.accounts.length > 0 ? (
+          <ul className="integrationCard__accounts" aria-label="Connected Sentry organizations">
+            {integration.accounts.map((account) => (
+              <li key={account.id}>
+                <span>
+                  <strong>{account.displayName}</strong>
+                  <small>
+                    {account.resourceCount} project{account.resourceCount === 1 ? "" : "s"}
+                  </small>
+                </span>
+                <span className="integrationCard__accountStatus">
+                  {account.status === "connected"
+                    ? "Connected"
+                    : account.status === "pending"
+                      ? "Pending"
+                      : "Error"}
+                </span>
+                <span className="integrationCard__accountActions">
+                  <button
+                    className="button button--secondary button--small"
+                    disabled={isConnecting}
+                    onClick={startConnection}
+                    type="button"
+                  >
+                    Reconnect
+                  </button>
+                  <button
+                    className="button button--secondary button--small"
+                    disabled={removingAccountId === account.id}
+                    onClick={() => {
+                      if (!window.confirm(
+                        `Disconnect ${account.displayName}? Responder will uninstall the app from this Sentry organization and remove its projects.`,
+                      )) return;
+                      setManualRemoval(null);
+                      void removeConnection(account.id);
+                    }}
+                    type="button"
+                  >
+                    {removingAccountId === account.id ? "Disconnecting…" : "Disconnect"}
+                  </button>
+                </span>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <small className="integrationCard__hint">
+            If Sentry says Responder is already installed, uninstall it from that
+            Sentry organization before trying again.
+          </small>
+        )}
+      </div>
+      {manualRemoval ? (
+        <div className="integrationCard__manualAction" role="alert">
+          <p>{manualRemoval.message}</p>
+          <div>
+            <a
+              className="button button--secondary button--small"
+              href={manualRemoval.manualUninstallUrl}
+              rel="noreferrer"
+              target="_blank"
+            >
+              Open Sentry settings
+            </a>
+            <button
+              className="button button--primary button--small"
+              disabled={removingAccountId === manualRemoval.accountId}
+              onClick={() => void removeConnection(manualRemoval.accountId, true)}
+              type="button"
+            >
+              I’ve uninstalled it — reconnect
+            </button>
+          </div>
+        </div>
+      ) : null}
+      {removeError ? <p className="siteDialog__error">{removeError}</p> : null}
+      <div className="integrationCard__actions">
+        {canConnect ? (
+          <button
+            aria-busy={isConnecting}
+            className="button button--primary button--small"
+            disabled={isConnecting}
+            onClick={startConnection}
+            type="button"
+          >
+            {integration.accountCount > 0 ? "Connect organization" : "Connect Sentry"}
+          </button>
+        ) : (
+          <small>Provider configuration required</small>
+        )}
+      </div>
     </article>
   );
 }

--- a/apps/control-plane/src/pages/settings.tsx
+++ b/apps/control-plane/src/pages/settings.tsx
@@ -18,7 +18,10 @@ import { providerDisplayName } from "../components/provider-glyphs";
 import { SettingsTabs } from "../components/settings-tabs";
 import { IntegrationSettingsSkeleton } from "../components/screen-skeletons";
 import { useDocumentTitle } from "../use-document-title";
-import { integrationActionUrl } from "./settings-presentation";
+import {
+  integrationActionUrl,
+  sentryConnectionUrl,
+} from "./settings-presentation";
 
 type IntegrationState =
   | "available"
@@ -684,12 +687,13 @@ function SentryIntegrationCard({
   const canConnect = Boolean(integration.connectUrl);
   const health = displayedSentryHealth(integration, sentryHealth);
 
-  function startConnection() {
+  function startConnection(options: {
+    accountId?: string;
+    freshInstall?: boolean;
+  } = {}) {
     if (!integration.connectUrl || isConnecting) return;
     setIsConnecting(true);
-    const url = new URL(integration.connectUrl, window.location.origin);
-    url.searchParams.set("returnTo", "/settings");
-    window.location.assign(`${url.pathname}${url.search}`);
+    window.location.assign(sentryConnectionUrl(integration.connectUrl, options));
   }
 
   async function removeConnection(accountId: string, localOnly = false) {
@@ -723,7 +727,7 @@ function SentryIntegrationCard({
       }
       if (localOnly) {
         window.location.assign(
-          "/api/integrations/sentry/start?returnTo=/settings",
+          "/api/integrations/sentry/start?mode=install&returnTo=/settings",
         );
       } else {
         window.location.reload();
@@ -781,7 +785,7 @@ function SentryIntegrationCard({
                   <button
                     className="button button--secondary button--small"
                     disabled={isConnecting}
-                    onClick={startConnection}
+                    onClick={() => startConnection({ accountId: account.id })}
                     type="button"
                   >
                     Reconnect
@@ -791,7 +795,7 @@ function SentryIntegrationCard({
                     disabled={removingAccountId === account.id}
                     onClick={() => {
                       if (!window.confirm(
-                        `Disconnect ${account.displayName}? Responder will uninstall the app from this Sentry organization and remove its projects.`,
+                        `Disconnect ${account.displayName}? Responder will uninstall the app from this Sentry organization, remove its projects, and pause agents triggered by it.`,
                       )) return;
                       setManualRemoval(null);
                       void removeConnection(account.id);
@@ -841,7 +845,7 @@ function SentryIntegrationCard({
             aria-busy={isConnecting}
             className="button button--primary button--small"
             disabled={isConnecting}
-            onClick={startConnection}
+            onClick={() => startConnection({ freshInstall: true })}
             type="button"
           >
             {integration.accountCount > 0 ? "Connect organization" : "Connect Sentry"}

--- a/apps/control-plane/src/styles.css
+++ b/apps/control-plane/src/styles.css
@@ -674,6 +674,31 @@ body:has(.appShell--investigation) {
   gap: 8px;
 }
 
+.appShell--settings .integrationCard__hint {
+  display: block;
+  margin-top: 12px;
+}
+
+.appShell--settings .integrationCard__manualAction {
+  border: 1px solid color-mix(in srgb, var(--ds-warning) 38%, transparent);
+  border-radius: var(--ds-radius-small);
+  margin-top: 12px;
+  padding: 12px;
+}
+
+.appShell--settings .integrationCard__manualAction p {
+  color: var(--ds-text-muted);
+  font-size: 12px;
+  line-height: 1.5;
+  margin: 0 0 10px;
+}
+
+.appShell--settings .integrationCard__manualAction > div {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
 .appShell--settings .integrationCard__arrow {
   right: 17px;
   bottom: 17px;

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -83,7 +83,9 @@ has sufficient permission. With the recommended read-only organization
 permission, it instead links an organization manager to Sentry's integration
 settings and resumes reconnection after they confirm the uninstall. Signed
 installation-deleted webhooks remove the matching local connection
-automatically.
+automatically. Disconnecting an integration pauses agents whose active trigger
+uses that account, so they cannot silently wait on an installation that no
+longer exists.
 
 ## GitHub
 

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -77,7 +77,13 @@ Create a public Sentry integration with:
   `SENTRY_CLIENT_SECRET`
 
 Responder validates `Sentry-Hook-Signature`, synchronizes visible projects,
-and triggers only agents whose installation and project match.
+and triggers only agents whose installation and project match. The Settings
+page can disconnect an installation through Sentry when its installation token
+has sufficient permission. With the recommended read-only organization
+permission, it instead links an organization manager to Sentry's integration
+settings and resumes reconnection after they confirm the uninstall. Signed
+installation-deleted webhooks remove the matching local connection
+automatically.
 
 ## GitHub
 

--- a/packages/core/src/db/integrations.test.ts
+++ b/packages/core/src/db/integrations.test.ts
@@ -96,7 +96,10 @@ describe("integration account tenancy", () => {
   it("disables agents before deleting their integration account", async () => {
     const updateWhere = vi.fn().mockResolvedValue(undefined);
     const returning = vi.fn().mockResolvedValue([{ id: "account-1" }]);
-    const deleteWhere = vi.fn(() => ({ returning }));
+    const deleteWhere = vi.fn((condition: unknown) => {
+      void condition;
+      return { returning };
+    });
     const database = {
       delete: vi.fn(() => ({ where: deleteWhere })),
       update: vi.fn(() => ({
@@ -122,6 +125,17 @@ describe("integration account tenancy", () => {
     expect(disableQuery.params).toEqual([
       account.organizationId,
       true,
+      "account-1",
+      account.organizationId,
+      "sentry",
+    ]);
+    expect(disableQuery.sql).toContain(
+      '"context_account_ids" @> jsonb_build_array',
+    );
+    const deleteQuery = new PgDialect().sqlToQuery(
+      deleteWhere.mock.calls[0]![0] as never,
+    );
+    expect(deleteQuery.params).toEqual([
       "account-1",
       account.organizationId,
       "sentry",
@@ -172,7 +186,13 @@ describe("integration account tenancy", () => {
   });
 
   it("targets one Sentry account when reconnecting among several", async () => {
-    const limit = vi.fn().mockResolvedValue([]);
+    const recoverableAccount = {
+      id: "30000000-0000-4000-8000-000000000000",
+      encryptedCredentials: null,
+      externalAccountId: "40000000-0000-4000-8000-000000000000",
+      metadata: { organizationSlug: "example" },
+    };
+    const limit = vi.fn().mockResolvedValue([recoverableAccount]);
     const where = vi.fn((condition: unknown) => {
       void condition;
       return { limit };
@@ -183,10 +203,12 @@ describe("integration account tenancy", () => {
       })),
     } as never);
 
-    await getRecoverableSentryIntegrationAccount(
-      account.organizationId,
-      "30000000-0000-4000-8000-000000000000",
-    );
+    await expect(
+      getRecoverableSentryIntegrationAccount(
+        account.organizationId,
+        "30000000-0000-4000-8000-000000000000",
+      ),
+    ).resolves.toEqual(recoverableAccount);
 
     const query = new PgDialect().sqlToQuery(where.mock.calls[0]![0] as never);
     expect(query.params).toEqual([
@@ -197,6 +219,7 @@ describe("integration account tenancy", () => {
       "pending",
       "error",
     ]);
+    expect(limit).toHaveBeenCalledWith(1);
   });
 
   it("serializes rotating credential updates without holding a transaction", async () => {

--- a/packages/core/src/db/integrations.test.ts
+++ b/packages/core/src/db/integrations.test.ts
@@ -6,6 +6,7 @@ import { getDatabase } from "./client.js";
 import {
   createIntegrationConnectionState,
   consumeIntegrationConnectionState,
+  deleteIntegrationAccountsByExternalId,
   IntegrationAccountCredentialSupersededError,
   updateIntegrationConnectionStateMetadata,
   upsertIntegrationAccount,
@@ -88,6 +89,33 @@ describe("integration account tenancy", () => {
 
     await expect(upsertIntegrationAccount(account)).resolves.toBe("account-1");
     expect(updateWhere).toHaveBeenCalledOnce();
+  });
+
+  it("removes every local account for a deleted provider installation", async () => {
+    const returning = vi.fn().mockResolvedValue([
+      { id: "account-1" },
+      { id: "account-2" },
+    ]);
+    const where = vi.fn((condition: unknown) => {
+      void condition;
+      return { returning };
+    });
+    vi.mocked(getDatabase).mockReturnValue({
+      delete: vi.fn(() => ({ where })),
+    } as never);
+
+    await expect(
+      deleteIntegrationAccountsByExternalId({
+        externalAccountId: "40000000-0000-4000-8000-000000000000",
+        provider: "sentry",
+      }),
+    ).resolves.toBe(2);
+
+    const query = new PgDialect().sqlToQuery(where.mock.calls[0]![0] as never);
+    expect(query.params).toEqual([
+      "40000000-0000-4000-8000-000000000000",
+      "sentry",
+    ]);
   });
 
   it("serializes rotating credential updates without holding a transaction", async () => {

--- a/packages/core/src/db/integrations.test.ts
+++ b/packages/core/src/db/integrations.test.ts
@@ -6,7 +6,9 @@ import { getDatabase } from "./client.js";
 import {
   createIntegrationConnectionState,
   consumeIntegrationConnectionState,
+  deleteIntegrationAccount,
   deleteIntegrationAccountsByExternalId,
+  getRecoverableSentryIntegrationAccount,
   IntegrationAccountCredentialSupersededError,
   updateIntegrationConnectionStateMetadata,
   upsertIntegrationAccount,
@@ -91,18 +93,65 @@ describe("integration account tenancy", () => {
     expect(updateWhere).toHaveBeenCalledOnce();
   });
 
+  it("disables agents before deleting their integration account", async () => {
+    const updateWhere = vi.fn().mockResolvedValue(undefined);
+    const returning = vi.fn().mockResolvedValue([{ id: "account-1" }]);
+    const deleteWhere = vi.fn(() => ({ returning }));
+    const database = {
+      delete: vi.fn(() => ({ where: deleteWhere })),
+      update: vi.fn(() => ({
+        set: vi.fn(() => ({ where: updateWhere })),
+      })),
+    };
+    vi.mocked(getDatabase).mockReturnValue(database as never);
+
+    await expect(
+      deleteIntegrationAccount({
+        integrationAccountId: "account-1",
+        organizationId: account.organizationId,
+        provider: "sentry",
+      }),
+    ).resolves.toBe(true);
+
+    expect(database.update.mock.invocationCallOrder[0]).toBeLessThan(
+      database.delete.mock.invocationCallOrder[0]!,
+    );
+    const disableQuery = new PgDialect().sqlToQuery(
+      updateWhere.mock.calls[0]![0] as never,
+    );
+    expect(disableQuery.params).toEqual([
+      account.organizationId,
+      true,
+      "account-1",
+      account.organizationId,
+      "sentry",
+    ]);
+  });
+
   it("removes every local account for a deleted provider installation", async () => {
+    const accounts = [
+      { id: "account-1", organizationId: account.organizationId },
+      {
+        id: "account-2",
+        organizationId: "10000000-0000-4000-8000-000000000001",
+      },
+    ];
+    const selectWhere = vi.fn().mockResolvedValue(accounts);
+    const updateWhere = vi.fn().mockResolvedValue(undefined);
     const returning = vi.fn().mockResolvedValue([
       { id: "account-1" },
-      { id: "account-2" },
     ]);
-    const where = vi.fn((condition: unknown) => {
-      void condition;
-      return { returning };
-    });
-    vi.mocked(getDatabase).mockReturnValue({
-      delete: vi.fn(() => ({ where })),
-    } as never);
+    const deleteWhere = vi.fn(() => ({ returning }));
+    const database = {
+      delete: vi.fn(() => ({ where: deleteWhere })),
+      select: vi.fn(() => ({
+        from: vi.fn(() => ({ where: selectWhere })),
+      })),
+      update: vi.fn(() => ({
+        set: vi.fn(() => ({ where: updateWhere })),
+      })),
+    };
+    vi.mocked(getDatabase).mockReturnValue(database as never);
 
     await expect(
       deleteIntegrationAccountsByExternalId({
@@ -111,10 +160,42 @@ describe("integration account tenancy", () => {
       }),
     ).resolves.toBe(2);
 
-    const query = new PgDialect().sqlToQuery(where.mock.calls[0]![0] as never);
+    const query = new PgDialect().sqlToQuery(
+      selectWhere.mock.calls[0]![0] as never,
+    );
     expect(query.params).toEqual([
       "40000000-0000-4000-8000-000000000000",
       "sentry",
+    ]);
+    expect(database.update).toHaveBeenCalledTimes(2);
+    expect(database.delete).toHaveBeenCalledTimes(2);
+  });
+
+  it("targets one Sentry account when reconnecting among several", async () => {
+    const limit = vi.fn().mockResolvedValue([]);
+    const where = vi.fn((condition: unknown) => {
+      void condition;
+      return { limit };
+    });
+    vi.mocked(getDatabase).mockReturnValue({
+      select: vi.fn(() => ({
+        from: vi.fn(() => ({ where })),
+      })),
+    } as never);
+
+    await getRecoverableSentryIntegrationAccount(
+      account.organizationId,
+      "30000000-0000-4000-8000-000000000000",
+    );
+
+    const query = new PgDialect().sqlToQuery(where.mock.calls[0]![0] as never);
+    expect(query.params).toEqual([
+      account.organizationId,
+      "sentry",
+      "30000000-0000-4000-8000-000000000000",
+      "connected",
+      "pending",
+      "error",
     ]);
   });
 

--- a/packages/core/src/db/integrations.ts
+++ b/packages/core/src/db/integrations.ts
@@ -1,7 +1,19 @@
 import { createHash, randomBytes, randomUUID } from "node:crypto";
-import { and, count, eq, gt, inArray, isNotNull, lte, or, sql } from "drizzle-orm";
+import {
+  and,
+  count,
+  eq,
+  gt,
+  inArray,
+  isNotNull,
+  lte,
+  or,
+  sql,
+} from "drizzle-orm";
 import { getDatabase } from "./client.js";
 import {
+  agentConfigVersions,
+  agents,
   integrationAccounts,
   integrationConnectionStates,
   integrationProvider,
@@ -206,7 +218,26 @@ export async function deleteIntegrationAccount(input: {
   organizationId: string;
   provider: IntegrationProvider;
 }): Promise<boolean> {
-  const deleted = await getDatabase()
+  const database = getDatabase();
+  await database
+    .update(agents)
+    .set({ enabled: false, updatedAt: new Date() })
+    .where(
+      and(
+        eq(agents.organizationId, input.organizationId),
+        eq(agents.enabled, true),
+        sql`exists (
+          select 1 from ${agentConfigVersions}, ${integrationAccounts}
+          where ${agentConfigVersions.id} = ${agents.activeVersionId}
+            and ${agentConfigVersions.triggerConfig} ->> 'integrationAccountId' = ${integrationAccounts.id}::text
+            and ${integrationAccounts.id} = ${input.integrationAccountId}
+            and ${integrationAccounts.organizationId} = ${input.organizationId}
+            and ${integrationAccounts.provider} = ${input.provider}
+        )`,
+      ),
+    );
+
+  const deleted = await database
     .delete(integrationAccounts)
     .where(
       and(
@@ -223,16 +254,28 @@ export async function deleteIntegrationAccountsByExternalId(input: {
   externalAccountId: string;
   provider: IntegrationProvider;
 }): Promise<number> {
-  const deleted = await getDatabase()
-    .delete(integrationAccounts)
+  const accounts = await getDatabase()
+    .select({
+      id: integrationAccounts.id,
+      organizationId: integrationAccounts.organizationId,
+    })
+    .from(integrationAccounts)
     .where(
       and(
         eq(integrationAccounts.externalAccountId, input.externalAccountId),
         eq(integrationAccounts.provider, input.provider),
       ),
-    )
-    .returning({ id: integrationAccounts.id });
-  return deleted.length;
+    );
+  const deleted = await Promise.all(
+    accounts.map((account) =>
+      deleteIntegrationAccount({
+        integrationAccountId: account.id,
+        organizationId: account.organizationId,
+        provider: input.provider,
+      }),
+    ),
+  );
+  return deleted.filter(Boolean).length;
 }
 
 export async function getOrganizationIntegrationAccount(input: {
@@ -503,6 +546,7 @@ export async function setIntegrationAccountStatusIfCredentialsMatch(input: {
 
 export async function getRecoverableSentryIntegrationAccount(
   organizationId: string,
+  integrationAccountId?: string,
 ) {
   const rows = await getDatabase()
     .select({
@@ -516,12 +560,17 @@ export async function getRecoverableSentryIntegrationAccount(
       and(
         eq(integrationAccounts.organizationId, organizationId),
         eq(integrationAccounts.provider, "sentry"),
+        integrationAccountId
+          ? eq(integrationAccounts.id, integrationAccountId)
+          : undefined,
         // A reconnect can be requested while the account is still marked
         // connected (for example when the provider revoked its refresh
         // token). Keep the existing installation eligible so the route can
         // refresh it in place instead of starting a duplicate install flow.
         inArray(integrationAccounts.status, ["connected", "pending", "error"]),
-        isNotNull(integrationAccounts.encryptedCredentials),
+        integrationAccountId
+          ? undefined
+          : isNotNull(integrationAccounts.encryptedCredentials),
       ),
     )
     .limit(1);

--- a/packages/core/src/db/integrations.ts
+++ b/packages/core/src/db/integrations.ts
@@ -229,7 +229,10 @@ export async function deleteIntegrationAccount(input: {
         sql`exists (
           select 1 from ${agentConfigVersions}, ${integrationAccounts}
           where ${agentConfigVersions.id} = ${agents.activeVersionId}
-            and ${agentConfigVersions.triggerConfig} ->> 'integrationAccountId' = ${integrationAccounts.id}::text
+            and (
+              ${agentConfigVersions.triggerConfig} ->> 'integrationAccountId' = ${integrationAccounts.id}::text
+              or ${agentConfigVersions.contextAccountIds} @> jsonb_build_array(${integrationAccounts.id}::text)
+            )
             and ${integrationAccounts.id} = ${input.integrationAccountId}
             and ${integrationAccounts.organizationId} = ${input.organizationId}
             and ${integrationAccounts.provider} = ${input.provider}

--- a/packages/core/src/db/integrations.ts
+++ b/packages/core/src/db/integrations.ts
@@ -219,6 +219,22 @@ export async function deleteIntegrationAccount(input: {
   return deleted.length > 0;
 }
 
+export async function deleteIntegrationAccountsByExternalId(input: {
+  externalAccountId: string;
+  provider: IntegrationProvider;
+}): Promise<number> {
+  const deleted = await getDatabase()
+    .delete(integrationAccounts)
+    .where(
+      and(
+        eq(integrationAccounts.externalAccountId, input.externalAccountId),
+        eq(integrationAccounts.provider, input.provider),
+      ),
+    )
+    .returning({ id: integrationAccounts.id });
+  return deleted.length;
+}
+
 export async function getOrganizationIntegrationAccount(input: {
   integrationAccountId: string;
   organizationId: string;


### PR DESCRIPTION
## Summary
- add tenant-scoped Sentry disconnect controls with automatic provider uninstall when the installation token permits it
- guide organization admins through manual uninstall and resume reconnect when Sentry rejects automatic removal
- retain failed, tokenless installations for recovery and clean up local records from signed installation-deleted webhooks
- target reconnects to the selected organization and pause agents whose trigger or context account is removed

## Hosted deployment
- superloglabs/responder#222 pins this application commit. Merge this pull request first.

## Validation
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test` (961 tests)
- `pnpm build`