### PR TITLE
Increase custom prompt limit

### DIFF
--- a/apps/control-plane/src/pages/agent-create.tsx
+++ b/apps/control-plane/src/pages/agent-create.tsx
@@ -7,7 +7,10 @@ import {
   type FormEvent,
   type ReactNode,
 } from "react";
-import { defaultLinearIssueTemplate } from "@responder/core/agents/config";
+import {
+  AGENT_PROMPT_MAX_LENGTH,
+  defaultLinearIssueTemplate,
+} from "@responder/core/agents/config";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import {
   type AgentConfiguration,
@@ -3457,9 +3460,9 @@ export function AgentCreatePage() {
                     ? promptRequirement ?? undefined
                     : undefined
                 }
-                hint={`The agent can use only the context connected above · ${draft.instructions.length.toLocaleString()} / 4,000`}
+                hint={`The agent can use only the context connected above · ${draft.instructions.length.toLocaleString()} / ${AGENT_PROMPT_MAX_LENGTH.toLocaleString()}`}
                 label="Agent prompt"
-                maxLength={4_000}
+                maxLength={AGENT_PROMPT_MAX_LENGTH}
                 onChange={(event) =>
                   updateDraft({ instructions: event.target.value })
                 }

--- a/apps/control-plane/src/pages/tag-mode-settings.tsx
+++ b/apps/control-plane/src/pages/tag-mode-settings.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState, type FormEvent } from "react";
+import { AGENT_PROMPT_MAX_LENGTH } from "@responder/core/agents/config";
 import { useNavigate } from "react-router-dom";
 import {
   fetchAgentOptions,
@@ -698,7 +699,7 @@ export function TagModeSettingsPage() {
             <TextAreaField
               className="tagModeSettings__promptField"
               label="Agent prompt"
-              maxLength={20_000}
+              maxLength={AGENT_PROMPT_MAX_LENGTH}
               onChange={(event) => update({ instructions: event.target.value })}
               rows={4}
               value={configuration.instructions}

--- a/packages/core/src/agents/config.test.ts
+++ b/packages/core/src/agents/config.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   agentConfigurationSchema,
+  AGENT_PROMPT_MAX_LENGTH,
   slackThreadModeConfigurationSchema,
 } from "./config.js";
 
@@ -52,6 +53,21 @@ describe("agent configuration", () => {
     expect(parsed.data?.secretIds).toEqual([]);
     expect(parsed.data?.createLinearTickets).toBe(false);
     expect(parsed.data?.linearIssueTemplate).toContain("{{issue_id}}");
+  });
+
+  it("allows custom prompts up to 400,000 characters", () => {
+    const maximumPrompt = agentConfigurationSchema.safeParse({
+      ...baseConfiguration,
+      instructions: "a".repeat(AGENT_PROMPT_MAX_LENGTH),
+    });
+    const oversizedPrompt = agentConfigurationSchema.safeParse({
+      ...baseConfiguration,
+      instructions: "a".repeat(AGENT_PROMPT_MAX_LENGTH + 1),
+    });
+
+    expect(maximumPrompt.success).toBe(true);
+    expect(oversizedPrompt.success).toBe(false);
+    expect(oversizedPrompt.error?.issues[0]?.path).toEqual(["instructions"]);
   });
 
   it("requires a non-empty Linear template when ticket settings are supplied", () => {

--- a/packages/core/src/agents/config.ts
+++ b/packages/core/src/agents/config.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 const integrationAccountId = z.uuid("Choose a connected account");
 const externalResourceId = z.string().trim().min(1);
 const reportSeverity = z.enum(["SEV-1", "SEV-2", "SEV-3"]);
+export const AGENT_PROMPT_MAX_LENGTH = 400_000;
 export const defaultLinearIssueTemplate = [
   "## Responder issue",
   "[{{issue_id}}]({{issue_url}})",
@@ -72,7 +73,11 @@ export const agentConfigurationSchema = z
     name: z.string().trim().min(1, "Name is required").max(80),
     description: z.string().trim().max(500).default(""),
     model: z.string().trim().min(1, "Model is required").max(160),
-    instructions: z.string().trim().min(1, "Instructions are required").max(20_000),
+    instructions: z
+      .string()
+      .trim()
+      .min(1, "Instructions are required")
+      .max(AGENT_PROMPT_MAX_LENGTH),
     enabled: z.boolean().default(true),
     prMode: agentPrModeSchema.default("disabled"),
     repositoryIds: z.array(z.uuid()).max(100).default([]),
@@ -125,7 +130,11 @@ export const agentConfigurationSchema = z
 export const slackThreadModeConfigurationSchema = z.object({
   enabled: z.boolean().default(false),
   model: z.string().trim().min(1, "Model is required").max(160),
-  instructions: z.string().trim().min(1, "Instructions are required").max(20_000),
+  instructions: z
+    .string()
+    .trim()
+    .min(1, "Instructions are required")
+    .max(AGENT_PROMPT_MAX_LENGTH),
   repositoryIds: z.array(z.uuid()).max(100).default([]),
   contextAccountIds: z.array(z.uuid()).max(20).default([]),
   contextResourceIds: z.array(z.uuid()).max(100).default([]),


### PR DESCRIPTION
## Summary
- increase the agent prompt limit from 4,000 to 400,000 characters
- share the limit across agent and tag-mode prompt editors and validation
- add boundary coverage for the new maximum

## Testing
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
- `pnpm exec vitest run packages/core/src/agents/config.test.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raises the agent prompt limit to 400,000 characters so longer agent instructions can be saved, and makes the limit consistent across agent creation, tag-mode settings, and validation. Previously the agent creation page allowed 4,000 characters while tag-mode settings and validation allowed 20,000; now all use the same limit. Adds boundary tests for the new maximum and one character over.

<sup>Written for commit 68827933324fe0ad27c03cf2e28a683686184ddb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superloglabs/responder-oss/pull/124?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

